### PR TITLE
Remove deprecated add_axioms_from_long method

### DIFF
--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -183,11 +183,11 @@ public:
     const exprt &input_int,
     size_t max_size);
   std::pair<exprt, string_constraintst>
+  add_axioms_for_string_of_long(const function_application_exprt &f);
+  std::pair<exprt, string_constraintst>
   add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i);
   std::pair<exprt, string_constraintst>
   add_axioms_from_int_hex(const function_application_exprt &f);
-  std::pair<exprt, string_constraintst>
-  add_axioms_from_long(const function_application_exprt &f);
   std::pair<exprt, string_constraintst>
   add_axioms_from_bool(const function_application_exprt &f);
   std::pair<exprt, string_constraintst>

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -279,7 +279,7 @@ string_constraint_generatort::add_axioms_for_function_application(
   else if(id == ID_cprover_string_of_double_func)
     return add_axioms_from_double(expr);
   else if(id == ID_cprover_string_of_long_func)
-    return add_axioms_from_long(expr);
+    return add_axioms_for_string_of_long(expr);
   else if(id == ID_cprover_string_set_length_func)
     return add_axioms_for_set_length(expr);
   else if(id == ID_cprover_string_delete_func)

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -35,25 +35,6 @@ static unsigned long to_integer_or_default(
   return def;
 }
 
-/// Add axioms corresponding to the String.valueOf(J) java function.
-/// \deprecated should use add_axioms_from_int instead
-/// \param f: function application with one long argument
-/// \return a new string expression
-DEPRECATED(SINCE(2017, 10, 5, "use add_axioms_for_string_of_int instead"))
-std::pair<exprt, string_constraintst>
-string_constraint_generatort::add_axioms_from_long(
-  const function_application_exprt &f)
-{
-  PRECONDITION(f.arguments().size() == 3 || f.arguments().size() == 4);
-  const array_string_exprt res =
-    array_pool.find(f.arguments()[1], f.arguments()[0]);
-  if(f.arguments().size() == 4)
-    return add_axioms_for_string_of_int_with_radix(
-      res, f.arguments()[2], f.arguments()[3], 0);
-  else
-    return add_axioms_for_string_of_int(res, f.arguments()[2], 0);
-}
-
 /// Add axioms stating that the returned string equals "true" when the Boolean
 /// expression is true and "false" when it is false.
 /// \deprecated This is Java specific and should be implemented in Java instead
@@ -122,6 +103,35 @@ string_constraint_generatort::add_axioms_for_string_of_int(
   const constant_exprt radix = from_integer(10, input_int.type());
   return add_axioms_for_string_of_int_with_radix(
     res, input_int, radix, max_size);
+}
+
+/// Add axioms enforcing that the result string of the
+/// `__CPROVER_string_of_long` built-in equals the decimal (or radix-`r`)
+/// representation of its long-typed argument.
+///
+/// The body delegates to \ref add_axioms_for_string_of_int (or its
+/// `_with_radix` companion), which is parametric in the bit-width of
+/// `f.arguments()[2].type()`, so the same axioms describe the
+/// representation of `int`-typed and `long`-typed inputs alike. This
+/// helper exists as a discoverable named entry point for
+/// `ID_cprover_string_of_long_func`, mirroring the surviving
+/// `add_axioms_from_*` thunks dispatched by
+/// \ref add_axioms_for_function_application.
+/// \param f: function application with the result-string slot
+///   (arguments 0 and 1), the long-typed value (argument 2) and
+///   optionally a radix (argument 3).
+/// \return code 0 on success
+std::pair<exprt, string_constraintst>
+string_constraint_generatort::add_axioms_for_string_of_long(
+  const function_application_exprt &f)
+{
+  PRECONDITION(f.arguments().size() == 3 || f.arguments().size() == 4);
+  const array_string_exprt res =
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
+  if(f.arguments().size() == 4)
+    return add_axioms_for_string_of_int_with_radix(
+      res, f.arguments()[2], f.arguments()[3], 0);
+  return add_axioms_for_string_of_int(res, f.arguments()[2], 0);
 }
 
 /// Add axioms enforcing that the string corresponds to the result


### PR DESCRIPTION
Removes the deprecated string_constraint_generatort::add_axioms_from_long method and inlines its implementation at the call site.

Fixes: #8021

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
