### PR TITLE
Remove deprecated add_axioms_from_bool method

### DIFF
--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -189,10 +189,6 @@ public:
   std::pair<exprt, string_constraintst>
   add_axioms_from_long(const function_application_exprt &f);
   std::pair<exprt, string_constraintst>
-  add_axioms_from_bool(const function_application_exprt &f);
-  std::pair<exprt, string_constraintst>
-  add_axioms_from_bool(const array_string_exprt &res, const exprt &b);
-  std::pair<exprt, string_constraintst>
   add_axioms_from_char(const function_application_exprt &f);
   std::pair<exprt, string_constraintst>
   add_axioms_from_char(const array_string_exprt &res, const exprt &c);

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -54,57 +54,6 @@ string_constraint_generatort::add_axioms_from_long(
     return add_axioms_for_string_of_int(res, f.arguments()[2], 0);
 }
 
-/// Add axioms stating that the returned string equals "true" when the Boolean
-/// expression is true and "false" when it is false.
-/// \deprecated This is Java specific and should be implemented in Java instead
-/// \param res: string expression for the result
-/// \param b: Boolean expression
-/// \return code 0 on success
-DEPRECATED(SINCE(2017, 10, 5, "Java specific, should be implemented in Java"))
-std::pair<exprt, string_constraintst>
-string_constraint_generatort::add_axioms_from_bool(
-  const array_string_exprt &res,
-  const exprt &b)
-{
-  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
-  PRECONDITION(b.type() == bool_typet() || b.type().id() == ID_c_bool);
-  string_constraintst constraints;
-  typecast_exprt eq(b, bool_typet());
-
-  // We add axioms:
-  // a1 : eq => res = |"true"|
-  // a2 : forall i < |"true"|. eq => res[i]="true"[i]
-  // a3 : !eq => res = |"false"|
-  // a4 : forall i < |"false"|. !eq => res[i]="false"[i]
-
-  std::string str_true = "true";
-  const implies_exprt a1(
-    eq, equal_to(array_pool.get_or_create_length(res), str_true.length()));
-  constraints.existential.push_back(a1);
-
-  for(std::size_t i = 0; i < str_true.length(); i++)
-  {
-    exprt chr = from_integer(str_true[i], char_type);
-    implies_exprt a2(eq, equal_exprt(res[i], chr));
-    constraints.existential.push_back(a2);
-  }
-
-  std::string str_false = "false";
-  const implies_exprt a3(
-    not_exprt(eq),
-    equal_to(array_pool.get_or_create_length(res), str_false.length()));
-  constraints.existential.push_back(a3);
-
-  for(std::size_t i = 0; i < str_false.length(); i++)
-  {
-    exprt chr = from_integer(str_false[i], char_type);
-    implies_exprt a4(not_exprt(eq), equal_exprt(res[i], chr));
-    constraints.existential.push_back(a4);
-  }
-
-  return {from_integer(0, get_return_code_type()), std::move(constraints)};
-}
-
 /// Add axioms enforcing that the string corresponds to the result
 /// of String.valueOf(I) or String.valueOf(J) Java functions applied
 /// on the integer expression.

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -26,6 +26,51 @@ static exprt format_arg_from_string(
   const irep_idt &id,
   array_poolt &array_pool);
 
+/// Add the axioms describing the result of formatting a Boolean argument
+/// as a string under the BOOLEAN format specifier (`%b`): the returned
+/// string equals `"true"` when `b` is true and `"false"` when it is
+/// false. This logic was previously the public, Java-specific
+/// `string_constraint_generatort::add_axioms_from_bool(const
+/// array_string_exprt &, const exprt &)` helper; the current home is
+/// local to this TU because the only caller is
+/// `add_axioms_for_format_specifier` below and the semantics are tied
+/// to `java.lang.String.format` / `java.util.Formatter`.
+/// \param constraints: the constraint set to extend
+/// \param res: the result string slot
+/// \param b: the Boolean argument; must be of `bool_typet` or `c_bool`
+/// \param array_pool: array pool of the calling solver
+/// \param char_type: element type of \p res
+static void add_axioms_for_format_bool(
+  string_constraintst &constraints,
+  const array_string_exprt &res,
+  const exprt &b,
+  array_poolt &array_pool,
+  const typet &char_type)
+{
+  INVARIANT(
+    b.type() == bool_typet{} || b.type().id() == ID_c_bool,
+    "format_arg_from_string with ID_boolean must yield a Boolean");
+
+  // a1 : eq         => |res| = |"true"|
+  // a2 : forall i < |"true"|.  eq => res[i] = "true"[i]
+  // a3 : !eq        => |res| = |"false"|
+  // a4 : forall i < |"false"|. !eq => res[i] = "false"[i]
+  const typecast_exprt eq{b, bool_typet{}};
+
+  auto emit_literal = [&](const exprt &guard, const std::string &lit)
+  {
+    constraints.existential.push_back(implies_exprt{
+      guard, equal_to(array_pool.get_or_create_length(res), lit.length())});
+    for(std::size_t i = 0; i < lit.length(); ++i)
+    {
+      constraints.existential.push_back(implies_exprt{
+        guard, equal_exprt{res[i], from_integer(lit[i], char_type)}});
+    }
+  };
+  emit_literal(eq, "true");
+  emit_literal(not_exprt{eq}, "false");
+}
+
 string_format_builtin_functiont::string_format_builtin_functiont(
   const exprt &return_code,
   const std::vector<exprt> &fun_args,
@@ -172,9 +217,13 @@ add_axioms_for_format_specifier(
     return {res, constraints};
   }
   case format_specifiert::BOOLEAN:
-    return_code = generator.add_axioms_from_bool(
-      res, format_arg_from_string(string_arg, ID_boolean, array_pool));
-    return {res, std::move(return_code.second)};
+    add_axioms_for_format_bool(
+      constraints,
+      res,
+      format_arg_from_string(string_arg, ID_boolean, array_pool),
+      array_pool,
+      char_type);
+    return {res, constraints};
   case format_specifiert::STRING:
   {
     const exprt arg_string = string_arg;


### PR DESCRIPTION
Removed the deprecated add_axioms_from_bool(array_string_exprt, exprt) method and inlined its logic at the call site in string_format_builtin_function.cpp

Fixes: #8022

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
