### PR TITLE
Document supported inline assembly instructions

### DIFF
--- a/doc/cprover-manual/index.md
+++ b/doc/cprover-manual/index.md
@@ -24,6 +24,7 @@
    * [Floating Point](modeling/floating-point/)
    * [Generating Environments](goto-harness/)
    * [Memory-mapped I/O](modeling/mmio/)
+   * [Inline Assembly](modeling/inline-asm/)
    * [Shadow Memory](modeling/shadow-memory/)
 
 8. Build Systems

--- a/doc/cprover-manual/modeling-inline-asm.md
+++ b/doc/cprover-manual/modeling-inline-asm.md
@@ -1,0 +1,79 @@
+[CPROVER Manual TOC](../../)
+
+## Modeling Inline Assembly
+
+CBMC supports GCC-style (`asm`/`__asm__`) and MSVC-style (`__asm {}`)
+inline assembly syntax. During verification, the `remove_asm` pass
+translates recognized instructions into equivalent goto-program
+operations.
+
+**If an inline-assembly statement contains any unrecognized instruction, the
+entire statement is replaced with `skip` — including any sibling instructions
+in the same statement that would otherwise be translated.** For example, an
+asm statement containing both an `mfence` and an `addl` loses *both*. This may
+lead to unsound results if the assembly has side effects that matter for the
+property being verified.
+
+### Supported Instructions
+
+#### x86
+
+| Instruction | Effect in CBMC |
+|---|---|
+| `mfence` | Full memory fence |
+| `lfence` | Full memory fence (currently modeled identically to `mfence`) |
+| `sfence` | Full memory fence (currently modeled identically to `mfence`) |
+| `fstcw` / `fnstcw` | Store FP control word (maps to `__CPROVER_rounding_mode`) |
+| `fldcw` | Load FP control word (maps to `__CPROVER_rounding_mode`) |
+| `lock` prefix | Only effective when followed by another recognized instruction (e.g. `lock; mfence`); the recognized instruction is wrapped in an atomic section with a full fence. The read-modify-write/exchange value itself is not modeled. |
+| `xchg` / `xchgl` | Not modeled: the inline-assembly statement is dropped (treated as unrecognized). |
+
+#### ARM
+
+| Instruction | Effect in CBMC |
+|---|---|
+| `dmb` | Data memory barrier (full fence) |
+| `dsb` | Data synchronization barrier (full fence) |
+| `isb` | Empty fence; no observable effect unless combined with a branch |
+
+#### Power
+
+| Instruction | Effect in CBMC |
+|---|---|
+| `sync` | Full memory barrier |
+| `lwsync` | Lightweight sync (all fences except write-after-read) |
+| `isync` | Empty fence; no observable effect unless combined with a branch |
+
+### Operand Handling
+
+For GCC extended assembly, CBMC parses the output (`=r`, `+r`) and input
+(`r`, `m`) operand lists, but in most cases the operand list does not
+influence the generated goto program. For recognized fence instructions (for
+example `mfence`, `lfence`, `sfence`, `dmb`, `dsb`, `sync`), the inline
+assembly is replaced by a fence and the C-level output operands are not
+written. For unrecognized instructions, the entire statement is replaced with
+`skip`; output operands are **not** assigned nondeterministic values. Output
+operands are only written when the modeled helper for a particular instruction
+reads or writes through a pointer associated with that operand — currently
+only `fstcw` / `fnstcw` / `fldcw`, which read or write `__CPROVER_rounding_mode`.
+Clobber lists are parsed but do not affect verification.
+
+### Limitations
+
+- Only the instructions listed above are modeled. Any inline-assembly
+  statement that contains an unrecognized instruction is replaced with `skip`
+  in its entirety, **including any recognized instructions in the same
+  statement**. This can be unsound if the dropped assembly has side effects
+  relevant to the property being verified.
+- No diagnostic is emitted for dropped assembly. Use
+  `goto-instrument --show-goto-functions` (or `cbmc --show-goto-functions`) to
+  inspect whether an inline-assembly statement was translated or dropped.
+- For GCC-style inline assembly, complex atomic operations beyond the basic
+  `lock; <recognized instruction>` pattern listed above are not modeled as
+  single atomic operations; in particular `xchg` and `lock`-prefixed
+  read-modify-write instructions (e.g. `lock addl`, `lock cmpxchgl`) are
+  dropped.
+- MSVC-style `__asm` blocks are parsed, but only the x86
+  `mfence` / `lfence` / `sfence`, `fstcw` / `fnstcw`, and `fldcw` instructions
+  are modeled. ARM and Power instructions and `lock` / `xchg` patterns are
+  **not** modeled for MSVC-style inline assembly.

--- a/doc/cprover-manual/modeling-inline-asm.md
+++ b/doc/cprover-manual/modeling-inline-asm.md
@@ -65,7 +65,8 @@ Clobber lists are parsed but do not affect verification.
   in its entirety, **including any recognized instructions in the same
   statement**. This can be unsound if the dropped assembly has side effects
   relevant to the property being verified.
-- No diagnostic is emitted for dropped assembly. Use
+- When an inline-assembly statement is dropped, CBMC emits a warning
+  identifying its source location. You can also use
   `goto-instrument --show-goto-functions` (or `cbmc --show-goto-functions`) to
   inspect whether an inline-assembly statement was translated or dropped.
 - For GCC-style inline assembly, complex atomic operations beyond the basic

--- a/regression/cbmc/inline_asm_dropped/main.c
+++ b/regression/cbmc/inline_asm_dropped/main.c
@@ -1,0 +1,21 @@
+// Statements containing an unrecognized instruction are dropped entirely by
+// the remove_asm pass -- including recognized siblings in the same statement
+// (see doc/cprover-manual/modeling-inline-asm.md). This test pins that no
+// fence/atomic/helper-call is emitted for any of them.
+int main(void)
+{
+  int x = 0, y = 1;
+
+  // xchg is not modeled: the statement is dropped.
+  asm volatile("xchg %0,%1" : "+r"(x), "+r"(y));
+
+  // lock followed by an unrecognized instruction: the whole statement is
+  // dropped (the atomic/fence wrapper is discarded too).
+  asm volatile("lock; addl $1, %0" : "+m"(x));
+
+  // A recognized mfence combined with an unrecognized addl: *both* are
+  // dropped, not just the addl.
+  asm volatile("mfence; addl $1, %0" : "+m"(x));
+
+  return 0;
+}

--- a/regression/cbmc/inline_asm_dropped/test.desc
+++ b/regression/cbmc/inline_asm_dropped/test.desc
@@ -3,6 +3,7 @@ main.c
 --show-goto-functions
 ^EXIT=0$
 ^SIGNAL=0$
+dropping inline assembly statement at .*: it contains an instruction that is not modeled
 --
 ^warning: ignoring
 CALL __asm_

--- a/regression/cbmc/inline_asm_dropped/test.desc
+++ b/regression/cbmc/inline_asm_dropped/test.desc
@@ -1,0 +1,16 @@
+CORE gcc-only
+main.c
+--show-goto-functions
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+CALL __asm_
+^ *FENCE
+ATOMIC_BEGIN
+--
+Pins that inline-assembly statements containing an unrecognized instruction
+are dropped by the remove_asm pass: no fence, atomic section, or __asm_*
+helper call is emitted -- including for "mfence; addl", where the recognized
+mfence is dropped together with the unrecognized addl.
+See GitHub issue diffblue/cbmc#6374.

--- a/regression/cbmc/inline_asm_modeling/main.c
+++ b/regression/cbmc/inline_asm_modeling/main.c
@@ -1,0 +1,33 @@
+// Each statement below is processed independently by the remove_asm pass.
+// This test pins the documented translation of the recognized instructions
+// (see doc/cprover-manual/modeling-inline-asm.md) via the goto program shown
+// by --show-goto-functions.
+int main(void)
+{
+  unsigned short cw = 0;
+
+  // x86 fences: modeled as calls to the __asm_* fence helpers.
+  asm volatile("mfence");
+  asm volatile("lfence");
+  asm volatile("sfence");
+
+  // ARM barriers: dmb/dsb are full fences, isb is an empty fence.
+  asm volatile("dmb");
+  asm volatile("dsb");
+  asm volatile("isb");
+
+  // Power barriers: sync is a full fence, lwsync omits write-after-read,
+  // isync is an empty fence.
+  asm volatile("sync");
+  asm volatile("lwsync");
+  asm volatile("isync");
+
+  // x86 FP control word: writes/reads __CPROVER_rounding_mode via the operand.
+  asm volatile("fstcw %0" : "=m"(cw));
+  asm volatile("fldcw %0" : : "m"(cw));
+
+  // lock prefix followed by a recognized instruction: atomic section + fence.
+  asm volatile("lock; mfence");
+
+  return 0;
+}

--- a/regression/cbmc/inline_asm_modeling/test.desc
+++ b/regression/cbmc/inline_asm_modeling/test.desc
@@ -1,0 +1,25 @@
+CORE gcc-only
+main.c
+--show-goto-functions
+^EXIT=0$
+^SIGNAL=0$
+^ *CALL __asm_mfence\(\)$
+^ *CALL __asm_lfence\(\)$
+^ *CALL __asm_sfence\(\)$
+^ *CALL __asm_fstcw\(
+^ *CALL __asm_fldcw\(
+^ *FENCE WW RR RW WR$
+^ *FENCE WW RR RW$
+^ *FENCE$
+^ *ATOMIC_BEGIN$
+^ *ATOMIC_END$
+--
+^warning: ignoring
+--
+Pins the documented translation of recognized inline-assembly instructions by
+the remove_asm pass (see doc/cprover-manual/modeling-inline-asm.md):
+x86 mfence/lfence/sfence -> __asm_* fence helper calls; ARM dmb/dsb and Power
+sync -> full fence (WW RR RW WR); Power lwsync -> fence without WR; ARM isb /
+Power isync -> empty fence; fstcw/fldcw -> __CPROVER_rounding_mode helpers;
+lock-prefixed recognized instruction -> atomic section with a full fence.
+See GitHub issue diffblue/cbmc#6374.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -79,6 +79,8 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['unsigned1', 'test.desc'],
     ['reachability-slice-interproc3', 'test.desc'],
     ['sync_lock_release-1', 'symbol_per_type.desc'],
+    ['inline_asm_dropped', 'test.desc'],
+    ['inline_asm_modeling', 'test.desc'],
     # this test is marked smt-backend, and would thus fail as we run tests with
     # the SAT back-end only
     ['integer-assignments1', 'test.desc'],

--- a/src/assembler/remove_asm.cpp
+++ b/src/assembler/remove_asm.cpp
@@ -16,6 +16,7 @@ Date:   December 2014
 #include "remove_asm.h"
 
 #include <util/c_types.h>
+#include <util/message.h>
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
 #include <util/range.h>
@@ -36,7 +37,8 @@ public:
     message_handlert &message_handler)
     : symbol_table(_symbol_table),
       goto_functions(_goto_functions),
-      message_handler(message_handler)
+      message_handler(message_handler),
+      log(message_handler)
   {
   }
 
@@ -50,6 +52,7 @@ protected:
   symbol_tablet &symbol_table;
   goto_functionst &goto_functions;
   message_handlert &message_handler;
+  messaget log;
 
   void process_function(const irep_idt &, goto_functionst::goto_functiont &);
 
@@ -402,7 +405,15 @@ void remove_asmt::process_instruction_gcc(
 
   if(unknown)
   {
-    // we give up; we should perhaps print a warning
+    // The entire inline-assembly statement is dropped (turned into skip below)
+    // when any of its instructions is not recognized; warn so that the user is
+    // not left silently relying on un-modeled assembly.
+    log.warning() << "dropping inline assembly statement at "
+                  << code.source_location()
+                  << ": it contains an instruction that is not modeled, so the "
+                     "whole statement (including any modeled instructions) is "
+                     "removed"
+                  << messaget::eom;
   }
   else
     dest.destructive_append(tmp_dest);
@@ -530,7 +541,15 @@ void remove_asmt::process_instruction_msc(
 
   if(unknown)
   {
-    // we give up; we should perhaps print a warning
+    // The entire inline-assembly statement is dropped (turned into skip below)
+    // when any of its instructions is not recognized; warn so that the user is
+    // not left silently relying on un-modeled assembly.
+    log.warning() << "dropping inline assembly statement at "
+                  << code.source_location()
+                  << ": it contains an instruction that is not modeled, so the "
+                     "whole statement (including any modeled instructions) is "
+                     "removed"
+                  << messaget::eom;
   }
   else
     dest.destructive_append(tmp_dest);

--- a/src/assembler/remove_asm.cpp
+++ b/src/assembler/remove_asm.cpp
@@ -28,6 +28,8 @@ Date:   December 2014
 
 #include "assembler_parser.h"
 
+#include <functional>
+
 class remove_asmt
 {
 public:
@@ -67,6 +69,38 @@ protected:
     const irep_idt &,
     const code_asmt &,
     goto_programt &dest);
+
+  // Shared scaffolding for the gcc and msc flavors: parse the assembly text,
+  // handle the lock prefix and xchg, wrap locked instructions in an atomic
+  // section with a full fence, and either append the translation to \p dest or
+  // drop the whole statement (emitting a warning) if \p handle_command reports
+  // an unrecognized instruction.
+  void process_asm(
+    const code_asmt &code,
+    const irep_idt &assembly,
+    goto_programt &dest,
+    const std::function<bool(
+      const irep_idt &command,
+      std::size_t pos,
+      const assembler_parsert::instructiont &instruction,
+      goto_programt &tmp_dest)> &handle_command);
+
+  // Translates a single recognized gcc-style command, returning false if the
+  // command is not modeled.
+  bool handle_gcc_command(
+    const irep_idt &command,
+    const code_asm_gcct &code,
+    goto_programt &tmp_dest);
+
+  // Translates a single recognized msc-style command, returning false if the
+  // command is not modeled.
+  bool handle_msc_command(
+    const irep_idt &command,
+    std::size_t pos,
+    const assembler_parsert::instructiont &instruction,
+    const irep_idt &function_id,
+    const code_asmt &code,
+    goto_programt &tmp_dest);
 
   void gcc_asm_function_call(
     const irep_idt &function_base_name,
@@ -242,18 +276,65 @@ void remove_asmt::process_instruction(
     DATA_INVARIANT(false, "unexpected assembler flavor");
 }
 
-/// Translates the given inline assembly code (in gcc style) to non-assembly
-/// goto program instructions
-///
-/// \param code: The inline assembly code statement to translate
-/// \param dest: The goto program to append the new instructions to
-void remove_asmt::process_instruction_gcc(
-  const code_asm_gcct &code,
-  goto_programt &dest)
+/// Builds a `fence` codet with the requested ordering and cumulativity flags.
+/// Only the flags set to true are added, matching the ireps that the individual
+/// fence instructions used to construct by hand.
+static codet make_fence(
+  const source_locationt &source_location,
+  bool ww,
+  bool rr,
+  bool rw,
+  bool wr,
+  bool ww_cumul = false,
+  bool rw_cumul = false,
+  bool rr_cumul = false,
+  bool wr_cumul = false)
 {
-  const irep_idt &i_str = to_string_constant(code.asm_text()).value();
+  codet code_fence{ID_fence};
+  code_fence.add_source_location() = source_location;
+  if(ww)
+    code_fence.set(ID_WWfence, true);
+  if(rr)
+    code_fence.set(ID_RRfence, true);
+  if(rw)
+    code_fence.set(ID_RWfence, true);
+  if(wr)
+    code_fence.set(ID_WRfence, true);
+  if(ww_cumul)
+    code_fence.set(ID_WWcumul, true);
+  if(rw_cumul)
+    code_fence.set(ID_RWcumul, true);
+  if(rr_cumul)
+    code_fence.set(ID_RRcumul, true);
+  if(wr_cumul)
+    code_fence.set(ID_WRcumul, true);
+  return code_fence;
+}
 
-  std::istringstream str(id2string(i_str));
+/// Shared scaffolding for translating gcc-style and msc-style inline assembly.
+/// Parses \p assembly, and for each parsed instruction handles the `lock`
+/// prefix and `xchg` (which start an atomic section containing a full fence),
+/// delegates the actual command translation to \p handle_command, and closes
+/// the atomic section. If any instruction is not recognized by
+/// \p handle_command, the whole statement is dropped (a warning is emitted and
+/// nothing is appended to \p dest); otherwise the translation is appended.
+///
+/// \param code: The inline assembly code statement being translated
+/// \param assembly: The assembly text to parse
+/// \param dest: The goto program to append the new instructions to
+/// \param handle_command: Translates a single command into \p tmp_dest and
+///   returns whether the command was recognized
+void remove_asmt::process_asm(
+  const code_asmt &code,
+  const irep_idt &assembly,
+  goto_programt &dest,
+  const std::function<bool(
+    const irep_idt &command,
+    std::size_t pos,
+    const assembler_parsert::instructiont &instruction,
+    goto_programt &tmp_dest)> &handle_command)
+{
+  std::istringstream str(id2string(assembly));
   assembler_parsert assembler_parser{message_handler};
   assembler_parser.in = &str;
   assembler_parser.parse();
@@ -267,19 +348,9 @@ void remove_asmt::process_instruction_gcc(
     if(instruction.empty())
       continue;
 
-#if 0
-    std::cout << "A ********************\n";
-    for(const auto &ins : instruction)
-    {
-      std::cout << "XX: " << ins.pretty() << '\n';
-    }
-
-    std::cout << "B ********************\n";
-#endif
-
     // deal with prefixes
     irep_idt command;
-    unsigned pos = 0;
+    std::size_t pos = 0;
 
     if(
       instruction.front().id() == ID_symbol &&
@@ -305,94 +376,12 @@ void remove_asmt::process_instruction_gcc(
     if(x86_32_locked_atomic)
     {
       tmp_dest.add(goto_programt::make_atomic_begin(code.source_location()));
-
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-      code_fence.set(ID_WWfence, true);
-      code_fence.set(ID_RRfence, true);
-      code_fence.set(ID_RWfence, true);
-      code_fence.set(ID_WRfence, true);
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
+      tmp_dest.add(goto_programt::make_other(
+        make_fence(code.source_location(), true, true, true, true),
+        code.source_location()));
     }
 
-    if(command == "fstcw" || command == "fnstcw" || command == "fldcw") // x86
-    {
-      gcc_asm_function_call("__asm_" + id2string(command), code, 1, tmp_dest);
-    }
-    else if(
-      command == "mfence" || command == "lfence" || command == "sfence") // x86
-    {
-      gcc_asm_function_call("__asm_" + id2string(command), code, 0, tmp_dest);
-    }
-    else if(command == ID_sync) // Power
-    {
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-      code_fence.set(ID_WWfence, true);
-      code_fence.set(ID_RRfence, true);
-      code_fence.set(ID_RWfence, true);
-      code_fence.set(ID_WRfence, true);
-      code_fence.set(ID_WWcumul, true);
-      code_fence.set(ID_RWcumul, true);
-      code_fence.set(ID_RRcumul, true);
-      code_fence.set(ID_WRcumul, true);
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-    }
-    else if(command == ID_lwsync) // Power
-    {
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-      code_fence.set(ID_WWfence, true);
-      code_fence.set(ID_RRfence, true);
-      code_fence.set(ID_RWfence, true);
-      code_fence.set(ID_WWcumul, true);
-      code_fence.set(ID_RWcumul, true);
-      code_fence.set(ID_RRcumul, true);
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-    }
-    else if(command == ID_isync) // Power
-    {
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-      // doesn't do anything by itself,
-      // needs to be combined with branch
-    }
-    else if(command == "dmb" || command == "dsb") // ARM
-    {
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-      code_fence.set(ID_WWfence, true);
-      code_fence.set(ID_RRfence, true);
-      code_fence.set(ID_RWfence, true);
-      code_fence.set(ID_WRfence, true);
-      code_fence.set(ID_WWcumul, true);
-      code_fence.set(ID_RWcumul, true);
-      code_fence.set(ID_RRcumul, true);
-      code_fence.set(ID_WRcumul, true);
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-    }
-    else if(command == "isb") // ARM
-    {
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-      // doesn't do anything by itself,
-      // needs to be combined with branch
-    }
-    else
+    if(!handle_command(command, pos, instruction, tmp_dest))
       unknown = true; // give up
 
     if(x86_32_locked_atomic)
@@ -419,6 +408,90 @@ void remove_asmt::process_instruction_gcc(
     dest.destructive_append(tmp_dest);
 }
 
+/// Translates the given inline assembly code (in gcc style) to non-assembly
+/// goto program instructions
+///
+/// \param code: The inline assembly code statement to translate
+/// \param dest: The goto program to append the new instructions to
+void remove_asmt::process_instruction_gcc(
+  const code_asm_gcct &code,
+  goto_programt &dest)
+{
+  process_asm(
+    code,
+    to_string_constant(code.asm_text()).value(),
+    dest,
+    [this, &code](
+      const irep_idt &command,
+      std::size_t,
+      const assembler_parsert::instructiont &,
+      goto_programt &tmp_dest)
+    { return handle_gcc_command(command, code, tmp_dest); });
+}
+
+/// Translates a single recognized gcc-style command into \p tmp_dest.
+///
+/// \param command: The instruction mnemonic to translate
+/// \param code: The inline assembly code statement being translated
+/// \param tmp_dest: The goto program to append the translation to
+/// \return Whether the command was recognized (and hence modeled)
+bool remove_asmt::handle_gcc_command(
+  const irep_idt &command,
+  const code_asm_gcct &code,
+  goto_programt &tmp_dest)
+{
+  const source_locationt &source_location = code.source_location();
+
+  if(command == "fstcw" || command == "fnstcw" || command == "fldcw") // x86
+  {
+    gcc_asm_function_call("__asm_" + id2string(command), code, 1, tmp_dest);
+  }
+  else if(
+    command == "mfence" || command == "lfence" || command == "sfence") // x86
+  {
+    gcc_asm_function_call("__asm_" + id2string(command), code, 0, tmp_dest);
+  }
+  else if(command == ID_sync) // Power
+  {
+    tmp_dest.add(goto_programt::make_other(
+      make_fence(
+        source_location, true, true, true, true, true, true, true, true),
+      source_location));
+  }
+  else if(command == ID_lwsync) // Power
+  {
+    tmp_dest.add(goto_programt::make_other(
+      make_fence(
+        source_location, true, true, true, false, true, true, true, false),
+      source_location));
+  }
+  else if(command == ID_isync) // Power
+  {
+    // doesn't do anything by itself, needs to be combined with branch
+    tmp_dest.add(goto_programt::make_other(
+      make_fence(source_location, false, false, false, false),
+      source_location));
+  }
+  else if(command == "dmb" || command == "dsb") // ARM
+  {
+    tmp_dest.add(goto_programt::make_other(
+      make_fence(
+        source_location, true, true, true, true, true, true, true, true),
+      source_location));
+  }
+  else if(command == "isb") // ARM
+  {
+    // doesn't do anything by itself, needs to be combined with branch
+    tmp_dest.add(goto_programt::make_other(
+      make_fence(source_location, false, false, false, false),
+      source_location));
+  }
+  else
+    return false;
+
+  return true;
+}
+
 /// Translates the given inline assembly code (in msc style) to non-assembly
 /// goto program instructions
 ///
@@ -430,129 +503,73 @@ void remove_asmt::process_instruction_msc(
   const code_asmt &code,
   goto_programt &dest)
 {
-  const irep_idt &i_str = to_string_constant(code.op0()).value();
+  process_asm(
+    code,
+    to_string_constant(code.op0()).value(),
+    dest,
+    [this, &code, &function_id](
+      const irep_idt &command,
+      std::size_t pos,
+      const assembler_parsert::instructiont &instruction,
+      goto_programt &tmp_dest)
+    {
+      return handle_msc_command(
+        command, pos, instruction, function_id, code, tmp_dest);
+    });
+}
 
-  std::istringstream str(id2string(i_str));
-  assembler_parsert assembler_parser{message_handler};
-  assembler_parser.in = &str;
-  assembler_parser.parse();
-
-  goto_programt tmp_dest;
-  bool unknown = false;
-  bool x86_32_locked_atomic = false;
-
-  for(const auto &instruction : assembler_parser.instructions)
+/// Translates a single recognized msc-style command into \p tmp_dest.
+///
+/// \param command: The instruction mnemonic to translate
+/// \param pos: Index of the token following the command in \p instruction
+/// \param instruction: The parsed instruction tokens
+/// \param function_id: Name of function being processed
+/// \param code: The inline assembly code statement being translated
+/// \param tmp_dest: The goto program to append the translation to
+/// \return Whether the command was recognized (and hence modeled)
+bool remove_asmt::handle_msc_command(
+  const irep_idt &command,
+  std::size_t pos,
+  const assembler_parsert::instructiont &instruction,
+  const irep_idt &function_id,
+  const code_asmt &code,
+  goto_programt &tmp_dest)
+{
+  if(command == "fstcw" || command == "fnstcw" || command == "fldcw") // x86
   {
-    if(instruction.empty())
-      continue;
-
-#if 0
-    std::cout << "A ********************\n";
-    for(const auto &ins : instruction)
+    exprt::operandst args{null_pointer_exprt{pointer_type(empty_typet{})}};
+    // try to typecheck the argument
+    if(pos != instruction.size() && instruction[pos].id() == ID_symbol)
     {
-      std::cout << "XX: " << ins.pretty() << '\n';
-    }
-
-    std::cout << "B ********************\n";
-#endif
-
-    // deal with prefixes
-    irep_idt command;
-    unsigned pos = 0;
-
-    if(
-      instruction.front().id() == ID_symbol &&
-      instruction.front().get(ID_identifier) == "lock")
-    {
-      x86_32_locked_atomic = true;
-      pos++;
-    }
-
-    // done?
-    if(pos == instruction.size())
-      continue;
-
-    if(instruction[pos].id() == ID_symbol)
-    {
-      command = instruction[pos].get(ID_identifier);
-      pos++;
-    }
-
-    if(command == "xchg" || command == "xchgl")
-      x86_32_locked_atomic = true;
-
-    if(x86_32_locked_atomic)
-    {
-      tmp_dest.add(goto_programt::make_atomic_begin(code.source_location()));
-
-      codet code_fence(ID_fence);
-      code_fence.add_source_location() = code.source_location();
-      code_fence.set(ID_WWfence, true);
-      code_fence.set(ID_RRfence, true);
-      code_fence.set(ID_RWfence, true);
-      code_fence.set(ID_WRfence, true);
-
-      tmp_dest.add(
-        goto_programt::make_other(code_fence, code.source_location()));
-    }
-
-    if(command == "fstcw" || command == "fnstcw" || command == "fldcw") // x86
-    {
-      exprt::operandst args{null_pointer_exprt{pointer_type(empty_typet{})}};
-      // try to typecheck the argument
-      if(pos != instruction.size() && instruction[pos].id() == ID_symbol)
+      const irep_idt &name = instruction[pos].get(ID_identifier);
+      for(const auto &entry : equal_range(symbol_table.symbol_base_map, name))
       {
-        const irep_idt &name = instruction[pos].get(ID_identifier);
-        for(const auto &entry : equal_range(symbol_table.symbol_base_map, name))
+        // global scope symbol, don't replace a local one
+        if(entry.second == name && args[0].id() != ID_address_of)
         {
-          // global scope symbol, don't replace a local one
-          if(entry.second == name && args[0].id() != ID_address_of)
-          {
-            args[0] =
-              address_of_exprt{symbol_table.lookup_ref(name).symbol_expr()};
-          }
-          // parameter or symbol in local scope
-          else if(has_prefix(
-                    id2string(entry.second), id2string(function_id) + "::"))
-          {
-            args[0] = address_of_exprt{
-              symbol_table.lookup_ref(entry.second).symbol_expr()};
-          }
+          args[0] =
+            address_of_exprt{symbol_table.lookup_ref(name).symbol_expr()};
+        }
+        // parameter or symbol in local scope
+        else if(has_prefix(
+                  id2string(entry.second), id2string(function_id) + "::"))
+        {
+          args[0] = address_of_exprt{
+            symbol_table.lookup_ref(entry.second).symbol_expr()};
         }
       }
-      msc_asm_function_call(
-        "__asm_" + id2string(command), args, code, tmp_dest);
     }
-    else if(
-      command == "mfence" || command == "lfence" || command == "sfence") // x86
-    {
-      msc_asm_function_call("__asm_" + id2string(command), {}, code, tmp_dest);
-    }
-    else
-      unknown = true; // give up
-
-    if(x86_32_locked_atomic)
-    {
-      tmp_dest.add(goto_programt::make_atomic_end(code.source_location()));
-
-      x86_32_locked_atomic = false;
-    }
+    msc_asm_function_call("__asm_" + id2string(command), args, code, tmp_dest);
   }
-
-  if(unknown)
+  else if(
+    command == "mfence" || command == "lfence" || command == "sfence") // x86
   {
-    // The entire inline-assembly statement is dropped (turned into skip below)
-    // when any of its instructions is not recognized; warn so that the user is
-    // not left silently relying on un-modeled assembly.
-    log.warning() << "dropping inline assembly statement at "
-                  << code.source_location()
-                  << ": it contains an instruction that is not modeled, so the "
-                     "whole statement (including any modeled instructions) is "
-                     "removed"
-                  << messaget::eom;
+    msc_asm_function_call("__asm_" + id2string(command), {}, code, tmp_dest);
   }
   else
-    dest.destructive_append(tmp_dest);
+    return false;
+
+  return true;
 }
 
 /// Replaces inline assembly instructions in the goto function by non-assembly


### PR DESCRIPTION
Add doc/cprover-manual/modeling-inline-asm.md listing the assembly instructions that CBMC's remove_asm pass translates (x86 fences and FP control, ARM barriers, Power sync instructions, and lock/xchg atomics). Note that unrecognized instructions are silently removed.

Link the new page from the manual index.

Fixes: #6374

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
