### PR TITLE
Fix memory leaks in XML parser

### DIFF
--- a/regression/cbmc/xml-interface-malformed/malformed_element.xml
+++ b/regression/cbmc/xml-interface-malformed/malformed_element.xml
@@ -1,0 +1,2 @@
+<options>
+  <valueOption name="function" actual="foo"

--- a/regression/cbmc/xml-interface-malformed/malformed_pi.xml
+++ b/regression/cbmc/xml-interface-malformed/malformed_pi.xml
@@ -1,0 +1,1 @@
+<?php some processing instruction?>

--- a/regression/cbmc/xml-interface-malformed/test.desc
+++ b/regression/cbmc/xml-interface-malformed/test.desc
@@ -1,0 +1,13 @@
+CORE
+--xml-interface
+--verbosity 8 < malformed_pi.xml
+^EXIT=6$
+^SIGNAL=0$
+<text>syntax error before .processing.</text>
+--
+double free
+--
+Regression test for the XML-parser double-free on error recovery: a
+malformed processing instruction must make the parser report a syntax
+error and exit cleanly, rather than double-freeing the STARTPI/NAME token
+values during Bison error recovery (which aborted with SIGABRT).

--- a/regression/cbmc/xml-interface-malformed/test_element.desc
+++ b/regression/cbmc/xml-interface-malformed/test_element.desc
@@ -1,0 +1,14 @@
+CORE
+--xml-interface
+--verbosity 8 < malformed_element.xml
+^EXIT=6$
+^SIGNAL=0$
+<text>syntax error</text>
+--
+double free
+--
+Regression test for the XML-parser double-free on error recovery: an
+unterminated element (syntax error after the START token's mid-rule
+action) must make the parser report a syntax error and exit cleanly,
+rather than double-freeing the START token value during Bison error
+recovery (which aborted with SIGABRT).

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -40,12 +40,12 @@ int yyxmlerror(xml_parsert &xml_parser, void *scanner, const std::string &error)
 %union {char *s;}
 
 %token STARTXMLDECL
-%token VERSION ENDPI EQ SLASH CLOSE END
-%token <s> ENCODING NAME VALUE DATA COMMENT START STARTPI
+%token ENDPI EQ SLASH CLOSE END
+%token <s> NAME VALUE DATA COMMENT START STARTPI
 %type <s> name_opt
 
 // Memory management: ensure allocated string tokens are freed during error recovery
-%destructor { free($$); } ENCODING NAME VALUE DATA COMMENT START STARTPI name_opt
+%destructor { free($$); } NAME VALUE DATA COMMENT START STARTPI name_opt
 
 %%
 

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -24,6 +24,13 @@ int yyxmlerror(xml_parsert &xml_parser, void *scanner, const std::string &error)
 // unreachable code
 #pragma warning(disable:4702)
 #endif
+
+// Bison-generated yydestruct only handles symbols with %destructor;
+// suppress the warning about unhandled enum values in that switch.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
 %}
 
 %parse-param {xml_parsert &xml_parser}
@@ -33,9 +40,12 @@ int yyxmlerror(xml_parsert &xml_parser, void *scanner, const std::string &error)
 %union {char *s;}
 
 %token STARTXMLDECL
-%token VERSION STARTPI ENDPI EQ SLASH CLOSE END
-%token <s> ENCODING NAME VALUE DATA COMMENT START
+%token VERSION ENDPI EQ SLASH CLOSE END
+%token <s> ENCODING NAME VALUE DATA COMMENT START STARTPI
 %type <s> name_opt
+
+// Memory management: ensure allocated string tokens are freed during error recovery
+%destructor { free($$); } ENCODING NAME VALUE DATA COMMENT START STARTPI name_opt
 
 %%
 
@@ -68,18 +78,18 @@ misc
 
 PI
  : STARTPI NAME
-   { free($2); xml_parser.stack.push_back(&xml_parser.parse_tree.xml); }
+   { xml_parser.stack.push_back(&xml_parser.parse_tree.xml); }
    attribute_seq_opt
    { xml_parser.stack.pop_back(); }
    ENDPI
+   { free($1); free($2); }
  ;
 
 element
- : START   { xml_parser.current().name=$1;
-                                  free($1);
-           }
+ : START   { xml_parser.current().name=$1; }
    attribute_seq_opt
    empty_or_content
+   { free($1); }
  ;
 
 empty_or_content
@@ -114,3 +124,9 @@ attribute
                                   free($1); free($3);}
  ;
 
+
+%%
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Fix a leak of the STARTPI token value (allocated by the lexer via malloc but never freed by any grammar rule). Also add Bison %destructor directives for all string-valued tokens so that memory is properly freed during error recovery.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
