### PR TITLE
Preserve byte_extract structure in trace RHS for incremental SMT2 backend

### DIFF
--- a/regression/cbmc/trace-values/unbounded_array.desc
+++ b/regression/cbmc/trace-values/unbounded_array.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend no-new-smt
+CORE broken-smt-backend
 unbounded_array.c
 --trace
 \{ \[0u?l?l?\]=1, \[1u?l?l?\]=2, \[\d+u?l?l?\]=42 \}

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -392,9 +392,28 @@ void build_goto_trace(
 
       if(SSA_step.ssa_full_lhs.is_not_nil())
       {
-        goto_trace_step.full_lhs_value =
-          decision_procedure.get(SSA_step.ssa_full_lhs);
-        simplify(goto_trace_step.full_lhs_value, ns);
+        if(
+          SSA_step.ssa_full_lhs.id() == ID_byte_extract_little_endian ||
+          SSA_step.ssa_full_lhs.id() == ID_byte_extract_big_endian)
+        {
+          // Preserve the byte_extract structure by resolving
+          // operands individually rather than simplifying the
+          // entire expression, which would evaluate away the
+          // byte_extract.
+          byte_extract_exprt be = to_byte_extract_expr(SSA_step.ssa_full_lhs);
+          be.op() = decision_procedure.get(be.op());
+          simplify(be.op(), ns);
+          replace_nondet_in_type(be.op(), decision_procedure);
+          be.offset() = decision_procedure.get(be.offset());
+          simplify(be.offset(), ns);
+          goto_trace_step.full_lhs_value = std::move(be);
+        }
+        else
+        {
+          goto_trace_step.full_lhs_value =
+            decision_procedure.get(SSA_step.ssa_full_lhs);
+          simplify(goto_trace_step.full_lhs_value, ns);
+        }
         replace_nondet_in_type(
           goto_trace_step.full_lhs_value, decision_procedure);
       }


### PR DESCRIPTION
When ssa_full_lhs is a byte_extract expression, resolve operands individually instead of simplifying the entire expression. This prevents the simplifier from evaluating away the byte_extract structure when the SMT2 backend returns a dense array_exprt.

Also remove the no-new-smt tag from the unbounded_array regression test since it now works with the incremental SMT2 backend.

Fixes: #8076

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
