### PR TITLE
Fix incorrect interval equality in VSD analysis

### DIFF
--- a/regression/goto-analyzer/pointer-dereference-indeterminate-values/main.c
+++ b/regression/goto-analyzer/pointer-dereference-indeterminate-values/main.c
@@ -13,4 +13,10 @@ int main()
   int q = *p;
 
   assert(q == a);
+
+  // q is in [10, 15], so this assertion is provably false (FAILURE).  If a
+  // regression let the dereference of *p silently go to top, q would be
+  // unconstrained and this would become UNKNOWN instead, so the probe guards
+  // against losing the dereferenced value.
+  assert(q == 5);
 }

--- a/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-constants.desc
+++ b/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-constants.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers constants
-^\[main.assertion.1\] line 15 assertion q == a: SUCCESS
+^\[main.assertion.1\] line 15 assertion q == a: UNKNOWN
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-constants.desc
+++ b/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-constants.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers constants
 ^\[main.assertion.1\] line 15 assertion q == a: UNKNOWN
+^\[main.assertion.2\] line 21 assertion q == 5: FAILURE
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-value-sets.desc
+++ b/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-value-sets.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers value-set
 ^\[main.assertion.1\] line 15 assertion q == a: UNKNOWN
+^\[main.assertion.2\] line 21 assertion q == 5: FAILURE
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-value-sets.desc
+++ b/regression/goto-analyzer/pointer-dereference-indeterminate-values/test-intervals-value-sets.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers value-set
-^\[main.assertion.1\] line 15 assertion q == a: SUCCESS
+^\[main.assertion.1\] line 15 assertion q == a: UNKNOWN
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-write-through-indeterminate/main.c
+++ b/regression/goto-analyzer/pointer-write-through-indeterminate/main.c
@@ -14,4 +14,10 @@ int main()
   }
 
   assert(*p == b);
+
+  // *p is in [10, 15], so this assertion is provably false (FAILURE).  If a
+  // regression let the write-through of *p silently go to top, *p would be
+  // unconstrained and this would become UNKNOWN instead, so the probe guards
+  // against losing the written-through value.
+  assert(*p == 5);
 }

--- a/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-constants.desc
+++ b/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-constants.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers constants
-^\[main.assertion.1\] line 16 assertion \*p == b: SUCCESS
+^\[main.assertion.1\] line 16 assertion \*p == b: UNKNOWN
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-constants.desc
+++ b/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-constants.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers constants
 ^\[main.assertion.1\] line 16 assertion \*p == b: UNKNOWN
+^\[main.assertion.2\] line 22 assertion \*p == 5: FAILURE
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-value-sets.desc
+++ b/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-value-sets.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers value-set
-^\[main.assertion.1\] line 16 assertion \*p == b: SUCCESS
+^\[main.assertion.1\] line 16 assertion \*p == b: UNKNOWN
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-value-sets.desc
+++ b/regression/goto-analyzer/pointer-write-through-indeterminate/test-intervals-value-sets.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --verify --variable-sensitivity --vsd-values intervals --vsd-pointers value-set
 ^\[main.assertion.1\] line 16 assertion \*p == b: UNKNOWN
+^\[main.assertion.2\] line 22 assertion \*p == 5: FAILURE
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/variable-sensitivity-asserts-02/test-intervals.desc
+++ b/regression/goto-analyzer/variable-sensitivity-asserts-02/test-intervals.desc
@@ -3,12 +3,12 @@ main.c
 --variable-sensitivity --vsd-values intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] line 13 x == y: SUCCESS
-\[main.assertion.2\] line 14 y == x: SUCCESS
-\[main.assertion.3\] line 15 !\(x == y\): FAILURE
-\[main.assertion.4\] line 16 !\(y == x\): FAILURE
-\[main.assertion.5\] line 17 x != y: FAILURE
-\[main.assertion.6\] line 18 y != x: FAILURE
-\[main.assertion.7\] line 19 !\(x != y\): SUCCESS
-\[main.assertion.8\] line 20 !\(y != x\): SUCCESS
+\[main.assertion.1\] line 13 x == y: UNKNOWN
+\[main.assertion.2\] line 14 y == x: UNKNOWN
+\[main.assertion.3\] line 15 !\(x == y\): UNKNOWN
+\[main.assertion.4\] line 16 !\(y == x\): UNKNOWN
+\[main.assertion.5\] line 17 x != y: UNKNOWN
+\[main.assertion.6\] line 18 y != x: UNKNOWN
+\[main.assertion.7\] line 19 !\(x != y\): UNKNOWN
+\[main.assertion.8\] line 20 !\(y != x\): UNKNOWN
 --

--- a/src/util/interval.cpp
+++ b/src/util/interval.cpp
@@ -1792,7 +1792,7 @@ tvt constant_interval_exprt::not_equal(
   const constant_interval_exprt &a,
   const constant_interval_exprt &b)
 {
-  return a.equal(b);
+  return a.not_equal(b);
 }
 
 constant_interval_exprt

--- a/src/util/interval.cpp
+++ b/src/util/interval.cpp
@@ -435,11 +435,6 @@ tvt constant_interval_exprt::equal(const constant_interval_exprt &o) const
     return tvt(equal(get_lower(), o.get_lower()));
   }
 
-  if(equal(get_upper(), o.get_upper()) && equal(get_lower(), o.get_lower()))
-  {
-    return tvt(true);
-  }
-
   if(
     less_than(o).is_true() || greater_than(o).is_true() ||
     o.less_than(*this).is_true() || o.greater_than(*this).is_true())
@@ -447,7 +442,7 @@ tvt constant_interval_exprt::equal(const constant_interval_exprt &o) const
     return tvt(false);
   }
 
-  // Don't know.  Could have [3, 5] == [4] (not equal)
+  // Overlapping intervals: some values may be equal, some may not.
   return tvt::unknown();
 }
 
@@ -1522,18 +1517,34 @@ bool operator>=(
   return lhs.greater_than(rhs).is_true();
 }
 
+/// Structural equality of two interval objects: the bounds compare
+/// value-equal and the types match.  This is what tests express as
+/// `actual == expected`, and what `interval_abstract_valuet::internal_equality`
+/// uses to deduplicate stored intervals.  It is deliberately *not* the
+/// value-equality predicate returned by `equal()`: `equal()` answers "is
+/// every value of lhs equal to the corresponding value of rhs?", which
+/// becomes `unknown` whenever the two intervals overlap (including two
+/// identical, non-singleton intervals), so using `equal().is_true()` here
+/// would make `actual == expected` false for every non-singleton interval.
 bool operator==(
   const constant_interval_exprt &lhs,
   const constant_interval_exprt &rhs)
 {
-  return lhs.equal(rhs).is_true();
+  // Compare each bound for value-equality -- via the static
+  // equal(exprt, exprt) helper, not the recursive member equal() -- and
+  // require matching types.  Per-bound value-equality preserves the
+  // historic intent (e.g. `min_value_exprt` of an unsigned type is treated
+  // as equal to a zero constant) while remaining sound.
+  return lhs.type() == rhs.type() &&
+         constant_interval_exprt::equal(lhs.get_lower(), rhs.get_lower()) &&
+         constant_interval_exprt::equal(lhs.get_upper(), rhs.get_upper());
 }
 
 bool operator!=(
   const constant_interval_exprt &lhs,
   const constant_interval_exprt &rhs)
 {
-  return lhs.not_equal(rhs).is_true();
+  return !(lhs == rhs);
 }
 
 const constant_interval_exprt operator+(

--- a/unit/util/interval/comparisons.cpp
+++ b/unit/util/interval/comparisons.cpp
@@ -270,17 +270,33 @@ TEST_CASE("interval::equality", "[core][analyses][interval]")
 
     SECTION("Same interval")
     {
-      // TODO: wrongly concludes that these are equal
-      // ADA-537
-      // REQUIRE(two_to_four.equal(two_to_four).is_unknown());
-      // REQUIRE(two_to_four.not_equal(two_to_four).is_unknown());
+      REQUIRE(two_to_four.equal(two_to_four).is_unknown());
+      REQUIRE(two_to_four.not_equal(two_to_four).is_unknown());
     }
     SECTION("Overlapping intervals")
     {
-      // TODO: wrongly concludes that these are not equal
-      // ADA-537
-      // REQUIRE_FALSE(six_to_eight.equal(five_to_ten).is_unknown());
-      // REQUIRE_FALSE(six_to_eight.not_equal(five_to_ten).is_unknown());
+      // The intervals overlap but neither contains the other, so value
+      // equality is genuinely unknown.  (A more precise, relational domain
+      // might do better, but the interval domain cannot.)
+      REQUIRE(six_to_eight.equal(five_to_ten).is_unknown());
+      REQUIRE(six_to_eight.not_equal(five_to_ten).is_unknown());
+    }
+    SECTION("operator== / operator!= on non-singleton intervals")
+    {
+      constant_interval_exprt also_two_to_four(CEV(2), CEV(4));
+      constant_interval_exprt two_to_five(CEV(2), CEV(5));
+
+      // Same bounds compare structurally equal even though value-equality
+      // (equal()) is unknown.
+      REQUIRE(two_to_four == also_two_to_four);
+      REQUIRE_FALSE(two_to_four != also_two_to_four);
+      REQUIRE(two_to_four.equal(also_two_to_four).is_unknown());
+
+      // Different bounds are not structurally equal (operator==) even when
+      // the intervals overlap.
+      REQUIRE_FALSE(two_to_four == two_to_five);
+      REQUIRE(two_to_four != two_to_five);
+      REQUIRE(two_to_four.equal(two_to_five).is_unknown());
     }
     SECTION("Disjoint intervals")
     {


### PR DESCRIPTION
constant_interval_exprt::equal() incorrectly returned true when two intervals had the same bounds (e.g., [1,3] == [1,3]), even though the variables could hold different values within those ranges. This caused goto-analyzer with --vsd-values intervals to report x == y as always true when x and y merely had overlapping intervals.

Remove the incorrect early return for same-bounds intervals. Only single-value intervals (e.g., [3,3] == [3,3]) can be definitively equal. For multi-value intervals, the result is now correctly unknown.

Update the test-intervals.desc for variable-sensitivity-asserts-02 to match the corrected behavior (UNKNOWN instead of SUCCESS/FAILURE).

Fixes: #6323

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
