### PR TITLE
Remove deprecated set_attribute calls from static_verifier.cpp

### DIFF
--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -60,12 +60,6 @@ xmlt static_verifier_resultt::output_xml(void) const
 
   x.set_attribute("status", as_string(this->status));
 
-  // DEPRECATED(SINCE(2020, 12, 2, "Remove and use the structured version"));
-  // Unstructured partial output of source location is not great...
-  x.set_attribute("file", id2string(this->source_location.get_file()));
-  x.set_attribute("line", id2string(this->source_location.get_line()));
-
-  // ... this is better
   x.new_element(xml(source_location));
 
   // ( get_comment is not output as part of xml(source_location) )


### PR DESCRIPTION
Fixes: #8027

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
