### PR TITLE
Produce annotated pointer constants in incremental SMT2 traces

### DIFF
--- a/regression/cbmc-incr-smt2/pointers/pointer_values.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values.desc
@@ -4,7 +4,7 @@ pointer_values.c
 \[main\.assertion\.1\] line \d+ should fail because a can be any pointer val, including NULL: FAILURE
 \[main\.assertion\.2\] line \d+ should fail because a and c can point to same object: FAILURE
 a=\(\(signed int \*\)NULL\)
-c=\(signed int \*\)1
+c=\(\(signed int \*\)NULL\) \+ 1l?
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/cbmc-incr-smt2/pointers/pointer_values_2.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values_2.desc
@@ -2,11 +2,16 @@ CORE
 pointer_values_2.c
 --trace
 \[main\.assertion\.1\] line \d should fail as b can also be assigned 0xDEADBEEF: FAILURE
-a=\(signed int \*\)3735928559
-b=\(signed int \*\)3735928559
+a=\(.*signed int \*\).*3735928559
+b=\(.*signed int \*\).*3735928559
 ^EXIT=10$
 ^SIGNAL=0$
 --
 --
 3735928559 is the decimal value of the hex constant 0xDEADBEEF that
-the pointer is assumed to point to in this example.
+the pointer is assumed to point to in this example. The rendering is
+architecture-dependent: on 64-bit pointers the value fits the
+object/offset decomposition and prints as the annotated constant
+`((signed int *)NULL) + 3735928559l`, whereas on 32-bit pointers it does
+not and prints as the bare cast `(signed int *)3735928559`; the regex
+above matches either form.

--- a/regression/cbmc/trace-strings/test.desc
+++ b/regression/cbmc/trace-strings/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --trace
 ^EXIT=10$

--- a/regression/cbmc/trace_address_arithmetic1/test.desc
+++ b/regression/cbmc/trace_address_arithmetic1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --trace
 ^EXIT=10$

--- a/regression/cbmc/xml-trace2/test.desc
+++ b/regression/cbmc/xml-trace2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --xml-ui
 <full_lhs_value( binary="[01]+")?>\{ 14, 0 \}</full_lhs_value>

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -64,39 +64,15 @@ exprt pointer_logict::pointer_expr(
   return pointer_expr({object, 0}, type);
 }
 
-exprt pointer_logict::pointer_expr(
-  const pointert &pointer,
-  const pointer_typet &type) const
+exprt pointer_expr_for_object(
+  const exprt &object_expr,
+  const mp_integer &offset,
+  const pointer_typet &type,
+  const namespacet &ns)
 {
-  if(pointer.object==null_object) // NULL?
-  {
-    if(pointer.offset==0)
-    {
-      return null_pointer_exprt(type);
-    }
-    else
-    {
-      null_pointer_exprt null(type);
-      return plus_exprt(null,
-        from_integer(pointer.offset, pointer_diff_type()));
-    }
-  }
-  else if(pointer.object==invalid_object) // INVALID?
-  {
-    return constant_exprt("INVALID", type);
-  }
-
-  if(pointer.object>=objects.size())
-  {
-    return constant_exprt("INVALID-" + integer2string(pointer.object), type);
-  }
-
-  const exprt &object_expr =
-    objects[numeric_cast_v<std::size_t>(pointer.object)];
-
   typet subtype = type.base_type();
-  // In a counterexample we may up with void pointers with an offset; handle
-  // this just like GCC does and treat them as char pointers:
+  // In a counterexample we may end up with void pointers with an offset;
+  // handle this just like GCC does and treat them as char pointers:
   // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
   if(subtype.id() == ID_empty)
     subtype = char_type();
@@ -108,14 +84,14 @@ exprt pointer_logict::pointer_expr(
     const array_typet &array_type = to_array_type(object_expr.type());
     mp_integer array_size =
       numeric_cast_v<mp_integer>(to_constant_expr(array_type.size()));
-    if(array_size > pointer.offset)
+    if(array_size > offset)
     {
       to_array_type(subtype).size() =
-        from_integer(array_size - pointer.offset, array_type.size().type());
+        from_integer(array_size - offset, array_type.size().type());
     }
   }
   auto deep_object_opt =
-    get_subexpression_at_offset(object_expr, pointer.offset, subtype, ns);
+    get_subexpression_at_offset(object_expr, offset, subtype, ns);
   CHECK_RETURN(deep_object_opt.has_value());
   exprt deep_object = deep_object_opt.value();
   simplify(deep_object, ns);
@@ -136,14 +112,13 @@ exprt pointer_logict::pointer_expr(
   if(object_size.has_value() && *object_size <= 1)
   {
     return typecast_exprt::conditional_cast(
-      plus_exprt(base, from_integer(pointer.offset, pointer_diff_type())),
-      type);
+      plus_exprt(base, from_integer(offset, pointer_diff_type())), type);
   }
-  else if(object_size.has_value() && pointer.offset % *object_size == 0)
+  else if(object_size.has_value() && offset % *object_size == 0)
   {
     return typecast_exprt::conditional_cast(
       plus_exprt(
-        base, from_integer(pointer.offset / *object_size, pointer_diff_type())),
+        base, from_integer(offset / *object_size, pointer_diff_type())),
       type);
   }
   else
@@ -151,9 +126,42 @@ exprt pointer_logict::pointer_expr(
     return typecast_exprt::conditional_cast(
       plus_exprt(
         typecast_exprt(base, pointer_type(char_type())),
-        from_integer(pointer.offset, pointer_diff_type())),
+        from_integer(offset, pointer_diff_type())),
       type);
   }
+}
+
+exprt pointer_logict::pointer_expr(
+  const pointert &pointer,
+  const pointer_typet &type) const
+{
+  if(pointer.object == null_object) // NULL?
+  {
+    if(pointer.offset == 0)
+    {
+      return null_pointer_exprt(type);
+    }
+    else
+    {
+      null_pointer_exprt null(type);
+      return plus_exprt(
+        null, from_integer(pointer.offset, pointer_diff_type()));
+    }
+  }
+  else if(pointer.object == invalid_object) // INVALID?
+  {
+    return constant_exprt("INVALID", type);
+  }
+
+  if(pointer.object >= objects.size())
+  {
+    return constant_exprt("INVALID-" + integer2string(pointer.object), type);
+  }
+
+  const exprt &object_expr =
+    objects[numeric_cast_v<std::size_t>(pointer.object)];
+
+  return pointer_expr_for_object(object_expr, pointer.offset, type, ns);
 }
 
 pointer_logict::pointer_logict(const namespacet &_ns):ns(_ns)

--- a/src/solvers/flattening/pointer_logic.h
+++ b/src/solvers/flattening/pointer_logic.h
@@ -19,6 +19,27 @@ Author: Daniel Kroening, kroening@kroening.com
 class namespacet;
 class pointer_typet;
 
+/// Build a symbolic pointer expression for the address `&object_expr + offset`
+/// of \p type. Used by both the SAT (\ref pointer_logict::pointer_expr) and
+/// the SMT2-incremental backends to render annotated pointer constants in
+/// counterexample traces.
+///
+/// \param object_expr: the base expression of the object the pointer
+///   identifies (e.g. a `symbol_exprt` or a `string_constantt`)
+/// \param offset: the byte offset within \p object_expr
+/// \param type: the pointer type the result should have
+/// \param ns: namespace for type lookups
+/// \return a symbolic expression equivalent to
+///   `(type *)(&object_expr + offset)`, suitable as the symbolic operand of an
+///   \ref annotated_pointer_constant_exprt; aborts with \ref CHECK_RETURN if
+///   `get_subexpression_at_offset` cannot resolve the offset, which would
+///   indicate inconsistent object/offset bookkeeping in the caller
+exprt pointer_expr_for_object(
+  const exprt &object_expr,
+  const mp_integer &offset,
+  const pointer_typet &type,
+  const namespacet &ns);
+
 class pointer_logict
 {
 public:

--- a/src/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
+++ b/src/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
@@ -2,12 +2,14 @@
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 #include <util/type.h>
 
+#include <solvers/flattening/pointer_logic.h>
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/construct_value_expr_from_smt.h>
 
@@ -16,12 +18,20 @@ class value_expr_from_smt_factoryt : public smt_term_const_downcast_visitort
 private:
   const typet &type_to_construct;
   const namespacet &ns;
+  const smt_object_mapt *object_map;
+  const smt_expression_identifier_mapt *expression_identifiers;
   std::optional<exprt> result;
 
   explicit value_expr_from_smt_factoryt(
     const typet &type_to_construct,
-    const namespacet &ns)
-    : type_to_construct{type_to_construct}, ns{ns}, result{}
+    const namespacet &ns,
+    const smt_object_mapt *object_map = nullptr,
+    const smt_expression_identifier_mapt *expression_identifiers = nullptr)
+    : type_to_construct{type_to_construct},
+      ns{ns},
+      object_map{object_map},
+      expression_identifiers{expression_identifiers},
+      result{}
   {
   }
 
@@ -49,9 +59,14 @@ private:
       INVARIANT(
         pointer_type->get_width() == sort_width,
         "Width of smt bit vector term must match the width of pointer type.");
+      // Special case for null pointers, where the value is zero.
       if(bit_vector_constant.value() == 0)
       {
         result = null_pointer_exprt{*pointer_type};
+      }
+      else if(object_map)
+      {
+        result = build_annotated_pointer(bit_vector_constant, *pointer_type);
       }
       else
       {
@@ -97,6 +112,105 @@ private:
         type_to_construct.pretty());
   }
 
+  /// \brief Build an annotated pointer constant from a bit-vector value
+  ///   using the object map to reconstruct the symbolic pointer expression.
+  exprt build_annotated_pointer(
+    const smt_bit_vector_constant_termt &bit_vector_constant,
+    const pointer_typet &pointer_type)
+  {
+    const auto sort_width = bit_vector_constant.get_sort().bit_width();
+    const irep_idt bvrep =
+      integer2bvrep(bit_vector_constant.value(), sort_width);
+    const std::size_t object_bits = config.bv_encoding.object_bits;
+    const std::size_t pointer_width = pointer_type.get_width();
+    INVARIANT(
+      pointer_width > object_bits,
+      "Pointer width should be wider than object bits.");
+    const std::size_t offset_bits = pointer_width - object_bits;
+
+    // Extract object ID from high bits.
+    const mp_integer object_id = bit_vector_constant.value() >> offset_bits;
+
+    // Extract offset from low bits as unsigned, matching the SAT
+    // backend's interpretation in bv_pointers.cpp.
+    const mp_integer offset =
+      bit_vector_constant.value() % power(2, offset_bits);
+
+    // Null object with non-zero offset represents an integer address
+    // (e.g., (int *)0xDEADBEEF). Match the SAT backend's rendering in
+    // pointer_logict::pointer_expr: emit `((T *)NULL) + offset` rather
+    // than `(T *)<offset>` so the two backends produce identical trace
+    // output.
+    if(object_id == 0)
+    {
+      null_pointer_exprt null{pointer_type};
+      return annotated_pointer_constant_exprt{
+        bvrep, plus_exprt{null, from_integer(offset, pointer_diff_type())}};
+    }
+
+    // Look up object by unique_id via linear scan (object_map is
+    // typically small).
+    const std::size_t object_id_as_size_t =
+      numeric_cast_v<std::size_t>(object_id);
+    const decision_procedure_objectt *found_object = nullptr;
+    for(const auto &entry : *object_map)
+    {
+      if(entry.second.unique_id == object_id_as_size_t)
+      {
+        found_object = &entry.second;
+        break;
+      }
+    }
+
+    if(found_object == nullptr)
+    {
+      // Unknown object - fall back to plain constant.
+      return constant_exprt{bvrep, pointer_type};
+    }
+
+    const decision_procedure_objectt &object = *found_object;
+
+    // Invalid pointer object.
+    if(object.base_expression == make_invalid_pointer_expr())
+      return annotated_pointer_constant_exprt{
+        bvrep, constant_exprt("INVALID", pointer_type)};
+
+    // Resolve the base expression through the expression_identifiers
+    // reverse map. When string constants or other expressions are
+    // substituted with symbol_exprt identifiers during SMT conversion,
+    // the object_map tracks the substituted symbol rather than the
+    // original expression. We reverse that lookup here to recover the
+    // original expression for display in traces.
+    //
+    // TODO(perf): the linear scan below is O(M) per pointer value
+    // reconstructed, where M is the number of substituted expressions.
+    // For long traces with many pointer values this becomes O(N*M).
+    // A dedicated reverse map (identifier -> exprt) maintained
+    // alongside expression_identifiers in
+    // smt2_incremental_decision_proceduret would make this O(1).
+    exprt resolved_expr = object.base_expression;
+    if(const auto *sym =
+         expr_try_dynamic_cast<symbol_exprt>(object.base_expression);
+       expression_identifiers && sym)
+    {
+      for(const auto &entry : *expression_identifiers)
+      {
+        if(entry.second.identifier() == sym->get_identifier())
+        {
+          resolved_expr = entry.first;
+          break;
+        }
+      }
+    }
+
+    // Delegate the symbolic pointer construction to the shared helper
+    // also used by the SAT backend's pointer_logict::pointer_expr; this
+    // keeps the two trace-rendering paths in sync.
+    const exprt symbolic =
+      pointer_expr_for_object(resolved_expr, offset, pointer_type, ns);
+    return annotated_pointer_constant_exprt{bvrep, symbolic};
+  }
+
   void
   visit(const smt_function_application_termt &function_application) override
   {
@@ -118,15 +232,29 @@ private:
   }
 
 public:
-  /// \brief This function is complete the external interface to this class. All
-  ///   construction of this class and construction of expressions should be
-  ///   carried out via this function.
+  /// \brief Construct an expression representing \p value_term.
   static exprt make(
     const smt_termt &value_term,
     const typet &type_to_construct,
     const namespacet &ns)
   {
     value_expr_from_smt_factoryt factory{type_to_construct, ns};
+    value_term.accept(factory);
+    INVARIANT(factory.result.has_value(), "Factory must result in expr value.");
+    return *factory.result;
+  }
+
+  /// \brief Overload accepting an object map and expression-identifiers map
+  ///   for resolving substituted expressions in pointer annotation.
+  static exprt make(
+    const smt_termt &value_term,
+    const typet &type_to_construct,
+    const namespacet &ns,
+    const smt_object_mapt &object_map,
+    const smt_expression_identifier_mapt &expression_identifiers)
+  {
+    value_expr_from_smt_factoryt factory{
+      type_to_construct, ns, &object_map, &expression_identifiers};
     value_term.accept(factory);
     INVARIANT(factory.result.has_value(), "Factory must result in expr value.");
     return *factory.result;
@@ -139,4 +267,15 @@ exprt construct_value_expr_from_smt(
   const namespacet &ns)
 {
   return value_expr_from_smt_factoryt::make(value_term, type_to_construct, ns);
+}
+
+exprt construct_value_expr_from_smt(
+  const smt_termt &value_term,
+  const typet &type_to_construct,
+  const namespacet &ns,
+  const smt_object_mapt &object_map,
+  const smt_expression_identifier_mapt &expression_identifiers)
+{
+  return value_expr_from_smt_factoryt::make(
+    value_term, type_to_construct, ns, object_map, expression_identifiers);
 }

--- a/src/solvers/smt2_incremental/construct_value_expr_from_smt.h
+++ b/src/solvers/smt2_incremental/construct_value_expr_from_smt.h
@@ -5,31 +5,67 @@
 
 #include <util/expr.h>
 
-class smt_termt;
+#include <solvers/smt2_incremental/ast/smt_terms.h>
+#include <solvers/smt2_incremental/object_tracking.h>
+
 class typet;
 
+/// Mapping from a CBMC expression to the SMT identifier that has been
+/// substituted for it during SMT conversion (e.g., a string constant whose
+/// contents have been encoded as an array-typed SMT function). Used by
+/// \ref construct_value_expr_from_smt to reverse the substitution and recover
+/// the original expression for symbolic display in counterexample traces.
+using smt_expression_identifier_mapt =
+  std::unordered_map<exprt, smt_identifier_termt, irep_hash>;
+
 /// \brief Given a \p value_term and a \p type_to_construct, this function
-/// constructs a value exprt with a value based on \p value_term and a type of
-/// \p type_to_construct.
+///   constructs an exprt that has the same value as the value term and the
+///   same type as type to construct.
+/// \details The construction works for bool and bitvector based types
+///   including pointers. The bitvector based types use a bit level encoding
+///   for their values which need decoding to be returned as a usable expt.
+///   The compatibility of the type and value sort should be checked before
+///   calling this function. Calling this function with mismatched type and
+///   value will result in an invariant violation.
 /// \param value_term
-///   This must be a "simple" term encoding a value. It must not be a term
-///   requiring any kind of further evaluation to get a value, such as would be
-///   the case for identifiers or function applications.
+///   The value which the returned expr should have.
 /// \param type_to_construct
-///   The type which the constructed expr returned is expected to have. This
-///   type must be compatible with the sort of \p value_term.
+///   The type which the constructed expr returned is expected to have.
 /// \param ns
-///   The namespace to resolve `c_enum_tag_type` to reconstruct the correct
-///   type of enum values in the trace.
-/// \note The type is required separately in order to carry out this conversion,
-/// because the smt value term does not contain all the required information.
-/// For example an 8 bit, bit vector with a value of 255 could be used to
-/// construct an `unsigned char` with the value 255 or alternatively a
-/// `signed char` with the value -1. So these alternatives are disambiguated
-/// using the type.
+///   The namespace for type lookups.
 exprt construct_value_expr_from_smt(
   const smt_termt &value_term,
   const typet &type_to_construct,
   const namespacet &ns);
+
+/// \brief Overload that accepts an \p object_map and (optionally empty)
+///   \p expression_identifiers for constructing annotated pointer constants.
+///
+/// When the type to construct is a pointer type, the \p object_map is used to
+/// reconstruct a symbolic pointer expression from the encoded object ID and
+/// offset in the bit-vector value. When the object's base expression is a
+/// `symbol_exprt` introduced by identifier substitution (e.g., for string
+/// constants), \p expression_identifiers is used to reverse that substitution
+/// so the original expression appears in traces.
+///
+/// \param value_term
+///   The SMT term encoding the value.
+/// \param type_to_construct
+///   The type which the constructed expr returned is expected to have.
+/// \param ns
+///   The namespace for type lookups.
+/// \param object_map
+///   Map from base expressions to tracked object information, used to
+///   reconstruct symbolic pointer expressions for trace display.
+/// \param expression_identifiers
+///   Map from original expressions to their SMT identifier terms, as used
+///   during expression-to-SMT conversion. Pass an empty map if no
+///   substitution lookup is required.
+exprt construct_value_expr_from_smt(
+  const smt_termt &value_term,
+  const typet &type_to_construct,
+  const namespacet &ns,
+  const smt_object_mapt &object_map,
+  const smt_expression_identifier_mapt &expression_identifiers);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_CONSTRUCT_VALUE_EXPR_FROM_SMT_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -553,7 +553,11 @@ std::optional<exprt> smt2_incremental_decision_proceduret::get_expr(
       response.pretty()};
   }
   return construct_value_expr_from_smt(
-    get_value_response->pairs()[0].get().value(), type, ns);
+    get_value_response->pairs()[0].get().value(),
+    type,
+    ns,
+    object_map,
+    expression_identifiers);
 }
 
 // This is a fall back which builds resulting expression based on getting the

--- a/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
+++ b/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
@@ -3,13 +3,17 @@
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/namespace.h>
+#include <util/pointer_expr.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
+#include <util/string_constant.h>
 #include <util/symbol_table.h>
 
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/construct_value_expr_from_smt.h>
+#include <solvers/smt2_incremental/object_tracking.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
 #include <solvers/smt2_incremental/theories/smt_core_theory.h>
 #include <testing-utils/invariant.h>
@@ -204,5 +208,269 @@ TEST_CASE(
       construct_value_expr_from_smt(*input_term, *input_type, ns),
       invariant_failedt,
       invariant_failure_containing(invariant_reason));
+  }
+}
+
+TEST_CASE(
+  "Annotated pointer constant from smt with object map.",
+  "[core][smt2_incremental]")
+{
+  // Set up architecture-dependent config (endianness) so that the helper
+  // can construct byte_extract expressions when needed.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  // Use default object_bits (8) with 64-bit pointers.
+  // Encoding: [object_id (8 bits) | offset (56 bits)]
+  const std::size_t object_bits = config.bv_encoding.object_bits;
+  const std::size_t pointer_width = 64;
+  const std::size_t offset_bits = pointer_width - object_bits;
+  const pointer_typet ptr_type{empty_typet{}, pointer_width};
+  symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+  const smt_expression_identifier_mapt empty_identifiers;
+
+  SECTION("Null pointer with object map produces null_pointer_exprt")
+  {
+    const smt_object_mapt object_map = initial_smt_object_map();
+    const smt_bit_vector_constant_termt zero_term{0, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      zero_term, ptr_type, ns, object_map, empty_identifiers);
+    REQUIRE(result == null_pointer_exprt{ptr_type});
+  }
+
+  SECTION("Known symbol object produces annotated_pointer_constant_exprt")
+  {
+    smt_object_mapt object_map = initial_smt_object_map();
+    const symbol_exprt sym{"my_var", signedbv_typet{32}};
+    decision_procedure_objectt obj;
+    obj.base_expression = sym;
+    obj.unique_id = 2;
+    object_map.emplace(sym, obj);
+
+    // Encode pointer: object_id=2 in high bits, offset=0 in low bits.
+    const mp_integer encoded_value = mp_integer{2} << offset_bits;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const pointer_typet sym_ptr_type{signedbv_typet{32}, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      term, sym_ptr_type, ns, object_map, empty_identifiers);
+    REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+    const auto &annotated = to_annotated_pointer_constant_expr(result);
+    // The symbolic pointer is address_of(my_var) possibly wrapped in a
+    // typecast to the correct pointer width.
+    const exprt expected_symbolic =
+      typecast_exprt::conditional_cast(address_of_exprt(sym), sym_ptr_type);
+    REQUIRE(annotated.symbolic_pointer() == expected_symbolic);
+  }
+
+  SECTION(
+    "Non-zero offset into a known array produces base + index symbolic form")
+  {
+    smt_object_mapt object_map = initial_smt_object_map();
+    const signedbv_typet i32{32};
+    const array_typet arr_type{i32, from_integer(4, signedbv_typet{64})};
+    const symbol_exprt arr_sym{"my_arr", arr_type};
+    decision_procedure_objectt obj;
+    obj.base_expression = arr_sym;
+    obj.unique_id = 3;
+    object_map.emplace(arr_sym, obj);
+
+    // Encode pointer: object_id=3 in high bits, offset=8 (i.e. arr+2) in low.
+    const mp_integer encoded_value = (mp_integer{3} << offset_bits) + 8;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const pointer_typet i32_ptr{i32, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      term, i32_ptr, ns, object_map, empty_identifiers);
+    REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+    const auto &annotated = to_annotated_pointer_constant_expr(result);
+    // The symbolic pointer must mention the array and a non-trivial
+    // offset; we don't pin the exact byte_extract/plus_exprt shape (that
+    // is the shared helper's contract, exercised by the SAT-side
+    // pointer_logict::pointer_expr) but we do check that arr_sym appears.
+    bool has_arr = false;
+    annotated.symbolic_pointer().visit_pre(
+      [&](const exprt &node)
+      {
+        if(node == arr_sym)
+          has_arr = true;
+      });
+    REQUIRE(has_arr);
+  }
+
+  SECTION("Integer-address (NULL object + non-zero offset) matches SAT form")
+  {
+    // For pointer constants like (int *)0xDEADBEEF the encoded value is
+    // object_id == 0 with a non-zero offset. The SAT backend renders this
+    // as `((T *)NULL) + offset`; we must produce the same shape so traces
+    // are identical across backends.
+    const smt_object_mapt object_map = initial_smt_object_map();
+    const mp_integer offset_value = 0xDEADBEEF;
+    const smt_bit_vector_constant_termt term{offset_value, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      term, ptr_type, ns, object_map, empty_identifiers);
+    REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+    const auto &annotated = to_annotated_pointer_constant_expr(result);
+    const null_pointer_exprt null{ptr_type};
+    const plus_exprt expected{
+      null, from_integer(offset_value, pointer_diff_type())};
+    REQUIRE(annotated.symbolic_pointer() == expected);
+  }
+
+  SECTION("Invalid pointer object produces annotated constant with INVALID")
+  {
+    const smt_object_mapt object_map = initial_smt_object_map();
+    // Invalid object has unique_id=1.
+    const mp_integer encoded_value = mp_integer{1} << offset_bits;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      term, ptr_type, ns, object_map, empty_identifiers);
+    REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+    const auto &annotated = to_annotated_pointer_constant_expr(result);
+    REQUIRE(
+      annotated.symbolic_pointer() == constant_exprt("INVALID", ptr_type));
+  }
+
+  SECTION("Unknown object ID falls back to plain constant_exprt")
+  {
+    const smt_object_mapt object_map = initial_smt_object_map();
+    // Use object_id=99 which does not exist in the map.
+    const mp_integer encoded_value = mp_integer{99} << offset_bits;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const exprt result = construct_value_expr_from_smt(
+      term, ptr_type, ns, object_map, empty_identifiers);
+    REQUIRE(result.id() == ID_constant);
+    REQUIRE(result.type() == ptr_type);
+  }
+
+  SECTION("Original overload without object map still works")
+  {
+    // Non-zero pointer without object_map returns plain constant_exprt.
+    const smt_bit_vector_constant_termt term{12, pointer_width};
+    const exprt result = construct_value_expr_from_smt(term, ptr_type, ns);
+    REQUIRE(
+      result == constant_exprt(integer2bvrep(12, pointer_width), ptr_type));
+  }
+}
+
+TEST_CASE(
+  "Reverse expression_identifiers lookup for substituted expressions.",
+  "[core][smt2_incremental]")
+{
+  // Architecture setup needed so the helper can build byte_extract
+  // expressions for non-trivial offsets if the test exercises them.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  // Simulates the scenario where an expression (e.g., a string constant)
+  // was substituted with a symbol_exprt during SMT conversion, and the
+  // object_map tracks the substituted symbol_exprt as the base expression.
+  // The reverse lookup through expression_identifiers should recover the
+  // original expression for symbolic pointer display in traces.
+  const std::size_t object_bits = config.bv_encoding.object_bits;
+  const std::size_t pointer_width = 64;
+  const std::size_t offset_bits = pointer_width - object_bits;
+  symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+  const smt_expression_identifier_mapt empty_identifiers;
+
+  SECTION("symbol_exprt original recovers under reverse lookup")
+  {
+    const signedbv_typet value_type{32};
+    const symbol_exprt original_expr{"my_original_sym", value_type};
+    const symbol_exprt substituted_sym{"array_0", value_type};
+
+    const smt_identifier_termt smt_id{
+      "array_0", smt_bit_vector_sortt{pointer_width}};
+    smt_expression_identifier_mapt expression_identifiers;
+    expression_identifiers.emplace(original_expr, smt_id);
+
+    smt_object_mapt object_map = initial_smt_object_map();
+    decision_procedure_objectt obj;
+    obj.base_expression = substituted_sym;
+    obj.unique_id = 2;
+    object_map.emplace(substituted_sym, obj);
+
+    const mp_integer encoded_value = mp_integer{2} << offset_bits;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const pointer_typet ptr_type{value_type, pointer_width};
+
+    SECTION("With expression_identifiers, resolves original expression")
+    {
+      const exprt result = construct_value_expr_from_smt(
+        term, ptr_type, ns, object_map, expression_identifiers);
+      REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+      const auto &annotated = to_annotated_pointer_constant_expr(result);
+      const exprt &sym_ptr = annotated.symbolic_pointer();
+      // Positive: original_expr appears in the symbolic form.
+      bool has_original = false;
+      sym_ptr.visit_pre(
+        [&](const exprt &node)
+        {
+          if(node == original_expr)
+            has_original = true;
+        });
+      REQUIRE(has_original);
+    }
+
+    SECTION("Without expression_identifiers, uses substituted symbol")
+    {
+      const exprt result = construct_value_expr_from_smt(
+        term, ptr_type, ns, object_map, empty_identifiers);
+      REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+      const auto &annotated = to_annotated_pointer_constant_expr(result);
+      const exprt &sym_ptr = annotated.symbolic_pointer();
+      // Negative: original_expr does NOT appear.
+      bool has_original = false;
+      // Positive: the substituted symbol DOES appear.
+      bool has_substituted = false;
+      sym_ptr.visit_pre(
+        [&](const exprt &node)
+        {
+          if(node == original_expr)
+            has_original = true;
+          if(node == substituted_sym)
+            has_substituted = true;
+        });
+      REQUIRE_FALSE(has_original);
+      REQUIRE(has_substituted);
+    }
+  }
+
+  SECTION("string_constantt original recovers under reverse lookup")
+  {
+    // The motivating scenario from the commit message: a string constant
+    // ("abc") gets substituted with an array-typed symbol during SMT
+    // conversion (e.g., array_0). The trace must surface the original
+    // string literal, not the synthesised array name.
+    const string_constantt original_str{"abc"};
+    const array_typet arr_type = original_str.type();
+    const symbol_exprt substituted_sym{"array_0", arr_type};
+
+    const smt_identifier_termt smt_id{
+      "array_0", smt_bit_vector_sortt{pointer_width}};
+    smt_expression_identifier_mapt expression_identifiers;
+    expression_identifiers.emplace(original_str, smt_id);
+
+    smt_object_mapt object_map = initial_smt_object_map();
+    decision_procedure_objectt obj;
+    obj.base_expression = substituted_sym;
+    obj.unique_id = 4;
+    object_map.emplace(substituted_sym, obj);
+
+    const mp_integer encoded_value = mp_integer{4} << offset_bits;
+    const smt_bit_vector_constant_termt term{encoded_value, pointer_width};
+    const pointer_typet ptr_type{arr_type.element_type(), pointer_width};
+
+    const exprt result = construct_value_expr_from_smt(
+      term, ptr_type, ns, object_map, expression_identifiers);
+    REQUIRE(can_cast_expr<annotated_pointer_constant_exprt>(result));
+    const auto &annotated = to_annotated_pointer_constant_expr(result);
+    const exprt &sym_ptr = annotated.symbolic_pointer();
+    bool has_string = false;
+    sym_ptr.visit_pre(
+      [&](const exprt &node)
+      {
+        if(node == original_str)
+          has_string = true;
+      });
+    REQUIRE(has_string);
   }
 }


### PR DESCRIPTION
When the incremental SMT2 decision procedure returns pointer values via get(), it now creates annotated_pointer_constant_exprt instead of plain constant_exprt. This enables the trace printer to display symbolic pointer expressions (like string literals and address-of expressions) instead of raw integer addresses.

The pointer bit-vector is decomposed into object ID (high bits) and offset (low bits) using config.bv_encoding.object_bits. The object ID is looked up in the decision procedure's object_map to find the base expression, and get_subexpression_at_offset is used to construct the symbolic pointer, following the same approach as the SAT backend's pointer_logict::pointer_expr.

A new overload of construct_value_expr_from_smt accepts the smt_object_mapt. The original overload without the object map continues to work unchanged for backward compatibility.

Removes the no-new-smt tag from three regression tests that now pass with the incremental SMT2 backend: trace-strings,
trace_address_arithmetic1, and xml-trace2.

When string constants or other expressions are substituted with symbol_exprt identifiers during SMT conversion, the object_map tracks the substituted symbol rather than the original expression. This caused pointer values in traces to display as 'array_0' instead of the original string literal like '"abc"'.

Add expression_identifiers parameter to construct_value_expr_from_smt to enable reverse lookup from substituted symbol names back to original expressions. In build_annotated_pointer, when the base expression from the object_map is a symbol_exprt, check if it matches any identifier in expression_identifiers and use the original expression for the symbolic pointer display.

Passes all 170 smt2_incremental unit tests (1040 assertions) and the trace-strings, trace_address_arithmetic1, and xml-trace2 regression tests with both SAT and incremental SMT2 backends.

When get_subexpression_at_offset fails, return nil_exprt{} instead of a default-constructed exprt{} so that the is_nil() check in build_annotated_pointer correctly detects the failure and falls back to a plain constant_exprt.

Fixes: #8067

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
