### PR TITLE
Add support for GCC nested functions in C front-end

### DIFF
--- a/regression/ansi-c/gcc_nested_functions1/main.c
+++ b/regression/ansi-c/gcc_nested_functions1/main.c
@@ -1,0 +1,17 @@
+// Test basic nested function definition
+int main()
+{
+  int outer_var = 10;
+
+  // Nested function definition
+  int nested_func(int x)
+  {
+    return x + outer_var;
+  }
+
+  int result = nested_func(5);
+  __CPROVER_assert(
+    result == 15, "nested function should access outer variable");
+
+  return 0;
+}

--- a/regression/ansi-c/gcc_nested_functions1/test.desc
+++ b/regression/ansi-c/gcc_nested_functions1/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/ansi-c/gcc_nested_functions2/main.c
+++ b/regression/ansi-c/gcc_nested_functions2/main.c
@@ -1,0 +1,20 @@
+// Test nested function with auto keyword and forward declaration
+int main()
+{
+  int outer_var = 20;
+
+  // Forward declaration with auto keyword
+  auto int nested_func(int x);
+
+  // Nested function definition
+  int nested_func(int x)
+  {
+    return x * outer_var;
+  }
+
+  int result = nested_func(3);
+  __CPROVER_assert(
+    result == 60, "nested function should access outer variable");
+
+  return 0;
+}

--- a/regression/ansi-c/gcc_nested_functions2/test.desc
+++ b/regression/ansi-c/gcc_nested_functions2/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/ansi-c/gcc_nested_functions3/main.c
+++ b/regression/ansi-c/gcc_nested_functions3/main.c
@@ -1,0 +1,23 @@
+// Test multiple nested function calls and interactions
+int main()
+{
+  int base = 5;
+
+  int add(int x)
+  {
+    return x + base;
+  }
+
+  int multiply(int x)
+  {
+    return x * base;
+  }
+
+  int result1 = add(10);
+  int result2 = multiply(4);
+
+  __CPROVER_assert(result1 == 15, "add should work");
+  __CPROVER_assert(result2 == 20, "multiply should work");
+
+  return 0;
+}

--- a/regression/ansi-c/gcc_nested_functions3/test.desc
+++ b/regression/ansi-c/gcc_nested_functions3/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/ansi-c/gcc_nested_functions4/main.c
+++ b/regression/ansi-c/gcc_nested_functions4/main.c
@@ -1,0 +1,18 @@
+// Test taking address of nested function (if supported)
+int main()
+{
+  int multiplier = 3;
+
+  int multiply_by(int x)
+  {
+    return x * multiplier;
+  }
+
+  // Taking address of nested function
+  int (*func_ptr)(int) = multiply_by;
+
+  int result = func_ptr(7);
+  __CPROVER_assert(result == 21, "function pointer should work");
+
+  return 0;
+}

--- a/regression/ansi-c/gcc_nested_functions4/test.desc
+++ b/regression/ansi-c/gcc_nested_functions4/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/cbmc/gcc_nested_functions/main.c
+++ b/regression/cbmc/gcc_nested_functions/main.c
@@ -1,0 +1,35 @@
+// GCC nested functions: verification of variable capture and calls
+int main()
+{
+  int outer = 10;
+
+  int add(int x)
+  {
+    return x + outer;
+  }
+
+  int multiply(int x)
+  {
+    return x * outer;
+  }
+
+  // basic call and variable capture
+  __CPROVER_assert(add(5) == 15, "add(5) == 15");
+  __CPROVER_assert(multiply(3) == 30, "multiply(3) == 30");
+
+  // mutation of captured variable is visible
+  outer = 20;
+  __CPROVER_assert(add(5) == 25, "add(5) == 25 after mutation");
+
+  // nested function used via function pointer
+  int (*fp)(int) = &add;
+  __CPROVER_assert(fp(1) == 21, "fp(1) == 21");
+
+  // nondet argument
+  int n;
+  __CPROVER_assume(n >= 0 && n <= 100);
+  int r = add(n);
+  __CPROVER_assert(r >= 20 && r <= 120, "add(n) in range");
+
+  return 0;
+}

--- a/regression/cbmc/gcc_nested_functions/test.desc
+++ b/regression/cbmc/gcc_nested_functions/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/gcc_nested_functions_const/main.c
+++ b/regression/cbmc/gcc_nested_functions_const/main.c
@@ -1,0 +1,15 @@
+// Exercises the `type_qualifier_list identifier_declarator` alternative of
+// gcc_nested_function_definition: a qualifier-only nested function head such
+// as `const add1(int x) { ... }` (return type defaults to a const-qualified
+// int). GCC accepts this with -Wimplicit-int.
+int main(void)
+{
+  const add1(int x)
+  {
+    return x + 1;
+  }
+
+  __CPROVER_assert(add1(4) == 5, "const-qualified nested function");
+
+  return 0;
+}

--- a/regression/cbmc/gcc_nested_functions_const/test.desc
+++ b/regression/cbmc/gcc_nested_functions_const/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$
+--
+Exercises the qualifier-only (type_qualifier_list) nested function head, e.g.
+`const add1(int x) { ... }`, which was previously untested.

--- a/regression/cbmc/gcc_nested_functions_func/main.c
+++ b/regression/cbmc/gcc_nested_functions_func/main.c
@@ -1,0 +1,43 @@
+// __func__ in the enclosing function should still resolve to the
+// enclosing function's name AFTER a nested function definition has
+// been parsed: the parser must restore the outer function's
+// source_location.function rather than clearing it.
+//
+// Also exercises that a global symbol with the same base name as the
+// nested function survives in parser-side lookups for code following
+// main(): caller() still calls the global helper, not the nested one.
+#include <string.h>
+
+int helper(int x)
+{
+  return x * 100;
+}
+
+int main()
+{
+  int outer = 10;
+
+  // Nested function with the same base name as the global `helper`.
+  int helper(int x)
+  {
+    return x + outer;
+  }
+
+  // Inside main, `helper` resolves to the nested one.
+  __CPROVER_assert(helper(5) == 15, "nested helper from main");
+
+  // After parsing the nested function body, parsing continues inside
+  // main(). The parser-wide source_location.function should still be
+  // "main" so __func__ expands to "main".
+  __CPROVER_assert(strcmp(__func__, "main") == 0, "outer __func__ is main");
+
+  return 0;
+}
+
+// caller is parsed after main has finished. The global `helper` must
+// still be resolvable: the nested-function machinery must not have
+// erased the parser's root-scope mapping for the global symbol.
+int caller(void)
+{
+  return helper(5);
+}

--- a/regression/cbmc/gcc_nested_functions_func/test.desc
+++ b/regression/cbmc/gcc_nested_functions_func/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Verifies that __func__ in the enclosing function still resolves to
+the enclosing function's name after a GCC nested function has been
+parsed (i.e. the parser restores the outer function context rather
+than clearing it), and that a pre-existing global symbol with the
+same base name as the nested function survives parser-side lookups
+for code following the enclosing function.

--- a/regression/cbmc/gcc_nested_functions_implicit_int/main.c
+++ b/regression/cbmc/gcc_nested_functions_implicit_int/main.c
@@ -1,0 +1,14 @@
+// Negative test documenting a deliberate boundary: GCC does not permit
+// implicit-int nested functions, so a bare `identifier_declarator` head
+// (no type specifier, e.g. `add1(int x) { ... }`) is rejected. The
+// gcc_nested_function_definition grammar deliberately does not mirror this
+// `function_head` alternative.
+int main(void)
+{
+  add1(int x)
+  {
+    return x + 1;
+  }
+
+  return add1(4) == 5 ? 0 : 1;
+}

--- a/regression/cbmc/gcc_nested_functions_implicit_int/test.desc
+++ b/regression/cbmc/gcc_nested_functions_implicit_int/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+syntax error
+^PARSING ERROR$
+--
+^VERIFICATION
+--
+GCC rejects implicit-int nested functions, so a bare identifier_declarator
+head is deliberately not accepted (see gcc_nested_function_definition).

--- a/regression/cbmc/gcc_nested_functions_label/main.c
+++ b/regression/cbmc/gcc_nested_functions_label/main.c
@@ -1,0 +1,23 @@
+// Regression test: a label defined before a nested function definition must
+// stay visible to a goto that appears after the nested function. Previously
+// the nested function's type-checking cleared the enclosing function's label
+// bookkeeping, so this was rejected with "branching label 'start' is not
+// defined in function".
+int main(void)
+{
+  int x = 0;
+
+  int inc(int y)
+  {
+    return y + 1;
+  }
+
+start:
+  x = inc(x);
+  if(x < 5)
+    goto start;
+
+  __CPROVER_assert(x == 5, "goto loop straddling a nested function reaches 5");
+
+  return 0;
+}

--- a/regression/cbmc/gcc_nested_functions_label/test.desc
+++ b/regression/cbmc/gcc_nested_functions_label/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--unwind 6 --no-unwinding-assertions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+A label defined before a nested function definition must remain visible to a
+goto after it (see c_typecheck_baset::typecheck_function_body). Without the
+save/restore of labels_used/labels_defined this was rejected as an undefined
+branching label.

--- a/regression/cbmc/gcc_nested_functions_nested_and_recursive/main.c
+++ b/regression/cbmc/gcc_nested_functions_nested_and_recursive/main.c
@@ -1,0 +1,30 @@
+// Pins two currently-working but previously-untested shapes:
+//  * a nested function defined inside another nested function (exercising the
+//    LIFO nested_function_context_stack), and
+//  * a recursive nested function.
+int main(void)
+{
+  // nested-in-nested
+  int outer(int a)
+  {
+    int inner(int b)
+    {
+      return b * 2;
+    }
+
+    return inner(a) + 1;
+  }
+
+  // recursive nested function
+  int fact(int n)
+  {
+    if(n <= 1)
+      return 1;
+    return n * fact(n - 1);
+  }
+
+  __CPROVER_assert(outer(3) == 7, "nested-in-nested result");
+  __CPROVER_assert(fact(4) == 24, "recursive nested function result");
+
+  return 0;
+}

--- a/regression/cbmc/gcc_nested_functions_nested_and_recursive/test.desc
+++ b/regression/cbmc/gcc_nested_functions_nested_and_recursive/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--unwind 6 --no-unwinding-assertions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^PARSING ERROR$
+--
+Pins nested-in-nested (LIFO nested_function_context_stack) and recursive
+nested functions, both currently working but previously untested.

--- a/regression/cbmc/gcc_nested_functions_storage_class/main.c
+++ b/regression/cbmc/gcc_nested_functions_storage_class/main.c
@@ -1,0 +1,14 @@
+// Negative test documenting a deliberate boundary: a storage-class qualifier
+// with implicit int (a `declaration_qualifier_list identifier_declarator`
+// head, e.g. `static g(void) { ... }`) is rejected for nested functions, as
+// GCC does not permit implicit int there. This `function_head` alternative is
+// deliberately not mirrored in gcc_nested_function_definition.
+int main(void)
+{
+  static g(void)
+  {
+    return 7;
+  }
+
+  return g() == 7 ? 0 : 1;
+}

--- a/regression/cbmc/gcc_nested_functions_storage_class/test.desc
+++ b/regression/cbmc/gcc_nested_functions_storage_class/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+syntax error
+^PARSING ERROR$
+--
+^VERIFICATION
+--
+GCC rejects implicit-int nested functions, so a storage-class-with-implicit-int
+head (declaration_qualifier_list identifier_declarator) is deliberately not
+accepted (see gcc_nested_function_definition).

--- a/regression/cbmc/gcc_nested_functions_void_return/main.c
+++ b/regression/cbmc/gcc_nested_functions_void_return/main.c
@@ -1,0 +1,20 @@
+// Regression test: a nested function whose return type (here void) differs
+// from the enclosing function's return type (here int) must not clobber the
+// enclosing function's return type. Previously this crashed goto conversion
+// with "function has return void but a return statement returning signed int"
+// followed by an invariant violation in convert_return.
+int main(void)
+{
+  int x = 0;
+
+  void set_x(void)
+  {
+    x = 1;
+  }
+
+  set_x();
+
+  __CPROVER_assert(x == 1, "nested void function updated captured variable");
+
+  return 0;
+}

--- a/regression/cbmc/gcc_nested_functions_void_return/test.desc
+++ b/regression/cbmc/gcc_nested_functions_void_return/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+A nested function with a void return type inside an int-returning function
+must not clobber the enclosing function's return type (see
+c_typecheck_baset::typecheck_function_body). Without the save/restore this
+aborted in goto conversion.

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -106,6 +106,25 @@ public:
   // convert a declarator and then add it to existing an declaration
   void add_declarator(exprt &declaration, irept &declarator);
 
+  /// \brief Bookkeeping needed to undo the parser-side effects of
+  ///   `add_declarator` (which forces a function into the root scope)
+  ///   for a single GCC nested function definition. Populated by
+  ///   `nested_function_setup` in `parser_static.inc` and consumed by
+  ///   `nested_function_teardown`.
+  struct nested_function_contextt
+  {
+    irep_idt base_name;
+    irep_idt outer_function_name;
+    bool had_prior_root_entry = false;
+    ansi_c_identifiert prior_root_entry;
+  };
+
+  /// LIFO stack of in-flight nested-function bookkeeping records,
+  /// one per active `gcc_nested_function_definition` rule on the
+  /// parsing stack. A stack rather than a single field is needed
+  /// because GCC permits nested functions inside nested functions.
+  std::vector<nested_function_contextt> nested_function_context_stack;
+
   // adds a tag to the current scope
   void add_tag_with_body(irept &tag);
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -619,6 +619,23 @@ void c_typecheck_baset::typecheck_function_body(symbolt &symbol)
 
   code_typet &code_type = to_code_type(symbol.type);
 
+  // A function body may contain nested function definitions (a GCC extension).
+  // Each such nested function is type-checked by a recursive call to this
+  // method while we are part-way through the enclosing function's body. That
+  // recursion would otherwise clobber the enclosing function's per-function
+  // state, so we save it here and restore it once the (possibly nested)
+  // function body has been checked. In particular:
+  //  * return_type, so that a `return` in the enclosing body after a nested
+  //    function with a different return type is checked against the enclosing
+  //    function's type (the C++ front-end does the same, see
+  //    cpp_typecheckt::typecheck_function_body); and
+  //  * labels_used/labels_defined, so that a label defined before a nested
+  //    function definition is still visible to a `goto` after it.
+  const typet old_return_type = return_type;
+  const std::map<irep_idt, source_locationt> old_labels_used = labels_used;
+  const std::map<irep_idt, source_locationt> old_labels_defined =
+    labels_defined;
+
   // reset labels
   labels_used.clear();
   labels_defined.clear();
@@ -652,6 +669,12 @@ void c_typecheck_baset::typecheck_function_body(symbolt &symbol)
       throw 0;
     }
   }
+
+  // restore the enclosing function's state (see above); this is only relevant
+  // when this body was a nested function definition, but is harmless otherwise
+  return_type = old_return_type;
+  labels_used = old_labels_used;
+  labels_defined = old_labels_defined;
 }
 
 void c_typecheck_baset::apply_asm_label(

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2360,6 +2360,7 @@ statement:
           declaration_statement
         | statement_attribute
         | stmt_not_decl_or_attr
+        | gcc_nested_function_definition
         ;
 
 stmt_not_decl_or_attr:
@@ -2382,6 +2383,50 @@ declaration_statement:
           init($$);
           statement($$, ID_decl);
           mto($$, $1);
+        }
+        ;
+
+gcc_nested_function_definition:
+          declaration_specifier declarator
+          post_declarator_attributes_opt
+          {
+            // GCC nested function definition. Parse the head like a
+            // top-level function_head, then hand off to the shared helper
+            // which relocates the symbol from the root scope into the
+            // enclosing local scope and remembers the outer function
+            // context.
+            nested_function_definition_head($$, $1, merge($3, $2));
+          }
+          function_body
+        {
+          nested_function_definition_body($$, $4, $5);
+        }
+        | type_specifier declarator
+          post_declarator_attributes_opt
+          {
+            nested_function_definition_head($$, $1, merge($3, $2));
+          }
+          function_body
+        {
+          nested_function_definition_body($$, $4, $5);
+        }
+        | type_qualifier_list identifier_declarator
+          {
+            // GCC accepts a qualifier-only head like
+            //   const foo(int x) { ... }
+            // for a nested function (the return type defaults to
+            // `int` with the given qualifiers; -Wimplicit-int will
+            // warn, but the function is parsed). The other implicit-
+            // int forms (a bare `identifier_declarator`, or a
+            // `declaration_qualifier_list identifier_declarator`
+            // with a storage-class keyword) are rejected by GCC in
+            // nested context, so they are deliberately not mirrored
+            // here.
+            nested_function_definition_head($$, $1, $2);
+          }
+          function_body
+        {
+          nested_function_definition_body($$, $3, $4);
         }
         ;
 

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -435,3 +435,190 @@ static void adjust_KnR_parameters(
     }
   }
 }
+
+/*******************************************************************\
+
+Function: nested_function_setup
+
+  Inputs: d - the YYSTYPE of a `declaration` node already initialised
+              with the merged type and declarator for a nested
+              function definition.
+
+ Outputs: A small POD aggregating the bookkeeping needed to undo the
+          parser-side effects of `add_declarator` for a nested
+          function. Pass it back to `nested_function_teardown` after
+          parsing the function body.
+
+ Purpose: Prepare the parser state for a GCC nested function
+          definition. `add_declarator` always treats functions as
+          living in the root scope: it sets the declarator's name to
+          the bare base name and writes an entry into
+          `root_scope().name_map[base]`. For a nested function we
+          want the symbol to live in the *enclosing* function's scope
+          instead, and we must not damage any pre-existing global
+          mapping for the same base name.
+
+          This helper rewrites the declarator's name to the
+          enclosing-scope-prefixed form, fixes up the current scope's
+          name_map entry to match, and restores any prior root-scope
+          entry (or removes the one freshly written by `add_declarator`
+          if there was no prior entry). It also records the parser's
+          current function name so that `nested_function_teardown`
+          can restore it after the nested body has been parsed,
+          rather than clearing it (which would lose the outer
+          function context for subsequent statements in the
+          enclosing body).
+
+\*******************************************************************/
+
+static ansi_c_parsert::nested_function_contextt
+nested_function_setup(const YYSTYPE d)
+{
+  ansi_c_declaratort &declarator =
+    to_ansi_c_declaration(parser_stack(d)).declarator();
+  const irep_idt base = declarator.get_base_name();
+
+  ansi_c_parsert::nested_function_contextt ctx;
+  ctx.base_name = base;
+  // Capture the outer function name *before* create_function_scope
+  // overwrites it with the nested function's name. We restore this in
+  // nested_function_teardown so that statements parsed after the
+  // nested function definition keep the outer function as their
+  // source_location.function (relevant for `__func__` and any other
+  // consumer of that field).
+  ctx.outer_function_name = PARSER.source_location().get_function();
+
+  // add_declarator forced this function into the root scope. Rewrite
+  // the declarator name to use the enclosing scope's prefix, and fix
+  // up the current scope's name_map entry to match.
+  const irep_idt local_name = PARSER.current_scope().prefix + id2string(base);
+  declarator.set_name(local_name);
+  PARSER.current_scope().name_map[base].prefixed_name = local_name;
+
+  // Snapshot any pre-existing root-scope entry for this base name
+  // before we drop the entry that add_declarator just installed.
+  // After the nested function has been parsed we restore the prior
+  // entry (if any), so a global symbol with the same base name keeps
+  // its parser-side mapping. If there was no prior entry, we just
+  // erase the freshly-written one.
+  auto root_it = PARSER.root_scope().name_map.find(base);
+  if(root_it != PARSER.root_scope().name_map.end())
+  {
+    ctx.had_prior_root_entry = true;
+    ctx.prior_root_entry = root_it->second;
+  }
+  else
+  {
+    ctx.had_prior_root_entry = false;
+  }
+
+  return ctx;
+}
+
+/*******************************************************************\
+
+Function: nested_function_teardown
+
+  Inputs: ctx - the bookkeeping returned by nested_function_setup.
+
+ Outputs:
+
+ Purpose: Undo the root-scope side effects of `add_declarator` for a
+          nested function and restore the enclosing function's
+          source-location context. Call after `pop_scope()` for the
+          nested function's body.
+
+\*******************************************************************/
+
+static void
+nested_function_teardown(const ansi_c_parsert::nested_function_contextt &ctx)
+{
+  // Restore (or erase) the root-scope name_map entry. We always
+  // overwrite, because add_declarator unconditionally wrote an entry
+  // for `base` into root_scope.
+  if(ctx.had_prior_root_entry)
+    PARSER.root_scope().name_map[ctx.base_name] = ctx.prior_root_entry;
+  else
+    PARSER.root_scope().name_map.erase(ctx.base_name);
+
+  // Restore the outer function context (the parser-wide source
+  // location's function field) rather than clearing it: parsing
+  // continues inside the enclosing function body, and code there
+  // should still be tagged with the enclosing function name.
+  if(ctx.outer_function_name.empty())
+    PARSER.clear_function();
+  else
+    PARSER.set_function(ctx.outer_function_name);
+}
+
+/*******************************************************************\
+
+Function: nested_function_definition_head
+
+  Inputs: result - YYSTYPE for the resulting declaration;
+          type - YYSTYPE holding the (return) type specifier;
+          declarator - YYSTYPE holding the function declarator (with any
+            post-declarator attributes already merged in).
+
+ Outputs:
+
+ Purpose: Shared mid-rule action for the alternatives of
+          gcc_nested_function_definition. Builds the ansi_c_declaration
+          for the nested function head, relocates it from the root scope
+          into the enclosing local scope (remembering the outer function
+          context via nested_function_setup), and opens the nested
+          function's scope. Mirrors function_head, plus the nested-scope
+          relocation.
+
+\*******************************************************************/
+
+static void nested_function_definition_head(
+  YYSTYPE &result,
+  YYSTYPE type,
+  YYSTYPE declarator)
+{
+  init(result, ID_declaration);
+  parser_stack(result).type().swap(parser_stack(type));
+  PARSER.add_declarator(parser_stack(result), parser_stack(declarator));
+  PARSER.nested_function_context_stack.push_back(nested_function_setup(result));
+  create_function_scope(result);
+}
+
+/*******************************************************************\
+
+Function: nested_function_definition_body
+
+  Inputs: result - YYSTYPE for the resulting declaration statement;
+          declaration - YYSTYPE holding the ansi_c_declaration produced
+            by nested_function_definition_head;
+          body - YYSTYPE holding the parsed function body.
+
+ Outputs:
+
+ Purpose: Shared post-body action for the alternatives of
+          gcc_nested_function_definition. Attaches the body as the
+          declaration's initialiser, closes the nested function's scope,
+          restores the enclosing function context, and wraps the result
+          as a declaration statement so it fits inside a block.
+
+\*******************************************************************/
+
+static void nested_function_definition_body(
+  YYSTYPE &result,
+  YYSTYPE declaration,
+  YYSTYPE body)
+{
+  ansi_c_declarationt &ansi_c_declaration =
+    to_ansi_c_declaration(parser_stack(declaration));
+  DATA_INVARIANT(
+    ansi_c_declaration.declarators().size() == 1, "exactly one declarator");
+  ansi_c_declaration.add_initializer(parser_stack(body));
+  PARSER.pop_scope();
+  nested_function_teardown(PARSER.nested_function_context_stack.back());
+  PARSER.nested_function_context_stack.pop_back();
+
+  // Wrap as a declaration statement so it fits in a block.
+  init(result);
+  statement(result, ID_decl);
+  mto(result, declaration);
+}


### PR DESCRIPTION
Add a gcc_nested_function_definition grammar rule to the C parser that allows function definitions inside compound statements, matching the GCC extension documented at
https://gcc.gnu.org/onlinedocs/gcc/Nested-Functions.html

The nested function is parsed as a local declaration with a function body. The parser places the function symbol in the enclosing scope (rather than forcing it to root scope as is done for top-level functions) so that parameter identifiers resolve correctly.

Variable capture from the enclosing scope works because CBMC's symbol resolution already looks up the scope chain.

Fixes: #84

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
