### PR TITLE
Add summary paragraphs to older CHANGELOG entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@ multi-dimensional arrays (via #8705).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.8.0...cbmc-6.9.0
 
 # CBMC 6.8.0
+
 This release extends the JSON interface to reading full GOTO functions (and not
 just symbol tables) (via #8713). Also included are various usability
 improvements around contracts instrumentation (see #8697, #8694).
@@ -123,6 +124,7 @@ improvements around contracts instrumentation (see #8697, #8694).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.7.1...cbmc-6.8.0
 
 # CBMC 6.7.1
+
 This release addresses bugs in our handling of array-update ("with") expressions
 (via #8674) and gaps in our C17/C23 support (via #8673).
 
@@ -136,6 +138,7 @@ This release addresses bugs in our handling of array-update ("with") expressions
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.7.0...cbmc-6.7.1
 
 # CBMC 6.7.0
+
 This release adds aarch64 va_list support (via #8572), which makes all tests
 pass on aarch64 Linux. We reworked expression simplification during symbolic
 execution (via #8642, #8647, #8627) to produce smaller and quicker-to-solve
@@ -166,6 +169,7 @@ formulae for scenarios seen by our users.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.6.0...cbmc-6.7.0
 
 # CBMC 6.6.0
+
 This release adds C17 and C23 support to our C front-end (via #8620, #8623). We
 have no longer provide Ubuntu 20.04 pre-built binaries as security support for
 that distribution has ended.
@@ -196,6 +200,7 @@ that distribution has ended.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.5.0...cbmc-6.6.0
 
 # CBMC 6.5.0
+
 This release addresses both soundness (via #8562) and performance issues
 (via #8574, #8576) in our code contracts instrumentation, and includes a
 collection of bit-operator cleanup (such as #8524, #8531) and floating-point
@@ -257,6 +262,7 @@ via #8538) that aid EBMC/HW-CBMC.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.4.1...cbmc-6.5.0
 
 # CBMC 6.4.1
+
 This patch release addresses a hard-coding of C semantics in the back-end for
 pointer subtraction (via #8497).
 
@@ -277,6 +283,7 @@ pointer subtraction (via #8497).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.4.0...cbmc-6.4.1
 
 # CBMC 6.4.0
+
 This release improves upon automated assigns-clause inference for loop
 invariants, which should make manually adding assigns clauses to loops less
 frequent.
@@ -302,6 +309,7 @@ frequent.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.3.1...cbmc-6.4.0
 
 # CBMC 6.3.1
+
 This patch release addresses build failures on Apple Silicon (via PR #8461).
 
 ## Bug Fixes
@@ -310,6 +318,7 @@ This patch release addresses build failures on Apple Silicon (via PR #8461).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.3.0...cbmc-6.3.1
 
 # CBMC 6.3.0
+
 This release addresses build failures on aarch64 (64-bit ARM) platforms (via
 PR #8366) and for some CMake configurations (via PR #8435). Users of loop
 invariants with dynamic frames have two changes to their user experience:
@@ -343,6 +352,7 @@ invariants with dynamic frames have two changes to their user experience:
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.2.0...cbmc-6.3.0
 
 # CBMC 6.2.0
+
 This release reduces noise from dynamic-frames contract checking by suppressing
 trivial properties (via #8413) and fixes several contract-related issues
 including do-while loop handling (via #8420) and skipped-loop write sets
@@ -373,6 +383,7 @@ including do-while loop handling (via #8420) and skipped-loop write sets
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.1.1...cbmc-6.2.0
 
 # CBMC 6.1.1
+
 This patch release compiles CaDiCaL with -DNDEBUG for improved solver
 performance (via #8397) and adds flattening support for addition and subtraction
 on the range type (via #8396).
@@ -388,6 +399,7 @@ on the range type (via #8396).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.1.0...cbmc-6.1.1
 
 # CBMC 6.1.0
+
 This release adds support for building with GCC 14 (via #8368), adds
 documentation for loop contracts and __CPROVER_loop_entry (via #8377), and
 improves loop contracts instrumentation including side-effect checking
@@ -420,6 +432,7 @@ improves loop contracts instrumentation including side-effect checking
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.0.1...cbmc-6.1.0
 
 # CBMC 6.0.1
+
 This patch release fixes a GOTO conversion bug where declaration hops could
 invalidate incomplete gotos (via #8349) and a union member handling issue
 (via #8347). It also reduces default verbosity of the cprover binary and runtime
@@ -440,6 +453,7 @@ messages (via #8352, #8354).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.0.0...cbmc-6.0.1
 
 # CBMC 6.0.0
+
 This major release requires C++17 to build (via #7989) and changes several
 defaults: malloc may now fail by default (via #8101), unwinding assertions are
 enabled by default (via #8274, #8273), pointer dereference, array bounds, and
@@ -678,6 +692,7 @@ additions (snprintf, dprintf, asprintf, and more).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.95.1...cbmc-6.0.0
 
 # CBMC 5.95.1
+
 This patch release improves multiplication encoding using the Dadda tree
 algorithm (via #7984) and fixes extraneous parameters in C library exp/logl
 models (via #7985).
@@ -691,6 +706,7 @@ models (via #7985).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.95.0...cbmc-5.95.1
 
 # CBMC 5.95.0
+
 This release adds C front-end support for vector expressions as compile-time
 constants (via #7947) and C library models for exp, log, and pow (via #7906).
 
@@ -708,6 +724,7 @@ constants (via #7947) and C library models for exp, log, and pow (via #7906).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.94.0...cbmc-5.95.0
 
 # CBMC 5.94.0
+
 This release adds documentation for CBMC Shadow Memory intrinsics (via #7913),
 models for C library functions getpwnam, getpwuid, and getopt
 (via #7919, #7916), and pointer-check support for shadow memory addresses

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,7 +82,6 @@ multi-dimensional arrays (via #8705).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.8.0...cbmc-6.9.0
 
 # CBMC 6.8.0
-
 This release extends the JSON interface to reading full GOTO functions (and not
 just symbol tables) (via #8713). Also included are various usability
 improvements around contracts instrumentation (see #8697, #8694).
@@ -124,9 +123,8 @@ improvements around contracts instrumentation (see #8697, #8694).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.7.1...cbmc-6.8.0
 
 # CBMC 6.7.1
-
-This release addresses bugs in our handling of array-update ("with")
-expressions (via #8674) and gaps in our C17/C23 support (via #8673).
+This release addresses bugs in our handling of array-update ("with") expressions
+(via #8674) and gaps in our C17/C23 support (via #8673).
 
 ## Bug Fixes
 * Remove deprecated make_with_expr by @tautschnig in https://github.com/diffblue/cbmc/pull/8666
@@ -138,7 +136,6 @@ expressions (via #8674) and gaps in our C17/C23 support (via #8673).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.7.0...cbmc-6.7.1
 
 # CBMC 6.7.0
-
 This release adds aarch64 va_list support (via #8572), which makes all tests
 pass on aarch64 Linux. We reworked expression simplification during symbolic
 execution (via #8642, #8647, #8627) to produce smaller and quicker-to-solve
@@ -169,7 +166,6 @@ formulae for scenarios seen by our users.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.6.0...cbmc-6.7.0
 
 # CBMC 6.6.0
-
 This release adds C17 and C23 support to our C front-end (via #8620, #8623). We
 have no longer provide Ubuntu 20.04 pre-built binaries as security support for
 that distribution has ended.
@@ -200,12 +196,11 @@ that distribution has ended.
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.5.0...cbmc-6.6.0
 
 # CBMC 6.5.0
-
-This release addresses both soundness (via #8562) and performance issues (via
-#8574, #8576) in our code contracts instrumentation, and includes a collection
-of bit-operator cleanup (such as #8524, #8531) and floating-point support
-improvements (TiesToAway rounding via #8515, native rounding to integer via
-#8538) that aid EBMC/HW-CBMC.
+This release addresses both soundness (via #8562) and performance issues
+(via #8574, #8576) in our code contracts instrumentation, and includes a
+collection of bit-operator cleanup (such as #8524, #8531) and floating-point
+support improvements (TiesToAway rounding via #8515, native rounding to integer
+via #8538) that aid EBMC/HW-CBMC.
 
 ## What's Changed
 * CONTRACTS: allow pointer predicates to fail in `assume` contexts by @remi-delmas-3000 in https://github.com/diffblue/cbmc/pull/8562
@@ -262,8 +257,8 @@ improvements (TiesToAway rounding via #8515, native rounding to integer via
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.4.1...cbmc-6.5.0
 
 # CBMC 6.4.1
-
-This patch release addresses a hard-coding of C semantics in the back-end for pointer subtraction (via #8497).
+This patch release addresses a hard-coding of C semantics in the back-end for
+pointer subtraction (via #8497).
 
 ## Bug Fixes
 * fix `update_bit` lowering by @kroening in https://github.com/diffblue/cbmc/pull/8496
@@ -282,8 +277,9 @@ This patch release addresses a hard-coding of C semantics in the back-end for po
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.4.0...cbmc-6.4.1
 
 # CBMC 6.4.0
-
-This release improves upon automated assigns-clause inference for loop invariants, which should make manually adding assigns clauses to loops less frequent.
+This release improves upon automated assigns-clause inference for loop
+invariants, which should make manually adding assigns clauses to loops less
+frequent.
 
 ## What's Changed
 * [CONTRACTS] Support alias of member pointers in loop assigns inference by @qinheping in https://github.com/diffblue/cbmc/pull/8486
@@ -306,7 +302,6 @@ This release improves upon automated assigns-clause inference for loop invariant
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.3.1...cbmc-6.4.0
 
 # CBMC 6.3.1
-
 This patch release addresses build failures on Apple Silicon (via PR #8461).
 
 ## Bug Fixes
@@ -315,10 +310,15 @@ This patch release addresses build failures on Apple Silicon (via PR #8461).
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.3.0...cbmc-6.3.1
 
 # CBMC 6.3.0
+This release addresses build failures on aarch64 (64-bit ARM) platforms (via
+PR #8366) and for some CMake configurations (via PR #8435). Users of loop
+invariants with dynamic frames have two changes to their user experience:
 
-This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR #8366) and for some CMake configurations (via PR #8435). Users of loop invariants with dynamic frames have two changes to their user experience:
-1) Users will no longer need to give unwinding specifications for `do { ... } while(0)` loops.
-2) Loop invariants that are conjunctions will be turned into more fine-grained properties to ease debugging of loop invariants when they aren't successfully proved.
+1. Users will no longer need to give unwinding specifications for `do { ... }
+   while(0)` loops.
+2. Loop invariants that are conjunctions will be turned into more fine-grained
+   properties to ease debugging of loop invariants when they aren't
+   successfully proved.
 
 ## What's Changed
 * Contracts: always remove spurious do {... } while(0) loops by @tautschnig in https://github.com/diffblue/cbmc/pull/8459
@@ -343,6 +343,11 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.2.0...cbmc-6.3.0
 
 # CBMC 6.2.0
+This release reduces noise from dynamic-frames contract checking by suppressing
+trivial properties (via #8413) and fixes several contract-related issues
+including do-while loop handling (via #8420) and skipped-loop write sets
+(via #8416). It also fixes inconsistent array flattening in the SMT2 back-end
+(via #8400).
 
 ## What's Changed
 * Dynamic frames: do not add trivial properties by @tautschnig in https://github.com/diffblue/cbmc/pull/8413
@@ -368,6 +373,9 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.1.1...cbmc-6.2.0
 
 # CBMC 6.1.1
+This patch release compiles CaDiCaL with -DNDEBUG for improved solver
+performance (via #8397) and adds flattening support for addition and subtraction
+on the range type (via #8396).
 
 ## What's Changed
 * Compile CaDiCaL with -DNDEBUG by @tautschnig in https://github.com/diffblue/cbmc/pull/8397
@@ -380,6 +388,11 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.1.0...cbmc-6.1.1
 
 # CBMC 6.1.0
+This release adds support for building with GCC 14 (via #8368), adds
+documentation for loop contracts and __CPROVER_loop_entry (via #8377), and
+improves loop contracts instrumentation including side-effect checking
+(via #8360). It also fixes complex-number multiplication and division
+(via #8376) and several SMT2 back-end issues (via #8379, #8387).
 
 ## What's Changed
 * Add support for building with GCC 14 by @tautschnig in https://github.com/diffblue/cbmc/pull/8368
@@ -407,6 +420,10 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.0.1...cbmc-6.1.0
 
 # CBMC 6.0.1
+This patch release fixes a GOTO conversion bug where declaration hops could
+invalidate incomplete gotos (via #8349) and a union member handling issue
+(via #8347). It also reduces default verbosity of the cprover binary and runtime
+messages (via #8352, #8354).
 
 ## Bug Fixes
 * Fix Python syntax error by @tautschnig in https://github.com/diffblue/cbmc/pull/8344
@@ -423,6 +440,15 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.0.0...cbmc-6.0.1
 
 # CBMC 6.0.0
+This major release requires C++17 to build (via #7989) and changes several
+defaults: malloc may now fail by default (via #8101), unwinding assertions are
+enabled by default (via #8274, #8273), pointer dereference, array bounds, and
+modulo-by-zero checks are now fatal assertions (via #8316, #8314, #8315), and
+the default verbosity level has been lowered (via #8331). The release also adds
+support for the --no-unwinding-assertions flag (via #8109), permits re-setting
+--object-bits (via #7858), adds support for loongarch64 (via #8266), GNU Hurd
+(via #8211), and emscripten (via #8334), and includes many C library model
+additions (snprintf, dprintf, asprintf, and more).
 
 ## Major Changes
 * Change C++ version to C++17 by @esteffin in https://github.com/diffblue/cbmc/pull/7989
@@ -632,7 +658,7 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 * Undefined shifts are now fatal by @kroening in https://github.com/diffblue/cbmc/pull/8304
 * array-bounds checks are now fatal by @kroening in https://github.com/diffblue/cbmc/pull/8314
 * Simplifier: c_bool (and others) are also bitvector types by @tautschnig in https://github.com/diffblue/cbmc/pull/8247
-* Delete `string_constantt::get_value` and  `string_constantt::set_value` functions by @NlightNFotis in https://github.com/diffblue/cbmc/pull/8003
+* Delete `string_constantt::get_value` and `string_constantt::set_value` functions by @NlightNFotis in https://github.com/diffblue/cbmc/pull/8003
 * Remove deprecated messaget() constructor by @tautschnig in https://github.com/diffblue/cbmc/pull/8143
 * Move GCC-13 CI job to Ubuntu 24.04 by @tautschnig in https://github.com/diffblue/cbmc/pull/8320
 * Make DFCC is_dead_object_update less restrictive by @tautschnig in https://github.com/diffblue/cbmc/pull/8261
@@ -652,26 +678,27 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.95.1...cbmc-6.0.0
 
 # CBMC 5.95.1
+This patch release improves multiplication encoding using the Dadda tree
+algorithm (via #7984) and fixes extraneous parameters in C library exp/logl
+models (via #7985).
 
 ## What's Changed
-
 * Multiplication encoding: cleanup, Dadda, data by @tautschnig in https://github.com/diffblue/cbmc/pull/7984
 
 ## Bug Fixes
-
 * Remove extraneous y parameter from calls to exp and logl by @NlightNFotis in https://github.com/diffblue/cbmc/pull/7985
 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.95.0...cbmc-5.95.1
 
-## CBMC 5.95.0
+# CBMC 5.95.0
+This release adds C front-end support for vector expressions as compile-time
+constants (via #7947) and C library models for exp, log, and pow (via #7906).
 
-### What's Changed
-
+## What's Changed
 * Add C front-end support for vector expressions as compile-time constants by @tautschnig in https://github.com/diffblue/cbmc/pull/7947
 * C library: add exp, log, pow models by @tautschnig in https://github.com/diffblue/cbmc/pull/7906
 
-### Bug Fixes
-
+## Bug Fixes
 * Fix bug with std::sort requires strict weak ordering by @tautschnig in https://github.com/diffblue/cbmc/pull/7956
 * SYNTHESIZER: Use only symbols from the original goto as terminals by @qinheping in https://github.com/diffblue/cbmc/pull/7970
 * Add missing lowering of symbol values in new SMT backend by @thomasspriggs in https://github.com/diffblue/cbmc/pull/7952
@@ -680,15 +707,19 @@ This release addresses build failures on aarch64 (64-bit ARM) platforms (via PR 
 
 **Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.94.0...cbmc-5.95.0
 
-## CBMC 5.94.0
+# CBMC 5.94.0
+This release adds documentation for CBMC Shadow Memory intrinsics (via #7913),
+models for C library functions getpwnam, getpwuid, and getopt
+(via #7919, #7916), and pointer-check support for shadow memory addresses
+(via #7936). The goto-synthesizer now accepts all CBMC options (via #7900).
 
-### What's Changed
+## What's Changed
 * Add models for C library: getpwnam, getpwuid, and getopt by @tautschnig in https://github.com/diffblue/cbmc/pull/7919 and https://github.com/diffblue/cbmc/pull/7916
 * Shadow memory addresses now also support --pointer-check argument by @esteffin in https://github.com/diffblue/cbmc/pull/7936
 * [DOCS] Add documentation on CBMC Shadow Memory intrinsics and shadow memory functions (via doxygen) by @NlightNFotis in https://github.com/diffblue/cbmc/pull/7913 and https://github.com/diffblue/cbmc/pull/7930
 * [SYNTHESIZER] goto-synthesizer now accepts all CBMC options by @qinheping in https://github.com/diffblue/cbmc/pull/7900
 
-### Bug Fixes
+## Bug Fixes
 * Fix problem on array size L2 renaming by @esteffin in https://github.com/diffblue/cbmc/pull/7877
 * Fix shadow memory missing aggregation on non-compound bitvector types by @esteffin in https://github.com/diffblue/cbmc/pull/7935
 * Fix SMT encoding of structs which contain a single struct field by @thomasspriggs in https://github.com/diffblue/cbmc/pull/7951

--- a/doc/ADR/release_process.md
+++ b/doc/ADR/release_process.md
@@ -1,7 +1,7 @@
 \page release-process Release Process
 
 **Date**: 2020-10-08
-**Updated**: 2023-03-29
+**Updated**: 2026-06-10
 **Author**: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 **Domain**: Release & Packaging
 
@@ -56,6 +56,28 @@ anything more, but the process is described below for reference:
    It also makes a PR to the homebrew repository that updates the version
    of CBMC in homebrew. That's then approved and merged by the maintainers
    of homebrew.
+
+## CHANGELOG structure
+
+The top-level [`CHANGELOG`](../../CHANGELOG) file records one entry per release,
+newest first. To keep the file consistent and readable, each release entry
+follows the same structure:
+
+1. A single-`#` release heading of the form `# CBMC X.Y.Z`. All releases use the
+   same heading level; using a deeper level (e.g. `##`) nests the release under
+   the preceding one when the file is rendered as Markdown.
+2. A blank line, followed by a short summary paragraph that highlights the most
+   user-visible changes of the release, referencing the relevant pull requests
+   (e.g. `via #1234`).
+3. The change listings, each introduced by a `##` subheading: `## What's
+   Changed`, optionally `## Major Changes`, and `## Bug Fixes`, enumerating the
+   merged pull requests.
+4. A closing `**Full Changelog**:` link comparing the previous tag to this one.
+
+When cutting a release, the summary paragraph (item 2) is written by hand; the
+remaining sections are produced by GitHub's release-notes generation. Keeping
+the heading levels uniform and the blank line after each release heading in
+place avoids structural drift between entries.
 
 ## Versioning
 


### PR DESCRIPTION
Add curated summary paragraphs to all CHANGELOG entries from 5.94.0 through 6.2.0 that were previously missing them. The summaries highlight the most user-visible changes in each release.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
