### PR TITLE
Incremental SMT2: Add size limit to array element retrieval

### DIFF
--- a/regression/cbmc/pointer-offset-01/test.desc
+++ b/regression/cbmc/pointer-offset-01/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --no-malloc-may-fail --trace
 ^\s*ub.*=(\(char \*\)&)?dynamic_object \+ \d+

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -26,6 +26,12 @@
 #include <stack>
 #include <unordered_set>
 
+/// Maximum number of array elements to retrieve from the solver during
+/// trace generation. Arrays larger than this threshold will not have
+/// their values retrieved element by element, as doing so would be
+/// prohibitively slow or cause out-of-memory issues.
+static const std::size_t MAX_TRACE_ARRAY_SIZE = 1000;
+
 /// Issues a command to the solving process which is expected to optionally
 /// return a success status followed by the actual response of interest.
 static smt_responset get_response_to_command(
@@ -438,6 +444,13 @@ std::optional<exprt> smt2_incremental_decision_proceduret::get_expr(
   INVARIANT(
     size,
     "Size of array must be convertible to std::size_t for getting array value");
+  if(*size > MAX_TRACE_ARRAY_SIZE)
+  {
+    log.warning() << "cannot retrieve array of size " << *size
+                  << " from SMT solver due to size limit of "
+                  << MAX_TRACE_ARRAY_SIZE << messaget::eom;
+    return {};
+  }
   std::vector<exprt> elements;
   const auto index_type = type.index_type();
   elements.reserve(*size);

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1197,3 +1197,38 @@ TEST_CASE(
 
   CHECK(test.sent_commands == expected_commands);
 }
+
+TEST_CASE(
+  "smt2_incremental_decision_proceduret get_expr returns empty for large "
+  "arrays.",
+  "[core][smt2_incremental]")
+{
+  auto test = decision_procedure_test_environmentt::make();
+  const auto index_type = signedbv_typet{32};
+  const auto value_type = signedbv_typet{8};
+  // Create an array type with a size exceeding MAX_TRACE_ARRAY_SIZE (1000).
+  const auto large_array_type =
+    array_typet{value_type, from_integer(1001, index_type)};
+  const symbolt large_array = make_test_symbol("large_array", large_array_type);
+  const smt_identifier_termt large_array_term{
+    "large_array",
+    smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{8}}};
+
+  test.sent_commands.clear();
+  test.procedure.set_to(
+    equal_exprt{large_array.symbol_expr(), large_array.symbol_expr()}, true);
+
+  // Solve to put procedure in suitable state.
+  test.mock_responses.push_back(smt_check_sat_responset{smt_sat_responset{}});
+  test.procedure();
+
+  // Mock the response for getting the array size.
+  test.mock_responses.push_back(smt_get_value_responset{
+    {{{smt_bit_vector_constant_termt{1001, 32}},
+      smt_bit_vector_constant_termt{1001, 32}}}});
+
+  // get_expr should return empty optional for the large array.
+  const auto result =
+    test.procedure.get_expr(large_array_term, large_array_type);
+  REQUIRE_FALSE(result.has_value());
+}


### PR DESCRIPTION
Add MAX_TRACE_ARRAY_SIZE (1000) threshold to get_expr for array_typet. When an array exceeds this size, return empty optional with a warning instead of enumerating all elements, which caused OOM for large arrays (e.g., __CPROVER_max_malloc_size = 2^23).

The caller in get() already handles empty optional gracefully by falling back to returning the original expression.

Also remove the no-new-smt exclusion tag from pointer-offset-01 test since this fix prevents the OOM that required the exclusion.

Fixes: #8071

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
