### PR TITLE
Implement builtin bitwise intrinsics in SMT2 incremental decision procedure

### DIFF
--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/bswap.c
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/bswap.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+
+#ifndef __GNUC__
+uint16_t __builtin_bswap16(uint16_t);
+uint32_t __builtin_bswap32(uint32_t);
+#endif
+
+int main()
+{
+  uint32_t a = 0x12345678u;
+  __CPROVER_assert(__builtin_bswap32(a) == 0x78563412u, "bswap32");
+
+  uint16_t b = 0xABCDu;
+  __CPROVER_assert(__builtin_bswap16(b) == 0xCDABu, "bswap16");
+}

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/bswap.desc
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/bswap.desc
@@ -1,0 +1,9 @@
+CORE
+bswap.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Tests __builtin_bswap32 via incremental SMT2.

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/builtins.c
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/builtins.c
@@ -1,0 +1,26 @@
+int main()
+{
+  unsigned a;
+
+  // popcount
+  __CPROVER_assume(a == 0xF0);
+  __CPROVER_assert(__builtin_popcount(a) == 4, "popcount of 0xF0 should be 4");
+
+  // count leading zeros (32-bit)
+  unsigned b;
+  __CPROVER_assume(b == 0x00800000u);
+  __CPROVER_assert(__builtin_clz(b) == 8, "clz of 0x00800000 should be 8");
+
+  // count trailing zeros
+  unsigned c;
+  __CPROVER_assume(c == 0x00800000u);
+  __CPROVER_assert(__builtin_ctz(c) == 23, "ctz of 0x00800000 should be 23");
+
+  // find first set (1-indexed from LSB)
+  unsigned d;
+  __CPROVER_assume(d == 0x00800000u);
+  __CPROVER_assert(__builtin_ffs(d) == 24, "ffs of 0x00800000 should be 24");
+
+  // ffs of zero
+  __CPROVER_assert(__builtin_ffs(0) == 0, "ffs of 0 should be 0");
+}

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/builtins.desc
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/builtins.desc
@@ -1,0 +1,9 @@
+CORE
+builtins.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Tests popcount, clz, ctz, and ffs builtins via incremental SMT2.

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate.c
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate.c
@@ -1,0 +1,17 @@
+int main()
+{
+  unsigned a;
+  __CPROVER_assume(a == 0x12345678u);
+
+  // Rotate left by 8: 0x12345678 -> 0x34567812
+  unsigned rl = __builtin_rotateleft32(a, 8);
+  __CPROVER_assert(rl == 0x34567812u, "rotl32 by 8");
+
+  // Rotate right by 8: 0x12345678 -> 0x78123456
+  unsigned rr = __builtin_rotateright32(a, 8);
+  __CPROVER_assert(rr == 0x78123456u, "rotr32 by 8");
+
+  // Rotate by 0 is identity
+  __CPROVER_assert(
+    __builtin_rotateleft32(a, 0) == a, "rotl32 by 0 is identity");
+}

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate.desc
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate.desc
@@ -1,0 +1,9 @@
+CORE
+rotate.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Tests rotate left and rotate right builtins via incremental SMT2.

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate_reverse.c
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate_reverse.c
@@ -1,0 +1,30 @@
+int main()
+{
+  // rotate left by constant
+  unsigned a;
+  __CPROVER_assume(a == 0x12345678u);
+  unsigned rl = (a << 8) | (a >> 24);
+  __CPROVER_assert(__builtin_rotateleft32(a, 8) == rl, "rotate left by 8");
+
+  // rotate right by constant
+  unsigned rr = (a >> 4) | (a << 28);
+  __CPROVER_assert(__builtin_rotateright32(a, 4) == rr, "rotate right by 4");
+
+  // rotate by zero
+  __CPROVER_assert(
+    __builtin_rotateleft32(a, 0) == a, "rotate left by 0 is identity");
+
+  // rotate left by dynamic amount
+  unsigned n;
+  __CPROVER_assume(n == 16);
+  unsigned rl_dyn = (a << 16) | (a >> 16);
+  __CPROVER_assert(
+    __builtin_rotateleft32(a, n) == rl_dyn, "rotate left by dynamic 16");
+
+  // bitreverse
+  unsigned char b;
+  __CPROVER_assume(b == 0xB0u); // 10110000
+  // reversed: 00001101 = 0x0D
+  __CPROVER_assert(
+    __builtin_bitreverse8(b) == 0x0Du, "bitreverse of 0xB0 should be 0x0D");
+}

--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate_reverse.desc
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/rotate_reverse.desc
@@ -1,0 +1,10 @@
+CORE
+rotate_reverse.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Tests rotate_left, rotate_right (constant and dynamic),
+and bitreverse builtins via incremental SMT2.

--- a/regression/cbmc/__builtin_clz-01/big-endian.desc
+++ b/regression/cbmc/__builtin_clz-01/big-endian.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --big-endian
 ^\[main.bit_count.\d+\] line 61 count leading zeros is undefined for value zero in __builtin_clz\(0u\): FAILURE$

--- a/regression/cbmc/__builtin_clz-01/test.desc
+++ b/regression/cbmc/__builtin_clz-01/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\[main.bit_count.\d+\] line 61 count leading zeros is undefined for value zero in __builtin_clz\(0u\): FAILURE$

--- a/regression/cbmc/__builtin_ctz-01/big-endian.desc
+++ b/regression/cbmc/__builtin_ctz-01/big-endian.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --big-endian
 ^\[main.bit_count.\d+\] line 46 count trailing zeros is undefined for value zero in __builtin_ctz\(0u\): FAILURE$

--- a/regression/cbmc/__builtin_ctz-01/test.desc
+++ b/regression/cbmc/__builtin_ctz-01/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\[main.bit_count.\d+\] line 46 count trailing zeros is undefined for value zero in __builtin_ctz\(0u\): FAILURE$

--- a/regression/cbmc/__builtin_ffs-01/big-endian.desc
+++ b/regression/cbmc/__builtin_ffs-01/big-endian.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --big-endian
 ^EXIT=0$

--- a/regression/cbmc/__builtin_ffs-01/test.desc
+++ b/regression/cbmc/__builtin_ffs-01/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/atomic_fetch_X-1/test.desc
+++ b/regression/cbmc/atomic_fetch_X-1/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --no-standard-checks
 ^EXIT=0$

--- a/regression/cbmc/clang_builtins/bitreverse.desc
+++ b/regression/cbmc/clang_builtins/bitreverse.desc
@@ -1,4 +1,4 @@
-CORE thorough-paths no-new-smt
+CORE thorough-paths
 bitreverse.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/clang_builtins/rotate.desc
+++ b/regression/cbmc/clang_builtins/rotate.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 rotate.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -982,12 +982,96 @@ static smt_termt convert_to_smt_shift(
     return factory(first_operand, second_operand);
   }
 }
+/// \brief Convert a rotate_left or rotate_right expression to SMT.
+/// Implements rotation as `(x << n) | (x >> (width - n))` for left rotation
+/// (and the converse for right), after normalizing the distance to match
+/// the value's bit width.
+/// \param rotate: the rotation expression (rotate_left or rotate_right)
+/// \param converted: map of already-converted sub-expressions
+/// \param is_left: true for left rotation, false for right
+static smt_termt convert_rotation_to_smt(
+  const shift_exprt &rotate,
+  const sub_expression_mapt &converted,
+  bool is_left)
+{
+  const smt_termt &value = converted.at(rotate.op0());
+  const smt_termt &distance = converted.at(rotate.op1());
+
+  const auto value_sort = value.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(value_sort, "Rotation value must have bit-vector sort");
+
+  const auto bit_width = value_sort->bit_width();
+  INVARIANT(bit_width > 0, "Rotation value must have a positive bit width");
+
+  // Try to extract constant distance for optimized SMT2 rotate operations
+  if(
+    const auto constant_distance =
+      expr_try_dynamic_cast<constant_exprt>(rotate.op1()))
+  {
+    mp_integer distance_int;
+    if(!to_integer(*constant_distance, distance_int))
+    {
+      if(distance_int < 0)
+        distance_int = 0;
+      if(bit_width != 0)
+        distance_int %= mp_integer(bit_width);
+      const auto normalized = numeric_cast_v<std::size_t>(distance_int);
+      if(is_left)
+        return smt_bit_vector_theoryt::rotate_left(normalized)(value);
+      else
+        return smt_bit_vector_theoryt::rotate_right(normalized)(value);
+    }
+  }
+
+  // For dynamic rotation, implement using shifts and or
+  // rotate_left(x, n) = (x << n) | (x >> (width - n))
+  // rotate_right(x, n) = (x >> n) | (x << (width - n))
+
+  const auto distance_sort = distance.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(distance_sort, "Rotation distance must have bit-vector sort");
+
+  const std::size_t distance_width = distance_sort->bit_width();
+
+  // Normalize distance to bit_width to match value's width if needed
+  smt_termt normalized_distance = distance;
+  if(distance_width < bit_width)
+  {
+    normalized_distance =
+      smt_bit_vector_theoryt::zero_extend(bit_width - distance_width)(distance);
+  }
+  else if(distance_width > bit_width)
+  {
+    normalized_distance =
+      smt_bit_vector_theoryt::extract(bit_width - 1, 0)(distance);
+  }
+
+  // Reduce modulo bit_width so shifts by >= width work correctly
+  const auto width_constant =
+    smt_bit_vector_constant_termt{bit_width, bit_width};
+  normalized_distance = smt_bit_vector_theoryt::unsigned_remainder(
+    normalized_distance, width_constant);
+
+  // Calculate complementary distance: width - (n % width)
+  const auto complementary_distance =
+    smt_bit_vector_theoryt::subtract(width_constant, normalized_distance);
+
+  smt_termt shifted_left =
+    is_left ? smt_bit_vector_theoryt::shift_left(value, normalized_distance)
+            : smt_bit_vector_theoryt::shift_left(value, complementary_distance);
+  smt_termt shifted_right =
+    is_left
+      ? smt_bit_vector_theoryt::logical_shift_right(
+          value, complementary_distance)
+      : smt_bit_vector_theoryt::logical_shift_right(value, normalized_distance);
+
+  return smt_bit_vector_theoryt::make_or(shifted_left, shifted_right);
+}
 
 static smt_termt convert_expr_to_smt(
   const shift_exprt &shift,
   const sub_expression_mapt &converted)
 {
-  // TODO: Dispatch for rotation expressions. A `shift_exprt` can be a rotation.
+  // Handle rotation expressions
   if(const auto left_shift = expr_try_dynamic_cast<shl_exprt>(shift))
   {
     return convert_to_smt_shift(
@@ -1006,6 +1090,14 @@ static smt_termt convert_expr_to_smt(
       smt_bit_vector_theoryt::arithmetic_shift_right,
       *right_arith_shift,
       converted);
+  }
+  if(shift.id() == ID_rol)
+  {
+    return convert_rotation_to_smt(shift, converted, true);
+  }
+  if(shift.id() == ID_ror)
+  {
+    return convert_rotation_to_smt(shift, converted, false);
   }
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for shift expression: " + shift.pretty());
@@ -1443,40 +1535,237 @@ convert_expr_to_smt(const let_exprt &let, const sub_expression_mapt &converted)
     "Generation of SMT formula for let expression: " + let.pretty());
 }
 
+/// \brief Convert a byte-swap (bswap) expression to SMT.
 static smt_termt convert_expr_to_smt(
   const bswap_exprt &byte_swap,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for byte swap expression: " +
-    byte_swap.pretty());
+  const auto operand = converted.at(byte_swap.op());
+  const auto *operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(operand_sort, "bswap operand must have bit-vector sort");
+
+  const auto bits_per_byte = byte_swap.get_bits_per_byte();
+  const auto bit_width = operand_sort->bit_width();
+  INVARIANT(
+    bit_width % bits_per_byte == 0,
+    "bswap width must be a multiple of bits_per_byte");
+
+  const std::size_t num_bytes = bit_width / bits_per_byte;
+
+  // Extract bytes and concatenate in reverse order
+  smt_termt result =
+    smt_bit_vector_theoryt::extract(bits_per_byte - 1, 0)(operand);
+
+  for(std::size_t i = 1; i < num_bytes; ++i)
+  {
+    const auto byte = smt_bit_vector_theoryt::extract(
+      (i + 1) * bits_per_byte - 1, i * bits_per_byte)(operand);
+    result = smt_bit_vector_theoryt::concat(result, byte);
+  }
+
+  return result;
 }
 
+/// \brief Convert a population-count (popcount) expression to SMT.
 static smt_termt convert_expr_to_smt(
   const popcount_exprt &population_count,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for population count expression: " +
-    population_count.pretty());
+  const auto operand = converted.at(population_count.op());
+  const auto operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(operand_sort, "Population count operand must have bit-vector sort");
+
+  const auto bit_width = operand_sort->bit_width();
+  const auto result_width =
+    to_bitvector_type(population_count.type()).get_width();
+  INVARIANT(
+    result_width >= 1, "Population count result must have a positive width");
+
+  // Build a sum of each bit in the operand
+  smt_termt result = smt_bit_vector_constant_termt{0, result_width};
+
+  for(std::size_t i = 0; i < bit_width; ++i)
+  {
+    const auto bit = smt_bit_vector_theoryt::extract(i, i)(operand);
+    const auto extended_bit =
+      smt_bit_vector_theoryt::zero_extend(result_width - 1)(bit);
+    result = smt_bit_vector_theoryt::add(result, extended_bit);
+  }
+
+  return result;
 }
 
+enum class bit_iteration_directiont
+{
+  least_to_most_significant,
+  most_to_least_significant
+};
+
+/// \brief Build a nested if-then-else term selecting a per-bit value, used by
+/// the count-leading-zeros, count-trailing-zeros and find-first-set
+/// conversions.
+/// \param operand: the bit-vector term whose bits are inspected
+/// \param bit_width: width of \p operand
+/// \param result_width: width of the produced (result) constant terms
+/// \param direction: order in which bits are visited; the bit visited last
+///   becomes the outermost (highest priority) if-then-else condition
+/// \param match_value: value to select when the visited bit is set, as a
+///   function of the bit index
+/// \param default_value: value selected when none of the inspected bits is set
+static smt_termt nested_bit_match(
+  const smt_termt &operand,
+  std::size_t bit_width,
+  std::size_t result_width,
+  bit_iteration_directiont direction,
+  const std::function<std::size_t(std::size_t)> &match_value,
+  std::size_t default_value)
+{
+  INVARIANT(
+    result_width >= 1, "result width of a bit search must be at least one");
+  smt_termt result = smt_bit_vector_constant_termt{default_value, result_width};
+  const auto one_bit = smt_bit_vector_constant_termt{1, 1};
+  for(std::size_t step = 0; step < bit_width; ++step)
+  {
+    const std::size_t bit_index =
+      direction == bit_iteration_directiont::least_to_most_significant
+        ? step
+        : bit_width - 1 - step;
+    const auto bit =
+      smt_bit_vector_theoryt::extract(bit_index, bit_index)(operand);
+    const auto bit_is_one = smt_core_theoryt::equal(bit, one_bit);
+    const auto value =
+      smt_bit_vector_constant_termt{match_value(bit_index), result_width};
+    result = smt_core_theoryt::if_then_else(bit_is_one, value, result);
+  }
+  return result;
+}
+
+/// \brief Convert a count-leading-zeros expression to SMT.
 static smt_termt convert_expr_to_smt(
   const count_leading_zeros_exprt &count_leading_zeros,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for count leading zeros expression: " +
-    count_leading_zeros.pretty());
+  const auto operand = converted.at(count_leading_zeros.op());
+  const auto operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    operand_sort, "Count leading zeros operand must have bit-vector sort");
+
+  const auto bit_width = operand_sort->bit_width();
+  const auto result_width =
+    to_bitvector_type(count_leading_zeros.type()).get_width();
+
+  // The result is the number of zero bits above the most-significant set bit,
+  // or bit_width if no bit is set. Visiting bits from least- to most-
+  // significant makes the most-significant bit's condition the outermost one.
+  return nested_bit_match(
+    operand,
+    bit_width,
+    result_width,
+    bit_iteration_directiont::least_to_most_significant,
+    [&](std::size_t bit_index) { return bit_width - 1 - bit_index; },
+    bit_width);
 }
 
+/// \brief Convert a count-trailing-zeros expression to SMT.
 static smt_termt convert_expr_to_smt(
   const count_trailing_zeros_exprt &count_trailing_zeros,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for count trailing zeros expression: " +
-    count_trailing_zeros.pretty());
+  const auto operand = converted.at(count_trailing_zeros.op());
+  const auto operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    operand_sort, "Count trailing zeros operand must have bit-vector sort");
+
+  const auto bit_width = operand_sort->bit_width();
+  const auto result_width =
+    to_bitvector_type(count_trailing_zeros.type()).get_width();
+
+  // The result is the number of zero bits below the least-significant set bit,
+  // or bit_width if no bit is set. Visiting bits from most- to least-
+  // significant makes the least-significant bit's condition the outermost one.
+  return nested_bit_match(
+    operand,
+    bit_width,
+    result_width,
+    bit_iteration_directiont::most_to_least_significant,
+    [](std::size_t bit_index) { return bit_index; },
+    bit_width);
+}
+
+/// \brief Convert a find-first-set expression to SMT.
+static smt_termt convert_expr_to_smt(
+  const find_first_set_exprt &find_first_set,
+  const sub_expression_mapt &converted)
+{
+  const auto operand = converted.at(find_first_set.op());
+  const auto *operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(operand_sort, "Find first set operand must have bit-vector sort");
+
+  const auto bit_width = operand_sort->bit_width();
+  const auto result_width =
+    to_bitvector_type(find_first_set.type()).get_width();
+
+  // The result is the 1-based index of the least-significant set bit, or 0 if
+  // no bit is set. Visiting bits from most- to least-significant makes the
+  // least-significant bit's condition the outermost one.
+  return nested_bit_match(
+    operand,
+    bit_width,
+    result_width,
+    bit_iteration_directiont::most_to_least_significant,
+    [](std::size_t bit_index) { return bit_index + 1; },
+    0);
+}
+
+/// \brief Convert a bit-reverse expression to SMT.
+static smt_termt convert_expr_to_smt(
+  const bitreverse_exprt &bit_reverse,
+  const sub_expression_mapt &converted)
+{
+  const auto operand = converted.at(bit_reverse.op());
+  const auto *operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(operand_sort, "Bit reverse operand must have bit-vector sort");
+
+  const auto bit_width = operand_sort->bit_width();
+
+  // Reverse bits by extracting each bit and concatenating in reverse order
+  if(bit_width == 1)
+    return operand;
+
+  smt_termt result = smt_bit_vector_theoryt::extract(0, 0)(operand);
+
+  for(std::size_t i = 1; i < bit_width; ++i)
+  {
+    const auto bit = smt_bit_vector_theoryt::extract(i, i)(operand);
+    result = smt_bit_vector_theoryt::concat(result, bit);
+  }
+
+  return result;
+}
+
+/// \brief Convert a bitwise NAND expression to SMT.
+/// `bitnand_exprt` is unary (bit-wise NOT), binary (bit-wise NAND), or N-ary
+/// for N >= 3 (bit-wise NOT of the bit-wise AND), per its class documentation.
+static smt_termt convert_expr_to_smt(
+  const bitnand_exprt &bit_nand,
+  const sub_expression_mapt &converted)
+{
+  if(!operands_are_of_type<bitvector_typet>(bit_nand))
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for bitwise nand expression: " +
+      bit_nand.pretty());
+  }
+
+  const auto &operands = bit_nand.operands();
+  if(operands.size() == 1)
+    return smt_bit_vector_theoryt::make_not(converted.at(operands.front()));
+  if(operands.size() == 2)
+    return smt_bit_vector_theoryt::nand(
+      converted.at(operands[0]), converted.at(operands[1]));
+  // NAND of three or more operands is NOT(AND(...)).
+  return smt_bit_vector_theoryt::make_not(convert_multiary_operator_to_terms(
+    bit_nand, converted, smt_bit_vector_theoryt::make_and));
 }
 
 static smt_termt convert_expr_to_smt(
@@ -1850,6 +2139,20 @@ static smt_termt dispatch_expr_to_smt_conversion(
       expr_try_dynamic_cast<prophecy_pointer_in_range_exprt>(expr))
   {
     return convert_expr_to_smt(*prophecy_pointer_in_range, converted);
+  }
+  if(
+    const auto find_first_set =
+      expr_try_dynamic_cast<find_first_set_exprt>(expr))
+  {
+    return convert_expr_to_smt(*find_first_set, converted);
+  }
+  if(const auto bit_reverse = expr_try_dynamic_cast<bitreverse_exprt>(expr))
+  {
+    return convert_expr_to_smt(*bit_reverse, converted);
+  }
+  if(const auto bit_nand = expr_try_dynamic_cast<bitnand_exprt>(expr))
+  {
+    return convert_expr_to_smt(*bit_nand, converted);
   }
 
   UNIMPLEMENTED_FEATURE(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1776,3 +1776,202 @@ TEST_CASE(
     CHECK(test.convert(assignment) == expected);
   }
 }
+
+TEST_CASE("popcount_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{2}};
+  const popcount_exprt popcount{
+    symbol_exprt{"foo", unsignedbv_typet{2}}, signedbv_typet{8}};
+  // Sum of each operand bit, zero-extended to the 8-bit result width.
+  const smt_termt expected = smt_bit_vector_theoryt::add(
+    smt_bit_vector_theoryt::add(
+      smt_bit_vector_constant_termt{0, 8},
+      smt_bit_vector_theoryt::zero_extend(7)(
+        smt_bit_vector_theoryt::extract(0, 0)(foo))),
+    smt_bit_vector_theoryt::zero_extend(7)(
+      smt_bit_vector_theoryt::extract(1, 1)(foo)));
+  CHECK(test.convert(popcount) == expected);
+}
+
+TEST_CASE(
+  "count_leading_zeros_exprt to SMT conversion",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{2}};
+  const count_leading_zeros_exprt clz{
+    symbol_exprt{"foo", unsignedbv_typet{2}}, false, unsignedbv_typet{8}};
+  const auto one_bit = smt_bit_vector_constant_termt{1, 1};
+  // Most-significant-bit check is outermost: result 0 if bit 1 set, else 1 if
+  // bit 0 set, else 2 (the operand width).
+  const smt_termt expected = smt_core_theoryt::if_then_else(
+    smt_core_theoryt::equal(
+      smt_bit_vector_theoryt::extract(1, 1)(foo), one_bit),
+    smt_bit_vector_constant_termt{0, 8},
+    smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(
+        smt_bit_vector_theoryt::extract(0, 0)(foo), one_bit),
+      smt_bit_vector_constant_termt{1, 8},
+      smt_bit_vector_constant_termt{2, 8}));
+  CHECK(test.convert(clz) == expected);
+}
+
+TEST_CASE(
+  "count_trailing_zeros_exprt to SMT conversion",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{2}};
+  const count_trailing_zeros_exprt ctz{
+    symbol_exprt{"foo", unsignedbv_typet{2}}, false, unsignedbv_typet{8}};
+  const auto one_bit = smt_bit_vector_constant_termt{1, 1};
+  // Least-significant-bit check is outermost: result 0 if bit 0 set, else 1 if
+  // bit 1 set, else 2 (the operand width).
+  const smt_termt expected = smt_core_theoryt::if_then_else(
+    smt_core_theoryt::equal(
+      smt_bit_vector_theoryt::extract(0, 0)(foo), one_bit),
+    smt_bit_vector_constant_termt{0, 8},
+    smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(
+        smt_bit_vector_theoryt::extract(1, 1)(foo), one_bit),
+      smt_bit_vector_constant_termt{1, 8},
+      smt_bit_vector_constant_termt{2, 8}));
+  CHECK(test.convert(ctz) == expected);
+}
+
+TEST_CASE("find_first_set_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{2}};
+  const find_first_set_exprt ffs{
+    symbol_exprt{"foo", unsignedbv_typet{2}}, unsignedbv_typet{8}};
+  const auto one_bit = smt_bit_vector_constant_termt{1, 1};
+  // 1-based index of the least-significant set bit, outermost first: 1 if bit 0
+  // set, else 2 if bit 1 set, else 0.
+  const smt_termt expected = smt_core_theoryt::if_then_else(
+    smt_core_theoryt::equal(
+      smt_bit_vector_theoryt::extract(0, 0)(foo), one_bit),
+    smt_bit_vector_constant_termt{1, 8},
+    smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(
+        smt_bit_vector_theoryt::extract(1, 1)(foo), one_bit),
+      smt_bit_vector_constant_termt{2, 8},
+      smt_bit_vector_constant_termt{0, 8}));
+  CHECK(test.convert(ffs) == expected);
+}
+
+TEST_CASE("bitreverse_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  SECTION("Multi-bit")
+  {
+    const bitreverse_exprt bitrev{symbol_exprt{"foo", unsignedbv_typet{8}}};
+    const auto result = test.convert(bitrev);
+    CHECK(result.get_sort() == smt_bit_vector_sortt{8});
+  }
+  SECTION("Single-bit identity")
+  {
+    const bitreverse_exprt bitrev1{symbol_exprt{"x", unsignedbv_typet{1}}};
+    const smt_termt x = smt_identifier_termt{"x", smt_bit_vector_sortt{1}};
+    CHECK(test.convert(bitrev1) == x);
+  }
+}
+
+TEST_CASE("bswap_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const bswap_exprt bswap{symbol_exprt{"foo", unsignedbv_typet{32}}, 8};
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{32}};
+  // bswap32 reverses 4 bytes: extract and concat in reverse
+  const smt_termt expected = smt_bit_vector_theoryt::concat(
+    smt_bit_vector_theoryt::concat(
+      smt_bit_vector_theoryt::concat(
+        smt_bit_vector_theoryt::extract(7, 0)(foo),
+        smt_bit_vector_theoryt::extract(15, 8)(foo)),
+      smt_bit_vector_theoryt::extract(23, 16)(foo)),
+    smt_bit_vector_theoryt::extract(31, 24)(foo));
+  CHECK(test.convert(bswap) == expected);
+}
+
+TEST_CASE("rotate expressions to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const typet u8 = unsignedbv_typet{8};
+  const smt_termt foo = smt_identifier_termt{"foo", smt_bit_vector_sortt{8}};
+
+  SECTION("Constant rotate left")
+  {
+    const shift_exprt rol{symbol_exprt{"foo", u8}, ID_rol, from_integer(3, u8)};
+    const auto result = test.convert(rol);
+    CHECK(result == smt_bit_vector_theoryt::rotate_left(3)(foo));
+  }
+  SECTION("Constant rotate right")
+  {
+    const shift_exprt ror{symbol_exprt{"foo", u8}, ID_ror, from_integer(2, u8)};
+    const auto result = test.convert(ror);
+    CHECK(result == smt_bit_vector_theoryt::rotate_right(2)(foo));
+  }
+  SECTION("Dynamic rotate left")
+  {
+    const shift_exprt rol{
+      symbol_exprt{"foo", u8}, ID_rol, symbol_exprt{"bar", u8}};
+    const smt_termt bar = smt_identifier_termt{"bar", smt_bit_vector_sortt{8}};
+    // rotate_left(foo, bar) = (foo << (bar % 8)) | (foo >> (8 - (bar % 8)))
+    const auto width = smt_bit_vector_constant_termt{8, 8};
+    const auto normalized =
+      smt_bit_vector_theoryt::unsigned_remainder(bar, width);
+    const auto complementary =
+      smt_bit_vector_theoryt::subtract(width, normalized);
+    const smt_termt expected = smt_bit_vector_theoryt::make_or(
+      smt_bit_vector_theoryt::shift_left(foo, normalized),
+      smt_bit_vector_theoryt::logical_shift_right(foo, complementary));
+    CHECK(test.convert(rol) == expected);
+  }
+  SECTION("Dynamic rotate left with narrower distance")
+  {
+    const typet u4 = unsignedbv_typet{4};
+    const shift_exprt rol{
+      symbol_exprt{"foo", u8}, ID_rol, symbol_exprt{"bar", u4}};
+    const auto result = test.convert(rol);
+    CHECK(result.get_sort() == smt_bit_vector_sortt{8});
+  }
+  SECTION("Dynamic rotate right with wider distance")
+  {
+    const typet u16 = unsignedbv_typet{16};
+    const shift_exprt ror{
+      symbol_exprt{"foo", u8}, ID_ror, symbol_exprt{"bar", u16}};
+    const auto result = test.convert(ror);
+    CHECK(result.get_sort() == smt_bit_vector_sortt{8});
+  }
+}
+
+TEST_CASE("bitnand_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  const typet u8 = unsignedbv_typet{8};
+  const smt_termt a = smt_identifier_termt{"a", smt_bit_vector_sortt{8}};
+  const smt_termt b = smt_identifier_termt{"b", smt_bit_vector_sortt{8}};
+  const smt_termt c = smt_identifier_termt{"c", smt_bit_vector_sortt{8}};
+  SECTION("Unary is bit-wise not")
+  {
+    const bitnand_exprt nand{exprt::operandst{symbol_exprt{"a", u8}}, u8};
+    CHECK(test.convert(nand) == smt_bit_vector_theoryt::make_not(a));
+  }
+  SECTION("Binary uses the bvnand factory")
+  {
+    const bitnand_exprt nand{symbol_exprt{"a", u8}, symbol_exprt{"b", u8}};
+    CHECK(test.convert(nand) == smt_bit_vector_theoryt::nand(a, b));
+  }
+  SECTION("Three or more operands is not(and(...))")
+  {
+    const bitnand_exprt nand{
+      exprt::operandst{
+        symbol_exprt{"a", u8}, symbol_exprt{"b", u8}, symbol_exprt{"c", u8}},
+      u8};
+    CHECK(
+      test.convert(nand) ==
+      smt_bit_vector_theoryt::make_not(smt_bit_vector_theoryt::make_and(
+        smt_bit_vector_theoryt::make_and(a, b), c)));
+  }
+}


### PR DESCRIPTION
- Add support for __builtin_clzl (count leading zeros)
- Add support for __builtin_ctz (count trailing zeros)
- Add support for __builtin_ffs (find first set)
- Add support for __builtin_popcount (population count)
- Add support for __builtin_rotateleft* and rotate right (ID_rol, ID_ror)
- Add support for bitreverse_exprt (bit reverse)
- Add support for ID_bitnand (bitwise nand)

Implements conversion to SMT terms for each intrinsic with proper bit-vector operations.

Fixes: #8055

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
