### PR TITLE
Fix name mangler to preserve definition when mangled name already exists

### DIFF
--- a/regression/goto-cc-file-local/multi-file-compile-together/a.c
+++ b/regression/goto-cc-file-local/multi-file-compile-together/a.c
@@ -1,0 +1,4 @@
+static void foo(int x)
+{
+  __CPROVER_assert(0, "reachable");
+}

--- a/regression/goto-cc-file-local/multi-file-compile-together/main.c
+++ b/regression/goto-cc-file-local/multi-file-compile-together/main.c
@@ -1,0 +1,6 @@
+void __CPROVER_file_local_a_c_foo(int);
+int main()
+{
+  __CPROVER_file_local_a_c_foo(0);
+  return 0;
+}

--- a/regression/goto-cc-file-local/multi-file-compile-together/test.desc
+++ b/regression/goto-cc-file-local/multi-file-compile-together/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+assertion-check compile-and-link
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.assertion.1\] .* reachable: FAILURE$
+--
+^warning: ignoring
+^\*\*\*\* WARNING: no body for function
+--
+Check that when files are compiled together with --export-file-local-symbols
+the local_bitvector_analysis does not crash with an invariant violation

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -51,7 +51,7 @@ public:
     rename_symbolt rename;
     std::map<irep_idt, irep_idt> renamed_funs;
     std::vector<symbolt> new_syms;
-    std::vector<symbol_tablet::symbolst::const_iterator> old_syms;
+    std::vector<irep_idt> old_syms;
 
     for(auto sym_it = model.symbol_table.symbols.begin();
         sym_it != model.symbol_table.symbols.end();
@@ -75,7 +75,7 @@ public:
       new_sym.is_file_local = false;
 
       new_syms.push_back(new_sym);
-      old_syms.push_back(sym_it);
+      old_syms.push_back(sym.name);
 
       rename.insert(sym.symbol_expr(), new_sym.symbol_expr());
       renamed_funs.insert(std::make_pair(sym.name, mangled));
@@ -84,9 +84,38 @@ public:
     }
 
     for(const auto &sym : new_syms)
-      model.symbol_table.insert(sym);
-    for(const auto &sym : old_syms)
-      model.symbol_table.erase(sym);
+    {
+      auto result = model.symbol_table.insert(sym);
+      if(!result.second)
+      {
+        symbolt &existing = result.first;
+        if(existing.value.is_nil() && existing.type.id() == ID_code)
+        {
+          // The existing symbol is a function declaration (no body). This
+          // happens when user code forward-declares the mangled name. Replace
+          // it with the definition so that parameter identifiers and the full
+          // type are preserved. Do NOT touch existing.module or
+          // existing.base_name: both participate in symbol_tablet's indices
+          // (symbol_module_map / symbol_base_map) and must not change after a
+          // symbol has been inserted (see symbol_tablet::validate()).
+          existing.type = sym.type;
+          existing.value = sym.value;
+          existing.is_file_local = sym.is_file_local;
+          existing.mode = sym.mode;
+          existing.location = sym.location;
+          if(!sym.pretty_name.empty())
+            existing.pretty_name = sym.pretty_name;
+        }
+        else
+        {
+          log.warning() << "Mangled name '" << sym.name
+                        << "' already exists with a definition"
+                        << messaget::eom;
+        }
+      }
+    }
+    for(const auto &name : old_syms)
+      model.symbol_table.remove(name);
 
     for(auto it = model.symbol_table.begin(); it != model.symbol_table.end();
         ++it)
@@ -107,6 +136,12 @@ public:
     {
       if(!fun.second.body_available())
         continue;
+      for(auto &identifier : fun.second.parameter_identifiers)
+      {
+        auto entry = rename.expr_map.find(identifier);
+        if(entry != rename.expr_map.end())
+          identifier = entry->second;
+      }
       for(auto &ins : fun.second.body.instructions)
       {
         rename(ins.code_nonconst());
@@ -125,11 +160,26 @@ public:
         "of the function that we renamed '" +
           std::string(pair.first.c_str()) + "'");
 
-      auto inserted = model.goto_functions.function_map.emplace(
-        pair.second, std::move(found->second));
-      if(!inserted.second)
+      auto existing = model.goto_functions.function_map.find(pair.second);
+      if(existing == model.goto_functions.function_map.end())
+      {
+        model.goto_functions.function_map.emplace(
+          pair.second, std::move(found->second));
+      }
+      else if(existing->second.body.instructions.empty())
+      {
+        // The mangled name already has a function map entry (from a forward
+        // declaration) with an empty body. Swap in the definition's body and
+        // parameter identifiers (goto_functiont::swap() also carries over
+        // function_is_hidden). We look the entry up rather than relying on a
+        // failed emplace, as the latter would leave found->second moved-from.
+        existing->second.swap(found->second);
+      }
+      else
+      {
         log.debug() << "Found a mangled name that already exists: "
-                    << std::string(pair.second.c_str()) << log.eom;
+                    << pair.second << messaget::eom;
+      }
 
       model.goto_functions.function_map.erase(found);
     }

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -53,11 +53,29 @@ public:
     std::vector<symbolt> new_syms;
     std::vector<irep_idt> old_syms;
 
-    for(auto sym_it = model.symbol_table.symbols.begin();
-        sym_it != model.symbol_table.symbols.end();
-        ++sym_it)
+    collect_file_local_functions(rename, renamed_funs, new_syms, old_syms);
+    merge_into_symbol_table(new_syms, old_syms);
+    apply_rename_to_symbols(rename);
+    apply_rename_to_functions(rename);
+    merge_into_function_map(renamed_funs);
+  }
+
+private:
+  /// \brief Find all file-local functions and compute their mangled names
+  ///
+  /// Populates \p new_syms with the mangled symbols to be inserted, \p old_syms
+  /// with the names of the original symbols to be removed, \p rename with the
+  /// old-to-new symbol mapping, and \p renamed_funs with the old-to-new
+  /// function-map name mapping.
+  void collect_file_local_functions(
+    rename_symbolt &rename,
+    std::map<irep_idt, irep_idt> &renamed_funs,
+    std::vector<symbolt> &new_syms,
+    std::vector<irep_idt> &old_syms)
+  {
+    for(const auto &named_symbol : model.symbol_table.symbols)
     {
-      const symbolt &sym = sym_it->second;
+      const symbolt &sym = named_symbol.second;
 
       if(sym.type.id() != ID_code) // is not a function
         continue;
@@ -82,7 +100,19 @@ public:
 
       log.debug() << "Mangling: " << sym.name << " -> " << mangled << log.eom;
     }
+  }
 
+  /// \brief Insert the mangled symbols and remove the original ones
+  ///
+  /// If the mangled name already denotes a function declaration (no body), the
+  /// declaration is updated in place with the definition. Its module and
+  /// base_name are deliberately left untouched: both participate in
+  /// symbol_tablet's indices and must not change after insertion (see
+  /// symbol_tablet::validate()). Any other collision is reported as a warning.
+  void merge_into_symbol_table(
+    const std::vector<symbolt> &new_syms,
+    const std::vector<irep_idt> &old_syms)
+  {
     for(const auto &sym : new_syms)
     {
       auto result = model.symbol_table.insert(sym);
@@ -91,13 +121,6 @@ public:
         symbolt &existing = result.first;
         if(existing.value.is_nil() && existing.type.id() == ID_code)
         {
-          // The existing symbol is a function declaration (no body). This
-          // happens when user code forward-declares the mangled name. Replace
-          // it with the definition so that parameter identifiers and the full
-          // type are preserved. Do NOT touch existing.module or
-          // existing.base_name: both participate in symbol_tablet's indices
-          // (symbol_module_map / symbol_base_map) and must not change after a
-          // symbol has been inserted (see symbol_tablet::validate()).
           existing.type = sym.type;
           existing.value = sym.value;
           existing.is_file_local = sym.is_file_local;
@@ -116,7 +139,11 @@ public:
     }
     for(const auto &name : old_syms)
       model.symbol_table.remove(name);
+  }
 
+  /// \brief Apply the renaming to the value and type of every symbol
+  void apply_rename_to_symbols(const rename_symbolt &rename)
+  {
     for(auto it = model.symbol_table.begin(); it != model.symbol_table.end();
         ++it)
     {
@@ -131,7 +158,12 @@ public:
       new_sym.value = e;
       new_sym.type = t;
     }
+  }
 
+  /// \brief Apply the renaming to the bodies and parameter identifiers of all
+  ///   functions
+  void apply_rename_to_functions(const rename_symbolt &rename)
+  {
     for(auto &fun : model.goto_functions.function_map)
     {
       if(!fun.second.body_available())
@@ -149,8 +181,19 @@ public:
           rename(ins.condition_nonconst());
       }
     }
+  }
 
-    // Add goto-programs with new function names
+  /// \brief Move each renamed function's body to its mangled name in the
+  ///   function map
+  ///
+  /// If the mangled name already has an empty function-map entry (from a
+  /// forward declaration), the definition's body is swapped in via
+  /// goto_functiont::swap() (which also carries over function_is_hidden). The
+  /// entry is looked up before the emplace so that the definition is not left
+  /// moved-from on a colliding emplace; a pre-existing non-empty entry is
+  /// reported at debug verbosity.
+  void merge_into_function_map(const std::map<irep_idt, irep_idt> &renamed_funs)
+  {
     for(const auto &pair : renamed_funs)
     {
       auto found = model.goto_functions.function_map.find(pair.first);
@@ -168,11 +211,6 @@ public:
       }
       else if(existing->second.body.instructions.empty())
       {
-        // The mangled name already has a function map entry (from a forward
-        // declaration) with an empty body. Swap in the definition's body and
-        // parameter identifiers (goto_functiont::swap() also carries over
-        // function_is_hidden). We look the entry up rather than relying on a
-        // failed emplace, as the latter would leave found->second moved-from.
         existing->second.swap(found->second);
       }
       else

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -74,6 +74,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_trace_output.cpp \
        goto-programs/is_goto_binary.cpp \
        goto-programs/label_function_pointer_call_sites.cpp \
+       goto-programs/name_mangler.cpp \
        goto-programs/osx_fat_reader.cpp \
        goto-programs/restrict_function_pointers.cpp \
        goto-programs/structured_trace_util.cpp \

--- a/unit/goto-programs/name_mangler.cpp
+++ b/unit/goto-programs/name_mangler.cpp
@@ -1,0 +1,257 @@
+/*******************************************************************\
+
+Module: Unit tests for function_name_manglert
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for function_name_manglert::mangle(), in particular the handling
+/// of a mangled name that already exists in the symbol table / function map
+/// (regression for #8254).
+
+#include <util/c_types.h>
+#include <util/cmdline.h>
+#include <util/config.h>
+#include <util/std_code.h>
+#include <util/std_types.h>
+#include <util/validation_mode.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/name_mangler.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <string>
+#include <vector>
+
+/// The mangled name that the test mangler below always produces.
+#define TEST_MANGLED CPROVER_PREFIX "file_local_test_foo"
+
+namespace
+{
+/// A mangler that ignores its arguments and always returns the same name, so
+/// that the test can deterministically create a collision with a pre-existing
+/// symbol of that name.
+class test_manglert
+{
+public:
+  test_manglert() = default;
+  irep_idt operator()(const symbolt &, const std::string &) const
+  {
+    return TEST_MANGLED;
+  }
+};
+
+/// A message handler that records all printed messages so the test can assert
+/// whether a particular warning was (or was not) emitted.
+class recording_message_handlert : public message_handlert
+{
+public:
+  std::vector<std::string> messages;
+
+  void print(unsigned level, const std::string &message) override
+  {
+    message_handlert::print(level, message);
+    messages.push_back(message);
+  }
+
+  void print(unsigned, const xmlt &) override
+  {
+  }
+
+  void print(unsigned, const jsont &) override
+  {
+  }
+
+  void flush(unsigned) override
+  {
+  }
+
+  bool contains(const std::string &needle) const
+  {
+    for(const auto &m : messages)
+    {
+      if(m.find(needle) != std::string::npos)
+        return true;
+    }
+    return false;
+  }
+};
+
+/// The type shared by the file-local definition and the forward declaration:
+/// `void foo(int)`.
+static code_typet make_code_type()
+{
+  code_typet::parametert param{signed_int_type()};
+  param.set_identifier("foo::x");
+  return code_typet{{param}, empty_typet{}};
+}
+
+/// Add the file-local definition `foo` (symbol with a body) plus its
+/// function-map entry (with a body, parameters and function_is_hidden set).
+static void add_file_local_definition(goto_modelt &model)
+{
+  const code_typet code_type = make_code_type();
+
+  symbolt foo_def{"foo", code_type, ID_C};
+  foo_def.base_name = "foo";
+  foo_def.pretty_name = "foo";
+  foo_def.module = "a";
+  foo_def.is_file_local = true;
+  foo_def.value = code_blockt{}; // non-nil: this is a definition
+  model.symbol_table.add(foo_def);
+
+  symbolt param_sym{"foo::x", signed_int_type(), ID_C};
+  param_sym.base_name = "x";
+  param_sym.module = "a";
+  param_sym.is_parameter = true;
+  model.symbol_table.add(param_sym);
+
+  goto_functiont foo_fun;
+  foo_fun.parameter_identifiers.push_back("foo::x");
+  foo_fun.make_hidden();
+  foo_fun.body.instructions.emplace_back(
+    goto_program_instruction_typet::END_FUNCTION);
+  model.goto_functions.function_map.emplace("foo", std::move(foo_fun));
+}
+} // namespace
+
+SCENARIO(
+  "function_name_manglert handles a pre-existing mangled name",
+  "[core][goto-programs][name_mangler]")
+{
+  // A proper architecture is needed so that C types are configured.
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  recording_message_handlert message_handler;
+  const code_typet code_type = make_code_type();
+  const std::string extra_info; // outlives the mangler (it stores a reference)
+
+  GIVEN("a file-local definition whose mangled name is forward-declared")
+  {
+    goto_modelt model;
+    add_file_local_definition(model);
+
+    // Forward declaration of the mangled name: a function symbol with no body
+    // and an empty function-map entry, as produced when files are compiled
+    // together with --export-file-local-symbols.
+    symbolt fwd{TEST_MANGLED, code_type, ID_C};
+    fwd.base_name = TEST_MANGLED;
+    fwd.module = "main";
+    fwd.is_file_local = false; // value stays nil: this is a declaration
+    model.symbol_table.add(fwd);
+    model.goto_functions.function_map.emplace(TEST_MANGLED, goto_functiont{});
+
+    WHEN("the names are mangled")
+    {
+      function_name_manglert<test_manglert> mangler{
+        message_handler, model, extra_info};
+      mangler.mangle();
+
+      THEN("the symbol table stays consistent")
+      {
+        REQUIRE_NOTHROW(
+          model.symbol_table.validate(validation_modet::EXCEPTION));
+      }
+
+      THEN("the definition replaces the declaration")
+      {
+        const symbolt *mangled = model.symbol_table.lookup(TEST_MANGLED);
+        REQUIRE(mangled != nullptr);
+        REQUIRE_FALSE(mangled->value.is_nil());
+        REQUIRE(mangled->type == code_type);
+        REQUIRE_FALSE(mangled->is_file_local);
+        REQUIRE(model.symbol_table.lookup("foo") == nullptr);
+      }
+
+      THEN("the function-map entry carries body, parameters and hidden flag")
+      {
+        auto entry = model.goto_functions.function_map.find(TEST_MANGLED);
+        REQUIRE(entry != model.goto_functions.function_map.end());
+        REQUIRE_FALSE(entry->second.body.instructions.empty());
+        REQUIRE(
+          entry->second.parameter_identifiers ==
+          std::vector<irep_idt>{"foo::x"});
+        REQUIRE(entry->second.is_hidden());
+        REQUIRE(
+          model.goto_functions.function_map.find("foo") ==
+          model.goto_functions.function_map.end());
+      }
+
+      THEN("no 'already exists with a definition' warning is emitted")
+      {
+        REQUIRE_FALSE(
+          message_handler.contains("already exists with a definition"));
+      }
+    }
+  }
+
+  GIVEN("a file-local definition whose mangled name already has a definition")
+  {
+    goto_modelt model;
+    add_file_local_definition(model);
+
+    // The mangled name already denotes a full definition (non-nil value).
+    symbolt existing{TEST_MANGLED, code_type, ID_C};
+    existing.base_name = TEST_MANGLED;
+    existing.module = "main";
+    existing.is_file_local = false;
+    existing.value = code_skipt{}; // distinguishable, non-nil definition
+    model.symbol_table.add(existing);
+    goto_functiont existing_fun;
+    existing_fun.body.instructions.emplace_back(
+      goto_program_instruction_typet::END_FUNCTION);
+    model.goto_functions.function_map.emplace(
+      TEST_MANGLED, std::move(existing_fun));
+
+    WHEN("the names are mangled")
+    {
+      function_name_manglert<test_manglert> mangler{
+        message_handler, model, extra_info};
+      mangler.mangle();
+
+      THEN("a warning is emitted and the existing definition is preserved")
+      {
+        REQUIRE(message_handler.contains("already exists with a definition"));
+        const symbolt *mangled = model.symbol_table.lookup(TEST_MANGLED);
+        REQUIRE(mangled != nullptr);
+        REQUIRE(mangled->value == code_skipt{});
+        REQUIRE_NOTHROW(
+          model.symbol_table.validate(validation_modet::EXCEPTION));
+      }
+    }
+  }
+
+  GIVEN("a file-local definition whose mangled name is a non-function symbol")
+  {
+    goto_modelt model;
+    add_file_local_definition(model);
+
+    // A non-function symbol happens to share the mangled name. It must not be
+    // overwritten just because its value is nil.
+    symbolt var{TEST_MANGLED, signed_int_type(), ID_C};
+    var.base_name = TEST_MANGLED;
+    var.module = "main";
+    model.symbol_table.add(var);
+
+    WHEN("the names are mangled")
+    {
+      function_name_manglert<test_manglert> mangler{
+        message_handler, model, extra_info};
+      mangler.mangle();
+
+      THEN("the non-function symbol is left untouched and a warning is emitted")
+      {
+        REQUIRE(message_handler.contains("already exists with a definition"));
+        const symbolt *mangled = model.symbol_table.lookup(TEST_MANGLED);
+        REQUIRE(mangled != nullptr);
+        REQUIRE(mangled->type == signed_int_type());
+        REQUIRE_NOTHROW(
+          model.symbol_table.validate(validation_modet::EXCEPTION));
+      }
+    }
+  }
+}


### PR DESCRIPTION
When --export-file-local-symbols is used and files are compiled together, a forward declaration using the mangled name (e.g., __CPROVER_file_local_a_c_foo) may already exist in the symbol table and function map before the mangler runs. The mangler's symbol_table.insert() silently failed in this case, leaving the declaration's type (with empty parameter identifiers) in place instead of the definition's type. This caused an invariant violation in goto_symext::locality() when it tried to look up the empty parameter identifier.

Fix the mangler to:
1. When insert fails and the existing symbol is a declaration (no body), update it with the definition's type/value. Log a warning when the existing symbol already has a definition.
2. When the mangled name already has an empty function map entry, swap in the definition's body and parameter_identifiers.
3. Rename parameter_identifiers when renaming functions (matching what link_goto_model already does).

Fixes: #8254

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
