### PR TITLE
SMT2 Incremental: Resolve duplicate and missing declarations

### DIFF
--- a/regression/cbmc/Initialization6/test.desc
+++ b/regression/cbmc/Initialization6/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Pointer_byte_extract4/program-only.desc
+++ b/regression/cbmc/Pointer_byte_extract4/program-only.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract4/test.desc
+++ b/regression/cbmc/Pointer_byte_extract4/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/byte_extract1/test.desc
+++ b/regression/cbmc/byte_extract1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -111,6 +111,10 @@ void smt2_incremental_decision_proceduret::initialize_array_elements(
   identifier_table.emplace(array_identifier.identifier(), array_identifier);
   const std::vector<exprt> &elements = array.operands();
   const typet &index_type = array.type().index_type();
+  for(const auto &element : elements)
+  {
+    define_dependent_functions(element);
+  }
   for(std::size_t i = 0; i < elements.size(); ++i)
   {
     const smt_termt index = convert_expr_to_smt(from_integer(i, index_type));
@@ -125,6 +129,7 @@ void smt2_incremental_decision_proceduret::initialize_array_elements(
   const array_of_exprt &array,
   const smt_identifier_termt &array_identifier)
 {
+  define_dependent_functions(array.what());
   const smt_sortt index_type =
     convert_type_to_smt_sort(array.type().index_type());
   const smt_identifier_termt array_index_identifier{
@@ -170,6 +175,8 @@ void send_function_definition(
     &expression_identifiers,
   std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
+  if(identifier_table.count(symbol_identifier))
+    return;
   const smt_declare_function_commandt function{
     smt_identifier_termt(
       symbol_identifier, convert_type_to_smt_sort(expr.type())),
@@ -342,6 +349,8 @@ void smt2_incremental_decision_proceduret::define_index_identifiers(
       if(const auto with_expr = expr_try_dynamic_cast<with_exprt>(expr_node))
       {
         const auto index_expr = with_expr->where();
+        if(expression_identifiers.count(index_expr))
+          return;
         const auto index_term = convert_expr_to_smt(index_expr);
         const auto index_identifier =
           "index_" + std::to_string(index_sequence());


### PR DESCRIPTION
Guard send_function_definition against duplicate declare-fun commands by checking identifier_table before sending. Guard define_index_identifiers against duplicate define-fun commands by checking expression_identifiers before defining. Ensure array element dependencies are declared before assertions by calling define_dependent_functions on elements in initialize_array_elements for both array_exprt and array_of_exprt.

Remove no-new-smt tag from byte_extract1, Initialization6, and Pointer_byte_extract4 regression tests that now pass with the fix.

Fixes: #8072

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
