### PR TITLE
SMT2 Incremental: support array-to-array typecasts

### DIFF
--- a/regression/cbmc/array-typecast-vector/main.c
+++ b/regression/cbmc/array-typecast-vector/main.c
@@ -1,0 +1,29 @@
+// Exercises the SMT2-incremental backend's array-to-array typecast
+// encoding via a GCC vector_size cast: int32x4 -> int64x2 (widening).
+// Without the fix in this PR, the incremental SMT2 backend bailed out
+// on the array-to-array typecast in vector lowering.
+//
+// The lane convention (which int32 ends up where in each int64) follows
+// the configured target endianness; with the cbmc default (little-endian
+// x86_64), the lower-indexed source elements occupy the least
+// significant bits of the corresponding target element.
+
+typedef int v4si __attribute__((vector_size(16)));
+typedef long long v2di __attribute__((vector_size(16)));
+
+int main(void)
+{
+  v4si a = {0x11111111, 0x22222222, 0x33333333, 0x44444444};
+  v2di b = (v2di)a;
+
+  // On little-endian, a[0] (low source idx) goes to the LSBs of b[0] and
+  // a[1] (next source idx) goes to the more significant 32 bits.
+  __CPROVER_assert(
+    b[0] == ((long long)0x22222222LL << 32 | 0x11111111LL),
+    "lane 0 little-endian");
+  __CPROVER_assert(
+    b[1] == ((long long)0x44444444LL << 32 | 0x33333333LL),
+    "lane 1 little-endian");
+
+  return 0;
+}

--- a/regression/cbmc/array-typecast-vector/test.desc
+++ b/regression/cbmc/array-typecast-vector/test.desc
@@ -1,0 +1,29 @@
+CORE gcc-only broken-smt-backend
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+End-to-end coverage of the SMT2-incremental backend's array-to-array
+typecast encoding (define_array_typecast_function): a GCC vector cast
+from int32x4 to int64x2 is lowered by the front-end to an
+array-to-array typecast_exprt, which the incremental SMT2 backend
+materialises as a fresh SMT array constrained by per-element concat
+clauses.
+
+The cbmc-CORE / paths-lifo profiles use the SAT/flattening backend
+(boolbvt) and the new-smt-backend profile uses the incremental SMT2
+backend; all pass the assertions. The cprover-smt2 and z3 profiles use
+the legacy SMT2 backend (smt2_conv.cpp), which has a pre-existing
+limitation on array-to-array typecasts (convert_typecast aborts with a
+generic invariant violation; the same behaviour is observed on develop
+without this PR's changes); the test is tagged `broken-smt-backend` to
+skip it on both. Removing that tag would require a separate fix in the
+legacy backend's convert_typecast handler analogous to the change this
+PR makes for the incremental backend.
+
+`gcc-only` is required because the test uses the GCC vector_size
+attribute.

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -263,6 +263,17 @@ static smt_termt convert_expr_to_smt(
   const auto &from_term = converted.at(cast.op());
   const typet &from_type = cast.op().type();
   const typet &to_type = cast.type();
+  // Array-to-array typecasts are handled by the decision procedure
+  // (define_array_typecast_function) and the expression should have been
+  // substituted before reaching this point.
+  if(to_type.id() == ID_array && from_type.id() == ID_array)
+  {
+    INVARIANT(
+      false,
+      "array-to-array typecasts must be substituted by "
+      "smt2_incremental_decision_proceduret::define_array_typecast_function "
+      "before reaching convert_expr_to_smt");
+  }
   if(type_try_dynamic_cast<bool_typet>(to_type))
     return make_not_zero(from_term, cast.op().type());
   if(const auto c_bool_type = type_try_dynamic_cast<c_bool_typet>(to_type))

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -4,8 +4,10 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
@@ -21,6 +23,7 @@
 #include <solvers/smt2_incremental/encoding/nondet_padding.h>
 #include <solvers/smt2_incremental/smt_solver_process.h>
 #include <solvers/smt2_incremental/theories/smt_array_theory.h>
+#include <solvers/smt2_incremental/theories/smt_bit_vector_theory.h>
 #include <solvers/smt2_incremental/theories/smt_core_theory.h>
 #include <solvers/smt2_incremental/type_size_mapping.h>
 
@@ -59,6 +62,18 @@ get_problem_messages(const smt_responset &response)
   return {};
 }
 
+/// \brief Predicate identifying typecasts whose source and target are both
+///   array types. Such typecasts are routed through
+///   \ref smt2_incremental_decision_proceduret::define_array_typecast_function
+///   and must therefore be reported as dependent expressions by
+///   \ref gather_dependent_expressions, so the two sites cannot drift apart.
+static bool is_array_to_array_typecast(const exprt &expr)
+{
+  const auto *typecast = expr_try_dynamic_cast<typecast_exprt>(expr);
+  return typecast && can_cast_type<array_typet>(typecast->type()) &&
+         can_cast_type<array_typet>(typecast->op().type());
+}
+
 /// \brief Find all sub expressions of the given \p expr which need to be
 ///   expressed as separate smt commands.
 /// \return A collection of sub expressions, which need to be expressed as
@@ -69,8 +84,9 @@ get_problem_messages(const smt_responset &response)
 ///   `convert_expr_to_smt`. This is because any sub expressions which
 ///   `convert_expr_to_smt` translates into function applications, must also be
 ///   returned by this`gather_dependent_expressions` function.
-/// \details `symbol_exprt`, `array_exprt` and `nondet_symbol_exprt` add
-///   dependant expressions.
+/// \details `symbol_exprt`, `nondet_symbol_exprt`, `array_exprt`,
+///   `array_of_exprt`, `string_constantt`, and array-to-array
+///   `typecast_exprt` add dependent expressions.
 static std::vector<exprt> gather_dependent_expressions(const exprt &root_expr)
 {
   std::vector<exprt> dependent_expressions;
@@ -87,7 +103,8 @@ static std::vector<exprt> gather_dependent_expressions(const exprt &root_expr)
       can_cast_expr<array_exprt>(expr_node) ||
       can_cast_expr<array_of_exprt>(expr_node) ||
       can_cast_expr<nondet_symbol_exprt>(expr_node) ||
-      can_cast_expr<string_constantt>(expr_node))
+      can_cast_expr<string_constantt>(expr_node) ||
+      is_array_to_array_typecast(expr_node))
     {
       dependent_expressions.push_back(expr_node);
     }
@@ -163,6 +180,177 @@ void smt2_incremental_decision_proceduret::define_array_function(
   expression_identifiers.emplace(array, array_identifier);
 }
 
+/// Equal-width pass-through: target[i] is just source[i].
+static smt_termt array_typecast_passthrough_lane(
+  const smt_termt &source_term,
+  const smt_termt &source_index_i)
+{
+  return smt_array_theoryt::select(source_term, source_index_i);
+}
+
+/// Widening: target[i] is the concatenation of `ratio` consecutive source
+/// elements starting at `i*ratio`. On little-endian targets, the lowest
+/// source index occupies the least significant bits; on big-endian
+/// targets, it occupies the most significant bits.
+static smt_termt array_typecast_widening_lane(
+  const smt_termt &source_term,
+  const std::vector<smt_termt> &source_indices,
+  std::size_t target_index,
+  std::size_t ratio,
+  bool big_endian)
+{
+  const std::size_t base = target_index * ratio;
+  std::vector<smt_termt> lanes;
+  lanes.reserve(ratio);
+  for(std::size_t j = 0; j < ratio; ++j)
+    lanes.push_back(
+      smt_array_theoryt::select(source_term, source_indices[base + j]));
+  if(big_endian)
+    std::reverse(lanes.begin(), lanes.end());
+  // smt_bit_vector_theoryt::concat(hi, lo) is most-significant first;
+  // build the result by iterating from the highest source-index lane
+  // down to the lowest.
+  smt_termt result = lanes.front();
+  for(std::size_t j = 1; j < ratio; ++j)
+    result = smt_bit_vector_theoryt::concat(lanes[j], result);
+  return result;
+}
+
+/// Narrowing: each source element is split into `ratio` target elements.
+/// On little-endian targets the lowest target lane (i % ratio == 0) takes
+/// the least significant bits of the corresponding source element; on
+/// big-endian targets it takes the most significant ones.
+static smt_termt array_typecast_narrowing_lane(
+  const smt_termt &source_term,
+  const std::vector<smt_termt> &source_indices,
+  std::size_t target_index,
+  std::size_t ratio,
+  std::size_t target_elem_width,
+  bool big_endian)
+{
+  const std::size_t src_idx = target_index / ratio;
+  const std::size_t lane = target_index % ratio;
+  const std::size_t lane_from_lsb = big_endian ? (ratio - 1 - lane) : lane;
+  const std::size_t offset = lane_from_lsb * target_elem_width;
+  const smt_termt src_elem =
+    smt_array_theoryt::select(source_term, source_indices[src_idx]);
+  return smt_bit_vector_theoryt::extract(
+    offset + target_elem_width - 1, offset)(src_elem);
+}
+
+/// \brief Defines a function of array sort for a typecast between two
+///   array types and asserts element-by-element reinterpretation
+///   constraints. Both widening (target elements wider than source
+///   elements, multiple source elements packed into one target element)
+///   and narrowing (target elements narrower than source elements, one
+///   source element split across multiple target elements) are
+///   supported, as well as the equal-width pass-through case.
+/// \details The lane convention follows the configured target endianness:
+///   on little-endian targets, lower-indexed source elements occupy the
+///   least significant bit positions of the corresponding target element
+///   when widening, and the lower halves of a source element when
+///   narrowing; on big-endian targets, lower-indexed source elements
+///   occupy the most significant bit positions instead.
+/// \param typecast: an array-to-array typecast whose source and target
+///   element types are both `bitvector_typet`s, whose source and target
+///   sizes are constant, whose total bit widths match, and whose element
+///   widths are non-zero and one divides the other; non-bitvector element
+///   types are reported via UNIMPLEMENTED_FEATURE.
+void smt2_incremental_decision_proceduret::define_array_typecast_function(
+  const typecast_exprt &typecast)
+{
+  const auto &source_array_type =
+    type_checked_cast<array_typet>(typecast.op().type());
+  const auto &target_array_type =
+    type_checked_cast<array_typet>(typecast.type());
+
+  // Non-bitvector element types (struct, union, nested array, etc.) would
+  // not work with the concat/extract encoding below; surface a targeted
+  // UNIMPLEMENTED_FEATURE rather than the generic "is not a
+  // bitvector_typet" invariant from the to_bitvector_type calls further
+  // down.
+  if(
+    !can_cast_type<bitvector_typet>(source_array_type.element_type()) ||
+    !can_cast_type<bitvector_typet>(target_array_type.element_type()))
+  {
+    UNIMPLEMENTED_FEATURE(
+      "array typecast with non-bitvector elements: " + typecast.pretty());
+  }
+
+  const auto source_elem_width =
+    to_bitvector_type(source_array_type.element_type()).get_width();
+  const auto target_elem_width =
+    to_bitvector_type(target_array_type.element_type()).get_width();
+  INVARIANT(
+    source_elem_width != 0 && target_elem_width != 0,
+    "array typecast requires non-zero element widths");
+  INVARIANT(
+    source_array_type.size().is_constant() &&
+      target_array_type.size().is_constant(),
+    "array typecast requires constant source and target sizes");
+  const auto source_size =
+    numeric_cast_v<std::size_t>(to_constant_expr(source_array_type.size()));
+  const auto target_size =
+    numeric_cast_v<std::size_t>(to_constant_expr(target_array_type.size()));
+  INVARIANT(
+    source_size * source_elem_width == target_size * target_elem_width,
+    "array typecast requires matching total bit widths");
+  INVARIANT(
+    target_elem_width % source_elem_width == 0 ||
+      source_elem_width % target_elem_width == 0,
+    "array typecast element widths must be multiples of each other");
+
+  const smt_sortt target_sort = convert_type_to_smt_sort(target_array_type);
+  const smt_identifier_termt array_id{
+    "array_" + std::to_string(array_sequence()), target_sort};
+  solver_process->send(smt_declare_function_commandt{array_id, {}});
+  identifier_table.emplace(array_id.identifier(), array_id);
+
+  const smt_termt source_term = convert_expr_to_smt(typecast.op());
+
+  // Pre-convert source-/target-index terms once each.
+  std::vector<smt_termt> source_indices;
+  source_indices.reserve(source_size);
+  for(std::size_t i = 0; i < source_size; ++i)
+    source_indices.push_back(
+      convert_expr_to_smt(from_integer(i, source_array_type.index_type())));
+  std::vector<smt_termt> target_indices;
+  target_indices.reserve(target_size);
+  for(std::size_t i = 0; i < target_size; ++i)
+    target_indices.push_back(
+      convert_expr_to_smt(from_integer(i, target_array_type.index_type())));
+
+  const bool big_endian =
+    config.ansi_c.endianness == configt::ansi_ct::endiannesst::IS_BIG_ENDIAN;
+
+  for(std::size_t i = 0; i < target_size; ++i)
+  {
+    smt_termt element_value = [&]()
+    {
+      if(target_elem_width == source_elem_width)
+        return array_typecast_passthrough_lane(source_term, source_indices[i]);
+      if(target_elem_width > source_elem_width)
+        return array_typecast_widening_lane(
+          source_term,
+          source_indices,
+          i,
+          target_elem_width / source_elem_width,
+          big_endian);
+      return array_typecast_narrowing_lane(
+        source_term,
+        source_indices,
+        i,
+        source_elem_width / target_elem_width,
+        target_elem_width,
+        big_endian);
+    }();
+    solver_process->send(smt_assert_commandt{smt_core_theoryt::equal(
+      smt_array_theoryt::select(array_id, target_indices[i]), element_value)});
+  }
+
+  expression_identifiers.emplace(typecast, array_id);
+}
+
 void send_function_definition(
   const exprt &expr,
   const irep_idt &symbol_identifier,
@@ -228,6 +416,10 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
       const auto string = expr_try_dynamic_cast<string_constantt>(current))
     {
       define_array_function(*string);
+    }
+    else if(is_array_to_array_typecast(current))
+    {
+      define_array_typecast_function(to_typecast_expr(current));
     }
     else if(
       const auto nondet_symbol =

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -23,6 +23,7 @@
 class namespacet;
 class smt_base_solver_processt; // IWYU pragma: keep
 class string_constantt;
+class typecast_exprt;
 class union_tag_typet;
 
 class smt2_incremental_decision_proceduret final
@@ -77,6 +78,10 @@ protected:
   /// `array_of_exprt`.
   template <typename t_exprt>
   void define_array_function(const t_exprt &array);
+  /// \brief Defines a function of array sort for a typecast between two
+  ///   array types and asserts element-by-element reinterpretation
+  ///   constraints.
+  void define_array_typecast_function(const typecast_exprt &typecast);
   /// \brief Generate and send to the SMT solver clauses asserting that each
   /// array element is as specified by \p array.
   void initialize_array_elements(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1462,6 +1462,34 @@ TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
 }
 
 TEST_CASE(
+  "Array to array typecast in convert_expr_to_smt",
+  "[core][smt2_incremental]")
+{
+  auto test =
+    expr_to_smt_conversion_test_environmentt::make(test_archt::x86_64);
+  const auto source_type =
+    array_typet{signedbv_typet{32}, from_integer(4, c_index_type())};
+  const auto target_type =
+    array_typet{signedbv_typet{64}, from_integer(2, c_index_type())};
+  const symbol_exprt source_array{"src_array", source_type};
+  const typecast_exprt cast{source_array, target_type};
+  const cbmc_invariants_should_throwt invariants_throw;
+  SECTION("Array to array typecast is not handled directly")
+  {
+    CHECK_THROWS(test.convert(cast));
+  }
+  SECTION("Sort conversion for array types")
+  {
+    CHECK(
+      convert_type_to_smt_sort(source_type) ==
+      smt_array_sortt{smt_bit_vector_sortt{64}, smt_bit_vector_sortt{32}});
+    CHECK(
+      convert_type_to_smt_sort(target_type) ==
+      smt_array_sortt{smt_bit_vector_sortt{64}, smt_bit_vector_sortt{64}});
+  }
+}
+
+TEST_CASE(
   "expr to smt conversion for address of operator",
   "[core][smt2_incremental]")
 {

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1197,3 +1197,167 @@ TEST_CASE(
 
   CHECK(test.sent_commands == expected_commands);
 }
+
+TEST_CASE("array to array typecast commands", "[core][smt2_incremental]")
+{
+  // The test environment sets up i386 (little-endian) by default; some
+  // SECTIONs override the endianness setting before invoking set_to.
+  // We build the precise expected sequence of smt_commandt values so a
+  // regression in lane ordering, extract bounds, source-index ordering,
+  // or array sort would surface immediately.
+  auto test = decision_procedure_test_environmentt::make();
+  const signedbv_typet i32{32};
+  const signedbv_typet i64{64};
+  const unsignedbv_typet u32{32};
+  const auto i32_4 = array_typet{i32, from_integer(4, i32)};
+  const auto i64_2 = array_typet{i64, from_integer(4, i32)};
+  // Note: the array_typet's size type is the "index type"; using i32 for
+  // both source and target keeps the converted index sort uniform.
+  const auto i64_2_with_2 = array_typet{i64, from_integer(2, i32)};
+  const auto u32_4 = array_typet{u32, from_integer(4, i32)};
+  const symbolt src_i32_4 = make_test_symbol("src", i32_4);
+  test.symbol_table.insert(src_i32_4);
+  const smt_identifier_termt src_term{
+    "src", smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{32}}};
+  const symbolt src_i64_2 = make_test_symbol("src64", i64_2_with_2);
+  test.symbol_table.insert(src_i64_2);
+  const smt_identifier_termt src64_term{
+    "src64",
+    smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{64}}};
+
+  SECTION("Widening int32[4] -> int64[2] on little-endian")
+  {
+    test.sent_commands.clear();
+    const typecast_exprt cast{src_i32_4.symbol_expr(), i64_2_with_2};
+    test.procedure.set_to(equal_exprt{cast, cast}, true);
+    const smt_identifier_termt array_term{
+      "array_0",
+      smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{64}}};
+    auto sel_src = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        src_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    auto sel_target = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        array_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    const std::vector<smt_commandt> expected_commands{
+      smt_declare_function_commandt{src_term, {}},
+      smt_declare_function_commandt{array_term, {}},
+      // target[0] = concat(src[1], src[0])  -- LE: low source idx -> low bits
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(0), smt_bit_vector_theoryt::concat(sel_src(1), sel_src(0)))},
+      // target[1] = concat(src[3], src[2])
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(1), smt_bit_vector_theoryt::concat(sel_src(3), sel_src(2)))},
+      // The trivial equality (cast == cast) appears as the substituted
+      // array == itself; no extra commands beyond the common-sub-expression
+      // de-duplication are added here.
+      smt_assert_commandt{smt_core_theoryt::equal(array_term, array_term)}};
+    REQUIRE(test.sent_commands == expected_commands);
+  }
+
+  SECTION("Widening int32[4] -> int64[2] on big-endian")
+  {
+    // Switch endianness for this section only; restore at the end.
+    const auto saved_endianness = config.ansi_c.endianness;
+    config.ansi_c.endianness = configt::ansi_ct::endiannesst::IS_BIG_ENDIAN;
+    test.sent_commands.clear();
+    const typecast_exprt cast{src_i32_4.symbol_expr(), i64_2_with_2};
+    test.procedure.set_to(equal_exprt{cast, cast}, true);
+    const smt_identifier_termt array_term{
+      "array_0",
+      smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{64}}};
+    auto sel_src = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        src_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    auto sel_target = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        array_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    const std::vector<smt_commandt> expected_commands{
+      smt_declare_function_commandt{src_term, {}},
+      smt_declare_function_commandt{array_term, {}},
+      // target[0] = concat(src[0], src[1])  -- BE: low source idx -> high bits
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(0), smt_bit_vector_theoryt::concat(sel_src(0), sel_src(1)))},
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(1), smt_bit_vector_theoryt::concat(sel_src(2), sel_src(3)))},
+      smt_assert_commandt{smt_core_theoryt::equal(array_term, array_term)}};
+    REQUIRE(test.sent_commands == expected_commands);
+    config.ansi_c.endianness = saved_endianness;
+  }
+
+  SECTION("Narrowing int64[2] -> int32[4] on little-endian")
+  {
+    test.sent_commands.clear();
+    const typecast_exprt cast{src_i64_2.symbol_expr(), i32_4};
+    test.procedure.set_to(equal_exprt{cast, cast}, true);
+    const smt_identifier_termt array_term{
+      "array_0",
+      smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{32}}};
+    auto sel_src = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        src64_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    auto sel_target = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        array_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    const std::vector<smt_commandt> expected_commands{
+      smt_declare_function_commandt{src64_term, {}},
+      smt_declare_function_commandt{array_term, {}},
+      // target[0] = extract(31, 0)  src[0]   -- LE: lowest target lane = LSBs
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(0), smt_bit_vector_theoryt::extract(31, 0)(sel_src(0)))},
+      // target[1] = extract(63, 32) src[0]
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(1), smt_bit_vector_theoryt::extract(63, 32)(sel_src(0)))},
+      // target[2] = extract(31, 0)  src[1]
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(2), smt_bit_vector_theoryt::extract(31, 0)(sel_src(1)))},
+      // target[3] = extract(63, 32) src[1]
+      smt_assert_commandt{smt_core_theoryt::equal(
+        sel_target(3), smt_bit_vector_theoryt::extract(63, 32)(sel_src(1)))},
+      smt_assert_commandt{smt_core_theoryt::equal(array_term, array_term)}};
+    REQUIRE(test.sent_commands == expected_commands);
+  }
+
+  SECTION("Equal-width pass-through int32[4] -> uint32[4]")
+  {
+    test.sent_commands.clear();
+    const typecast_exprt cast{src_i32_4.symbol_expr(), u32_4};
+    test.procedure.set_to(equal_exprt{cast, cast}, true);
+    const smt_identifier_termt array_term{
+      "array_0",
+      smt_array_sortt{smt_bit_vector_sortt{32}, smt_bit_vector_sortt{32}}};
+    auto sel_src = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        src_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    auto sel_target = [&](unsigned i)
+    {
+      return smt_array_theoryt::select(
+        array_term, smt_bit_vector_constant_termt{i, 32});
+    };
+    std::vector<smt_commandt> expected_commands{
+      smt_declare_function_commandt{src_term, {}},
+      smt_declare_function_commandt{array_term, {}}};
+    for(unsigned i = 0; i < 4; ++i)
+    {
+      expected_commands.push_back(smt_assert_commandt{
+        smt_core_theoryt::equal(sel_target(i), sel_src(i))});
+    }
+    expected_commands.push_back(
+      smt_assert_commandt{smt_core_theoryt::equal(array_term, array_term)});
+    REQUIRE(test.sent_commands == expected_commands);
+  }
+}


### PR DESCRIPTION
Handle typecasts between array types with different element widths by creating a new SMT array and asserting element-by-element reinterpretation constraints: concatenation for widening (e.g., int32[4] to int64[2]) and extraction for narrowing.

Keep SIMD1 excluded from incremental SMT2 (no-new-smt) as it also requires saturating arithmetic support which is not yet implemented.

Fixes: #8075

Co-authored-by: Kiro (autonomous agent) <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
