### PR TITLE
Implement quantifier support for incremental SMT2 decision procedure

### DIFF
--- a/regression/cbmc/Quantifiers-copy/test.desc
+++ b/regression/cbmc/Quantifiers-copy/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-initialisation/test.desc
+++ b/regression/cbmc/Quantifiers-initialisation/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-nested/main.c
+++ b/regression/cbmc/Quantifiers-nested/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+// Nested quantifiers: the body of the outer forall contains an inner forall
+// that references the outer quantifier's bound variable `i`. This exercises the
+// nested-scope handling in the incremental SMT2 backend's dependency gathering,
+// where `i` must be treated as bound (and hence not emitted as a top-level
+// declaration) within the inner quantifier's body.
+int main()
+{
+  int b[2][2];
+  // clang-format off
+  __CPROVER_assume(__CPROVER_forall {
+    int i;
+    (i >= 0 && i < 2) ==>
+      (__CPROVER_forall {
+        int j;
+        (j >= 0 && j < 2) ==> b[i][j] == i + j
+      })
+  });
+  // clang-format on
+  assert(b[0][0] == 0);
+  assert(b[0][1] == 1);
+  assert(b[1][0] == 1);
+  assert(b[1][1] == 2);
+  return 0;
+}

--- a/regression/cbmc/Quantifiers-nested/test.desc
+++ b/regression/cbmc/Quantifiers-nested/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^\*\* 0 of \d+ failed
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/Quantifiers-statement-expression2/test.desc
+++ b/regression/cbmc/Quantifiers-statement-expression2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-type2/test.desc
+++ b/regression/cbmc/Quantifiers-type2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\*\* Results:$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1396,20 +1396,40 @@ static smt_termt convert_expr_to_smt(
     "Generation of SMT formula for literal expression: " + literal.pretty());
 }
 
+/// Shared conversion for quantifier expressions. \tparam smt_quantifier_termt
+/// is the SMT term to produce (\ref smt_forall_termt or \ref smt_exists_termt);
+/// the rest of the conversion is identical for `forall` and `exists`.
+template <typename smt_quantifier_termt>
+static smt_termt convert_quantifier_to_smt(
+  const quantifier_exprt &quantifier,
+  const sub_expression_mapt &converted)
+{
+  // Extract the bound variables from the quantifier expression
+  std::vector<smt_identifier_termt> bound_variables;
+  bound_variables.reserve(quantifier.variables().size());
+  for(const auto &variable : quantifier.variables())
+  {
+    bound_variables.push_back(smt_identifier_termt{
+      variable.get_identifier(), convert_type_to_smt_sort(variable.type())});
+  }
+
+  // Get the converted predicate (body) of the quantifier
+  return smt_quantifier_termt{
+    std::move(bound_variables), converted.at(quantifier.where())};
+}
+
 static smt_termt convert_expr_to_smt(
   const forall_exprt &for_all,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for for all expression: " + for_all.pretty());
+  return convert_quantifier_to_smt<smt_forall_termt>(for_all, converted);
 }
 
 static smt_termt convert_expr_to_smt(
   const exists_exprt &exists,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for exists expression: " + exists.pretty());
+  return convert_quantifier_to_smt<smt_exists_termt>(exists, converted);
 }
 
 static smt_termt convert_expr_to_smt(
@@ -1932,8 +1952,19 @@ void filtered_visit_post(
       // do modification of 'top' before pushing in case 'top' isn't stable
       top.operands_pushed = true;
       if(filter(*top.e))
-        for(auto &op : top.e->operands())
-          stack.emplace(&op);
+      {
+        // Special handling for quantifiers: only push body,
+        // not bound variables tuple
+        if(can_cast_expr<quantifier_exprt>(*top.e))
+        {
+          stack.emplace(&to_quantifier_expr(*top.e).where());
+        }
+        else
+        {
+          for(auto &op : top.e->operands())
+            stack.emplace(&op);
+        }
+      }
     }
   }
 }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -6,6 +6,7 @@
 #include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/mathematical_expr.h>
 #include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
@@ -24,6 +25,7 @@
 #include <solvers/smt2_incremental/theories/smt_core_theory.h>
 #include <solvers/smt2_incremental/type_size_mapping.h>
 
+#include <memory>
 #include <stack>
 #include <unordered_set>
 
@@ -75,32 +77,63 @@ static std::vector<exprt> gather_dependent_expressions(const exprt &root_expr)
 {
   std::vector<exprt> dependent_expressions;
 
-  std::stack<const exprt *> stack;
-  stack.push(&root_expr);
+  // Each frame carries the node to visit together with the set of identifiers
+  // bound by the enclosing quantifiers. The bound set is shared between frames
+  // and only extended when entering a quantifier, so a nested quantifier
+  // correctly sees the variables bound by all of its enclosing quantifiers (and
+  // those variables are not emitted as top-level dependencies).
+  using bound_sett = std::unordered_set<irep_idt>;
+  struct framet
+  {
+    const exprt *node;
+    std::shared_ptr<const bound_sett> bound;
+  };
+
+  std::stack<framet> stack;
+  stack.push({&root_expr, std::make_shared<const bound_sett>()});
 
   while(!stack.empty())
   {
-    const exprt &expr_node = *stack.top();
+    const framet frame = stack.top();
     stack.pop();
-    if(
-      can_cast_expr<symbol_exprt>(expr_node) ||
-      can_cast_expr<array_exprt>(expr_node) ||
-      can_cast_expr<array_of_exprt>(expr_node) ||
-      can_cast_expr<nondet_symbol_exprt>(expr_node) ||
-      can_cast_expr<string_constantt>(expr_node))
+    const exprt &node = *frame.node;
+
+    // A quantifier binds its variables within its body. Extend the bound set
+    // and descend into the body only; the bound-variable tuple itself is not a
+    // dependency.
+    if(can_cast_expr<quantifier_exprt>(node))
     {
-      dependent_expressions.push_back(expr_node);
+      const quantifier_exprt &quantifier = to_quantifier_expr(node);
+      auto extended_bound = std::make_shared<bound_sett>(*frame.bound);
+      for(const auto &var : quantifier.variables())
+        extended_bound->insert(var.get_identifier());
+      stack.push({&quantifier.where(), std::move(extended_bound)});
+      continue;
+    }
+
+    if(
+      can_cast_expr<symbol_exprt>(node) || can_cast_expr<array_exprt>(node) ||
+      can_cast_expr<array_of_exprt>(node) ||
+      can_cast_expr<nondet_symbol_exprt>(node) ||
+      can_cast_expr<string_constantt>(node))
+    {
+      // A symbol bound by an enclosing quantifier is declared by the SMT-LIB
+      // quantifier rather than as a top-level dependency.
+      const auto symbol = expr_try_dynamic_cast<symbol_exprt>(node);
+      if(!(symbol && frame.bound->count(symbol->get_identifier())))
+        dependent_expressions.push_back(node);
     }
     // The decision procedure does not depend on the values inside address of
     // code typed expressions. We can build the address without knowing the
     // value at that memory location. In this case the hypothetical compiled
     // machine instructions at the address are not relevant to solving, only
     // representing *which* function a pointer points to is needed.
-    const auto address_of = expr_try_dynamic_cast<address_of_exprt>(expr_node);
+    const auto address_of = expr_try_dynamic_cast<address_of_exprt>(node);
     if(address_of && can_cast_type<code_typet>(address_of->object().type()))
       continue;
-    for(auto &operand : expr_node.operands())
-      stack.push(&operand);
+
+    for(auto &operand : node.operands())
+      stack.push({&operand, frame.bound});
   }
   return dependent_expressions;
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -6,6 +6,7 @@
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/constructor_of.h>
+#include <util/mathematical_expr.h>
 #include <util/namespace.h>
 #include <util/pointer_predicates.h>
 #include <util/std_expr.h>
@@ -1775,4 +1776,34 @@ TEST_CASE(
           smt_bit_vector_constant_termt{1, 64})));
     CHECK(test.convert(assignment) == expected);
   }
+}
+
+TEST_CASE(
+  "expr to smt conversion for forall quantifier",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const signedbv_typet int_type{32};
+  const symbol_exprt bound{"x", int_type};
+  const exprt predicate = equal_exprt{bound, from_integer(0, int_type)};
+  const forall_exprt forall{bound, predicate};
+  const smt_termt expected = smt_forall_termt{
+    {smt_identifier_termt{"x", smt_bit_vector_sortt{32}}},
+    test.convert(predicate)};
+  CHECK(test.convert(forall) == expected);
+}
+
+TEST_CASE(
+  "expr to smt conversion for exists quantifier",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const signedbv_typet int_type{32};
+  const symbol_exprt bound{"x", int_type};
+  const exprt predicate = equal_exprt{bound, from_integer(0, int_type)};
+  const exists_exprt exists{bound, predicate};
+  const smt_termt expected = smt_exists_termt{
+    {smt_identifier_termt{"x", smt_bit_vector_sortt{32}}},
+    test.convert(predicate)};
+  CHECK(test.convert(exists) == expected);
 }


### PR DESCRIPTION
Convert forall_exprt and exists_exprt to smt_forall_termt and
smt_exists_termt respectively. Skip bound variable tuples during
expression traversal in filtered_visit_post. Track quantifier-bound
variable identifiers in gather_dependent_expressions and exclude
them from dependencies, preventing spurious SMT function declarations
for variables that should be bound by the quantifier.

Remove no-new-smt exclusion tag from Quantifiers-copy,
Quantifiers-initialisation, Quantifiers-statement-expression2,
and Quantifiers-type2 which now pass.

Fixes: #8053

Co-authored-by: Kiro (autonomous agent) <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
