### PR TITLE
Implement incremental symex with periodic and concurrent SAT solving

### DIFF
--- a/doc/architectural/incremental-symex-goals.md
+++ b/doc/architectural/incremental-symex-goals.md
@@ -1,0 +1,77 @@
+# Incremental Symex Goal Construction
+
+## Overview
+
+CBMC's standard verification flow runs symbolic execution to completion,
+then converts all assertions into a single SAT query. The incremental
+goal construction feature allows the SAT solver to be invoked at
+intermediate points during symbolic execution, enabling early detection
+of property violations and concurrent solver execution.
+
+## Algorithm
+
+The standard `convert_assertions` builds a single disjunction:
+
+    NOT(a1) OR NOT(a2) OR ... OR NOT(aN)
+
+where each `ai` is an assertion condition (under its path assumption).
+The solver checks whether any assertion can fail.
+
+The incremental variant (`convert_assertions_incremental`) adds a free
+"goal extender" variable `v` to make the disjunction extensible:
+
+    NOT(a1) OR NOT(a2) OR ... OR v
+
+The solver is called with the assumption `NOT(v)`, which effectively
+closes the disjunction. On the next call (after more symex steps
+produce new assertions), a new clause links to the previous extender:
+
+    NOT(v) OR NOT(a3) OR NOT(a4) OR ... OR v2
+
+With assumption `NOT(v2)`, the solver now checks all assertions from
+both batches. The chain of extender variables allows arbitrary
+incremental extension without rebuilding earlier clauses.
+
+## Components
+
+### `symex_target_equationt::convert_assertions_incremental`
+
+Core algorithm in `src/goto-symex/symex_target_equation.cpp`. Tracks:
+- `current_goal_extender`: the latest extender variable
+- `incremental_last_converted`: iterator to resume from
+- `incremental_assumption`: accumulated path assumptions
+
+### `periodic_incremental_symex_checker`
+
+In `src/goto-checker/`. Subclasses `symex_bmct` to count symex steps
+and pause every N steps (set via `--incremental-check-interval`).
+The main loop alternates between symex and solver invocations.
+
+### `concurrent_incremental_symex_checker`
+
+In `src/goto-checker/`. Runs symex in a separate thread. Uses
+mutex + condition variable for handoff: symex pauses and sets
+`symex_paused=true`, the solver thread processes the equation, then
+sets `solver_done=true` to resume symex. The equation is only accessed
+by one thread at a time (no concurrent reads/writes).
+
+## Usage
+
+    # Check every 50 symex steps:
+    cbmc program.c --incremental-check-interval 50
+
+    # Same, but with concurrent symex and solving:
+    cbmc program.c --incremental-check-interval 50 --concurrent-incremental
+
+    # With the existing incremental-loop mode:
+    cbmc program.c --incremental-loop main.0 --unwind-max 20
+
+## Limitations
+
+- The incremental check interval is measured in symex steps, not
+  assertions. A small interval increases solver overhead; a large
+  interval reduces the benefit of early detection.
+- The concurrent mode uses a single solver thread. The symex thread
+  is blocked while the solver runs (and vice versa), so the speedup
+  comes from overlapping symex work with solver work, not from
+  parallel solving.

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -436,6 +436,11 @@ threads. Symbolic execution pauses every N steps (set via
 \fB\-\-incremental\-check\-interval\fR) and hands off to the solver.
 Requires \fB\-\-incremental\-check\-interval\fR.
 .TP
+\fB\-\-speculative\-check\fR
+speculatively check assertions on partial equations using
+cone\-of\-influence slicing. Use with
+\fB\-\-incremental\-check\-interval\fR.
+.TP
 \fB\-\-show\-vcc\fR
 show the verification conditions
 .TP

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -424,6 +424,18 @@ stop incremental\-loop after nr unwindings
 do not check properties before unwind\-min
 when using incremental\-loop
 .TP
+\fB\-\-incremental\-check\-interval\fR N
+invoke the SAT solver every N symbolic execution steps to check
+assertions discovered so far, using incremental goal construction
+to avoid rebuilding the assertion disjunction from scratch.
+Can find property violations before symbolic execution completes.
+.TP
+\fB\-\-concurrent\-incremental\fR
+run symbolic execution and SAT solving concurrently in separate
+threads. Symbolic execution pauses every N steps (set via
+\fB\-\-incremental\-check\-interval\fR) and hands off to the solver.
+Requires \fB\-\-incremental\-check\-interval\fR.
+.TP
 \fB\-\-show\-vcc\fR
 show the verification conditions
 .TP

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -350,6 +350,11 @@ threads. Symbolic execution pauses every N steps (set via
 \fB\-\-incremental\-check\-interval\fR) and hands off to the solver.
 Requires \fB\-\-incremental\-check\-interval\fR.
 .TP
+\fB\-\-speculative\-check\fR
+speculatively check assertions on partial equations using
+cone\-of\-influence slicing. Use with
+\fB\-\-incremental\-check\-interval\fR.
+.TP
 \fB\-\-show\-vcc\fR
 show the verification conditions
 .TP

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -339,6 +339,17 @@ stop incremental\-loop after nr unwindings
 do not check properties before unwind\-min
 when using incremental\-loop
 .TP
+\fB\-\-incremental\-check\-interval\fR N
+invoke the SAT solver every N symbolic execution steps to check
+assertions discovered so far, using incremental goal construction.
+Can find property violations before symbolic execution completes.
+.TP
+\fB\-\-concurrent\-incremental\fR
+run symbolic execution and SAT solving concurrently in separate
+threads. Symbolic execution pauses every N steps (set via
+\fB\-\-incremental\-check\-interval\fR) and hands off to the solver.
+Requires \fB\-\-incremental\-check\-interval\fR.
+.TP
 \fB\-\-show\-vcc\fR
 show the verification conditions
 .TP

--- a/jbmc/src/jbmc/Makefile
+++ b/jbmc/src/jbmc/Makefile
@@ -43,7 +43,7 @@ OBJ += ../$(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \
 
 INCLUDES= -I .. -I ../$(CPROVER_DIR)/src
 
-LIBS =
+LIBS = -lpthread
 
 include ../config.inc
 include ../$(CPROVER_DIR)/src/config.inc

--- a/jbmc/unit/Makefile
+++ b/jbmc/unit/Makefile
@@ -133,6 +133,8 @@ N_CATCH_TESTS = $(shell \
                   cat $$(find . -name "*.cpp" ) | \
                   grep -c -E "(SCENARIO|TEST_CASE)")
 
+LIBS = -lpthread
+
 CLEANFILES = $(CATCH_TEST) java-testing-utils/java-testing-utils$(LIBEXT)
 
 # only add a dependency for libraries to avoid triggering implicit rules, which

--- a/regression/cbmc-incr-oneloop/concurrent-check-fail1/main.c
+++ b/regression/cbmc-incr-oneloop/concurrent-check-fail1/main.c
@@ -1,0 +1,13 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 5);
+  int sum = 0;
+  while(x > 0)
+  {
+    sum = sum + x;
+    x = x - 1;
+  }
+  assert(sum <= 10);
+}

--- a/regression/cbmc-incr-oneloop/concurrent-check-fail1/test.desc
+++ b/regression/cbmc-incr-oneloop/concurrent-check-fail1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--no-standard-checks --concurrent-incremental --incremental-check-interval 15 --unwinding-assertions --unwind 10
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/concurrent-check1/main.c
+++ b/regression/cbmc-incr-oneloop/concurrent-check1/main.c
@@ -1,0 +1,16 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 10);
+  int y = 0;
+  while(x > 0)
+  {
+    y = y + 1;
+    x = x - 1;
+    assert(y >= 1);
+    assert(x >= 0);
+  }
+  assert(y >= 0);
+  assert(x == 0);
+}

--- a/regression/cbmc-incr-oneloop/concurrent-check1/test.desc
+++ b/regression/cbmc-incr-oneloop/concurrent-check1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--no-standard-checks --concurrent-incremental --incremental-check-interval 20 --unwinding-assertions --unwind 15
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/early-detection1/main.c
+++ b/regression/cbmc-incr-oneloop/early-detection1/main.c
@@ -1,0 +1,29 @@
+// Test that incremental checking detects failures before symex completes.
+extern int nondet_int();
+
+int compute(int *arr, int n)
+{
+  int sum = 0;
+  for(int i = 0; i < n; i++)
+  {
+    sum += arr[i];
+    assert(sum < 1000000);
+  }
+  return sum;
+}
+
+int main()
+{
+  int n = nondet_int();
+  __CPROVER_assume(n >= 1 && n <= 50);
+
+  int arr[50];
+  for(int i = 0; i < 50; i++)
+  {
+    arr[i] = nondet_int();
+    __CPROVER_assume(arr[i] >= 0 && arr[i] <= 100000);
+  }
+
+  int result = compute(arr, n);
+  assert(result >= 0);
+}

--- a/regression/cbmc-incr-oneloop/early-detection1/test.desc
+++ b/regression/cbmc-incr-oneloop/early-detection1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--no-standard-checks --incremental-check-interval 100 --unwinding-assertions --unwind 55
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+Test that incremental checking finds the failure before symex completes

--- a/regression/cbmc-incr-oneloop/equivalence-check1/main.c
+++ b/regression/cbmc-incr-oneloop/equivalence-check1/main.c
@@ -1,0 +1,21 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 8);
+  int sum = 0;
+  int count = 0;
+  while(x > 0)
+  {
+    sum = sum + x;
+    count = count + 1;
+    x = x - 1;
+    assert(count >= 1);   // always true
+    assert(sum >= count); // always true
+    assert(x >= 0);       // always true
+  }
+  assert(count <= 8); // always true
+  assert(sum <= 36);  // always true (max: 8+7+...+1 = 36)
+  assert(sum <= 10);  // FAILS for x >= 5
+  assert(x == 0);     // always true
+}

--- a/regression/cbmc-incr-oneloop/equivalence-check1/test.desc
+++ b/regression/cbmc-incr-oneloop/equivalence-check1/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--no-standard-checks --incremental-check-interval 10 --unwinding-assertions --unwind 10
+^EXIT=10$
+^SIGNAL=0$
+\[main\.assertion\.1\] .* count >= 1: SUCCESS
+\[main\.assertion\.2\] .* sum >= count: SUCCESS
+\[main\.assertion\.3\] .* x >= 0: SUCCESS
+\[main\.assertion\.4\] .* count <= 8: SUCCESS
+\[main\.assertion\.5\] .* sum <= 36: SUCCESS
+\[main\.assertion\.6\] .* sum <= 10: FAILURE
+\[main\.assertion\.7\] .* x == 0: SUCCESS
+--
+^warning: ignoring
+--
+Verify incremental checking produces identical verdicts to non-incremental

--- a/regression/cbmc-incr-oneloop/incremental-goals1/main.c
+++ b/regression/cbmc-incr-oneloop/incremental-goals1/main.c
@@ -1,0 +1,12 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 1);
+  while(x < 5)
+  {
+    x = x + 1;
+    assert(x <= 5);
+  }
+  assert(x == 5);
+}

--- a/regression/cbmc-incr-oneloop/incremental-goals1/test.desc
+++ b/regression/cbmc-incr-oneloop/incremental-goals1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--no-standard-checks --incremental-loop main.0 --unwinding-assertions --unwind-max 10
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/periodic-check-fail1/main.c
+++ b/regression/cbmc-incr-oneloop/periodic-check-fail1/main.c
@@ -1,0 +1,13 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 5);
+  int sum = 0;
+  while(x > 0)
+  {
+    sum = sum + x;
+    x = x - 1;
+  }
+  assert(sum <= 10);
+}

--- a/regression/cbmc-incr-oneloop/periodic-check-fail1/test.desc
+++ b/regression/cbmc-incr-oneloop/periodic-check-fail1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--no-standard-checks --incremental-check-interval 15 --unwinding-assertions --unwind 10
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/periodic-check1/main.c
+++ b/regression/cbmc-incr-oneloop/periodic-check1/main.c
@@ -1,0 +1,16 @@
+extern int nondet_int();
+int main()
+{
+  int x = nondet_int();
+  __CPROVER_assume(0 <= x && x <= 10);
+  int y = 0;
+  while(x > 0)
+  {
+    y = y + 1;
+    x = x - 1;
+    assert(y >= 1);
+    assert(x >= 0);
+  }
+  assert(y >= 0);
+  assert(x == 0);
+}

--- a/regression/cbmc-incr-oneloop/periodic-check1/test.desc
+++ b/regression/cbmc-incr-oneloop/periodic-check1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--no-standard-checks --incremental-check-interval 20 --unwinding-assertions --unwind 15
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/scripts/bench_incremental.sh
+++ b/scripts/bench_incremental.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Benchmark incremental symex modes on aws-c-common proofs.
+# Usage: scripts/bench_incremental.sh [cbmc_binary] [aws-c-common_dir]
+set -e
+
+CBMC="${1:-build/bin/cbmc}"
+GOTO_CC="${CBMC%cbmc}goto-cc"
+AWS="${2:-/tmp/aws-c-common}"
+RESULTS="/tmp/incremental_bench_results.txt"
+
+if [ ! -x "$CBMC" ]; then echo "cbmc not found: $CBMC"; exit 1; fi
+if [ ! -d "$AWS" ]; then echo "aws-c-common not found: $AWS"; exit 1; fi
+
+SRCDIR="$AWS"
+PROOF_BASE="$AWS/verification/cbmc"
+PROOF_SOURCE="$PROOF_BASE/source"
+PROOF_STUB="$PROOF_BASE/stubs"
+INCLUDE="-I$AWS/include -I$PROOF_BASE/include -I$AWS"
+
+# Select a subset of proofs (same approach as CI: first 6 per data structure)
+PROOFS=$(ls -d "$PROOF_BASE/proofs/aws_"*/ 2>/dev/null | head -18)
+
+compile_proof() {
+  local proof_dir="$1"
+  local name=$(basename "$proof_dir")
+  local harness="$proof_dir/${name}_harness.c"
+  local out="/tmp/bench_${name}.gb"
+
+  [ -f "$harness" ] || return 1
+
+  # Gather sources from Makefile
+  local sources="$harness"
+  local makefile="$proof_dir/Makefile"
+
+  # Add common sources
+  for src in "$SRCDIR/source/common.c" "$SRCDIR/source/allocator.c"; do
+    [ -f "$src" ] && sources="$sources $src"
+  done
+  # Add proof helpers
+  for src in "$PROOF_SOURCE/make_common_data_structures.c" \
+             "$PROOF_SOURCE/utils.c" "$PROOF_STUB/error.c"; do
+    [ -f "$src" ] && sources="$sources $src"
+  done
+  # Add project sources mentioned in Makefile
+  for src in $(grep 'PROJECT_SOURCES.*source/' "$makefile" 2>/dev/null | \
+               sed 's/.*\$(SRCDIR)//' | sed 's/\s*$//' ); do
+    [ -f "$SRCDIR$src" ] && sources="$sources $SRCDIR$src"
+  done
+  # Add stub sources
+  for src in $(grep 'PROOF_STUB.*\.c' "$makefile" 2>/dev/null | \
+               sed "s|.*\$(PROOF_STUB)/||" | sed 's/\s*$//'); do
+    [ -f "$PROOF_STUB/$src" ] && sources="$sources $PROOF_STUB/$src"
+  done
+
+  timeout 30 "$GOTO_CC" $INCLUDE \
+    -DCBMC -D__CPROVER \
+    --function "${name}_harness" \
+    $sources -o "$out" 2>/dev/null && echo "$out"
+}
+
+run_cbmc() {
+  local gb="$1" mode="$2" extra="$3"
+  timeout 60 /usr/bin/time -f "%e" \
+    "$CBMC" "$gb" --unwind 10 --unwinding-assertions \
+    --no-standard-checks $extra 2>&1
+}
+
+printf "%-40s %10s %10s %10s %10s\n" \
+  "Proof" "baseline" "periodic" "concurrent" "result" > "$RESULTS"
+printf "%-40s %10s %10s %10s %10s\n" \
+  "----" "--------" "--------" "----------" "------" >> "$RESULTS"
+
+compiled=0
+for proof_dir in $PROOFS; do
+  name=$(basename "$proof_dir")
+  gb=$(compile_proof "$proof_dir" 2>/dev/null)
+  [ -z "$gb" ] && continue
+  [ ! -f "$gb" ] && continue
+  compiled=$((compiled + 1))
+
+  # Baseline
+  out_b=$(run_cbmc "$gb" baseline "" 2>&1)
+  time_b=$(echo "$out_b" | tail -1)
+  result=$(echo "$out_b" | grep -o 'VERIFICATION [A-Z]*' | head -1)
+
+  # Periodic
+  out_p=$(run_cbmc "$gb" periodic "--incremental-check-interval 200" 2>&1)
+  time_p=$(echo "$out_p" | tail -1)
+
+  # Concurrent
+  out_c=$(run_cbmc "$gb" concurrent \
+    "--concurrent-incremental --incremental-check-interval 200" 2>&1)
+  time_c=$(echo "$out_c" | tail -1)
+
+  printf "%-40s %10s %10s %10s %10s\n" \
+    "$name" "${time_b}s" "${time_p}s" "${time_c}s" "$result" | \
+    tee -a "$RESULTS"
+done
+
+echo
+echo "Compiled $compiled proofs"
+echo "Results in $RESULTS"
+cat "$RESULTS"

--- a/src/cbmc/Makefile
+++ b/src/cbmc/Makefile
@@ -45,7 +45,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
 
 INCLUDES= -I ..
 
-LIBS =
+LIBS = -lpthread
 
 include ../config.inc
 include ../common

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -40,9 +40,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-checker/all_properties_verifier_with_fault_localization.h>
 #include <goto-checker/all_properties_verifier_with_trace_storage.h>
 #include <goto-checker/bmc_util.h>
+#include <goto-checker/concurrent_incremental_symex_checker.h>
 #include <goto-checker/cover_goals_verifier_with_trace_storage.h>
 #include <goto-checker/multi_path_symex_checker.h>
 #include <goto-checker/multi_path_symex_only_checker.h>
+#include <goto-checker/periodic_incremental_symex_checker.h>
 #include <goto-checker/properties.h>
 #include <goto-checker/single_loop_incremental_symex_checker.h>
 #include <goto-checker/single_path_symex_checker.h>
@@ -437,6 +439,16 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     }
   }
 
+  if(cmdline.isset("incremental-check-interval"))
+  {
+    options.set_option(
+      "incremental-check-interval",
+      cmdline.get_value("incremental-check-interval"));
+  }
+
+  if(cmdline.isset("concurrent-incremental"))
+    options.set_option("concurrent-incremental", true);
+
   if(cmdline.isset("graphml-witness"))
   {
     options.set_option("graphml-witness", cmdline.get_value("graphml-witness"));
@@ -704,7 +716,34 @@ int cbmc_parse_optionst::doit()
 
   std::unique_ptr<goto_verifiert> verifier = nullptr;
 
-  if(options.is_set("incremental-loop"))
+  if(
+    options.get_bool_option("concurrent-incremental") &&
+    !options.is_set("incremental-check-interval"))
+  {
+    log.error()
+      << "--concurrent-incremental requires --incremental-check-interval"
+      << messaget::eom;
+    return CPROVER_EXIT_USAGE_ERROR;
+  }
+
+  if(
+    options.get_bool_option("concurrent-incremental") &&
+    options.is_set("incremental-check-interval"))
+  {
+    if(options.get_bool_option("stop-on-fail"))
+    {
+      verifier = std::make_unique<
+        stop_on_fail_verifiert<concurrent_incremental_symex_checkert>>(
+        options, ui_message_handler, goto_model);
+    }
+    else
+    {
+      verifier = std::make_unique<all_properties_verifier_with_trace_storaget<
+        concurrent_incremental_symex_checkert>>(
+        options, ui_message_handler, goto_model);
+    }
+  }
+  else if(options.is_set("incremental-loop"))
   {
     if(options.get_bool_option("stop-on-fail"))
     {
@@ -716,6 +755,21 @@ int cbmc_parse_optionst::doit()
     {
       verifier = std::make_unique<all_properties_verifier_with_trace_storaget<
         single_loop_incremental_symex_checkert>>(
+        options, ui_message_handler, goto_model);
+    }
+  }
+  else if(options.is_set("incremental-check-interval"))
+  {
+    if(options.get_bool_option("stop-on-fail"))
+    {
+      verifier = std::make_unique<
+        stop_on_fail_verifiert<periodic_incremental_symex_checkert>>(
+        options, ui_message_handler, goto_model);
+    }
+    else
+    {
+      verifier = std::make_unique<all_properties_verifier_with_trace_storaget<
+        periodic_incremental_symex_checkert>>(
         options, ui_message_handler, goto_model);
     }
   }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -449,6 +449,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("concurrent-incremental"))
     options.set_option("concurrent-incremental", true);
 
+  if(cmdline.isset("speculative-check"))
+    options.set_option("speculative-check", true);
+
   if(cmdline.isset("graphml-witness"))
   {
     options.set_option("graphml-witness", cmdline.get_value("graphml-witness"));

--- a/src/goto-analyzer/Makefile
+++ b/src/goto-analyzer/Makefile
@@ -27,7 +27,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
 
 INCLUDES= -I ..
 
-LIBS =
+LIBS = -lpthread
 
 include ../config.inc
 include ../common

--- a/src/goto-checker/CMakeLists.txt
+++ b/src/goto-checker/CMakeLists.txt
@@ -3,4 +3,7 @@ add_library(goto-checker ${sources})
 
 generic_includes(goto-checker)
 
-target_link_libraries(goto-checker goto-programs goto-symex solvers util xml)
+find_package(Threads REQUIRED)
+target_link_libraries(
+  goto-checker goto-programs goto-symex solvers util xml Threads::Threads
+)

--- a/src/goto-checker/Makefile
+++ b/src/goto-checker/Makefile
@@ -1,4 +1,5 @@
 SRC = bmc_util.cpp \
+      concurrent_incremental_symex_checker.cpp \
       counterexample_beautification.cpp \
       cover_goals_report_util.cpp \
       fatal_assertions.cpp \
@@ -9,6 +10,7 @@ SRC = bmc_util.cpp \
       incremental_goto_checker.cpp \
       multi_path_symex_checker.cpp \
       multi_path_symex_only_checker.cpp \
+      periodic_incremental_symex_checker.cpp \
       properties.cpp \
       report_util.cpp \
       single_loop_incremental_symex_checker.cpp \

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -413,3 +413,33 @@ void run_property_decider(
     result.progress = incremental_goto_checkert::resultt::progresst::FOUND_FAIL;
   }
 }
+
+std::chrono::duration<double> prepare_property_decider_incremental(
+  propertiest &properties,
+  symex_target_equationt &equation,
+  goto_symex_property_decidert &property_decider,
+  ui_message_handlert &ui_message_handler)
+{
+  auto solver_start = std::chrono::steady_clock::now();
+
+  messaget log(ui_message_handler);
+  log.status()
+    << "Passing problem to "
+    << property_decider.get_decision_procedure().decision_procedure_text()
+    << messaget::eom;
+
+  // Pop previous incremental assumptions if any
+  property_decider.pop_incremental_assumptions();
+
+  log.status() << "converting SSA" << messaget::eom;
+  equation.convert_without_assertions(
+    property_decider.get_decision_procedure());
+
+  property_decider.update_properties_goals_from_symex_target_equation(
+    properties);
+  property_decider.convert_goals_incremental();
+  property_decider.convert_goals();
+
+  auto solver_stop = std::chrono::steady_clock::now();
+  return std::chrono::duration<double>(solver_stop - solver_start);
+}

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -201,6 +201,7 @@ std::chrono::duration<double> prepare_property_decider_incremental(
   "(incremental-loop):"                                                        \
   "(incremental-check-interval):"                                              \
   "(concurrent-incremental)"                                                   \
+  "(speculative-check)"                                                        \
   "(unwind-min):"                                                              \
   "(unwind-max):"                                                              \
   "(ignore-properties-before-unwind-min)"                                      \
@@ -231,6 +232,10 @@ std::chrono::duration<double> prepare_property_decider_incremental(
   " {y--concurrent-incremental} \t "                                           \
   "run symbolic execution and SAT solving concurrently in separate "           \
   "threads (use with {y--incremental-check-interval})\n"                       \
+  " {y--speculative-check} \t "                                                \
+  "speculatively check assertions on partial equations using "                 \
+  "cone-of-influence slicing (use with "                                       \
+  "{y--incremental-check-interval})\n"                                         \
   " {y--unwind-min} {unr} \t "                                                 \
   "start incremental-loop after {unr} unwindings but before solving that "     \
   "iteration. If for example it is 1, then the loop will be unwound once, "    \

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -164,6 +164,21 @@ void run_property_decider(
   std::chrono::duration<double> solver_runtime,
   bool set_pass = true);
 
+/// Prepare the property decider using incremental goal construction.
+/// Converts the equation without assertions (only new steps are
+/// converted), then converts assertions incrementally and sets up
+/// goals.
+/// \param [in,out] properties: The property statuses to update
+/// \param [in,out] equation: The equation to convert
+/// \param [in,out] property_decider: The property decider to set up
+/// \param [in,out] ui_message_handler: For logging
+/// \return The runtime for converting the equation
+std::chrono::duration<double> prepare_property_decider_incremental(
+  propertiest &properties,
+  symex_target_equationt &equation,
+  goto_symex_property_decidert &property_decider,
+  ui_message_handlert &ui_message_handler);
+
 #define OPT_BMC                                                                \
   "(program-only)"                                                             \
   "(show-byte-ops)"                                                            \
@@ -184,6 +199,8 @@ void run_property_decider(
   "(symex-complexity-limit):"                                                  \
   "(symex-complexity-failed-child-loops-limit):"                               \
   "(incremental-loop):"                                                        \
+  "(incremental-check-interval):"                                              \
+  "(concurrent-incremental)"                                                   \
   "(unwind-min):"                                                              \
   "(unwind-max):"                                                              \
   "(ignore-properties-before-unwind-min)"                                      \
@@ -208,6 +225,12 @@ void run_property_decider(
   " {y--incremental-loop} {uL} \t "                                            \
   "check properties after each unwinding of loop {uL} (use {y--show-loops} "   \
   "to get the loop IDs)\n"                                                     \
+  " {y--incremental-check-interval} {uN} \t "                                  \
+  "invoke the SAT solver every {uN} symex steps to check properties "          \
+  "discovered so far\n"                                                        \
+  " {y--concurrent-incremental} \t "                                           \
+  "run symbolic execution and SAT solving concurrently in separate "           \
+  "threads (use with {y--incremental-check-interval})\n"                       \
   " {y--unwind-min} {unr} \t "                                                 \
   "start incremental-loop after {unr} unwindings but before solving that "     \
   "iteration. If for example it is 1, then the loop will be unwound once, "    \

--- a/src/goto-checker/concurrent_incremental_symex_checker.cpp
+++ b/src/goto-checker/concurrent_incremental_symex_checker.cpp
@@ -341,12 +341,13 @@ concurrent_incremental_symex_checkert::operator()(propertiest &properties)
 
     full_equation_generated = sync.symex_done;
 
-    revert_slice(equation);
-
+    // New steps from symex will be converted on the next iteration
+    // by prepare_property_decider_incremental. We do NOT revert the
+    // slice or reset current_equation_converted, because re-converting
+    // the entire equation into the same solver creates duplicate
+    // Tseitin clauses that corrupt the formula.
     update_properties_status_from_symex_target_equation(
       properties, result.updated_properties, equation);
-
-    current_equation_converted = false;
   }
 
   return result;

--- a/src/goto-checker/concurrent_incremental_symex_checker.cpp
+++ b/src/goto-checker/concurrent_incremental_symex_checker.cpp
@@ -1,0 +1,412 @@
+/*******************************************************************\
+
+Module: Goto Checker using Multi-Path Symbolic Execution
+        with Concurrent SAT Solving
+
+Author: CBMC Contributors
+
+\*******************************************************************/
+
+/// \file
+/// Goto Checker using multi-path symbolic execution with concurrent
+/// SAT solving in a separate thread
+
+#include "concurrent_incremental_symex_checker.h"
+
+#include <util/ui_message.h>
+
+#include "bmc_util.h"
+#include "counterexample_beautification.h"
+
+#include <thread>
+
+// --- symex_bmc_concurrent_stept implementation ---
+
+concurrent_incremental_symex_checkert::symex_bmc_concurrent_stept::
+  symex_bmc_concurrent_stept(
+    message_handlert &message_handler,
+    const symbol_tablet &outer_symbol_table,
+    symex_target_equationt &target,
+    const optionst &options,
+    path_storaget &path_storage,
+    guard_managert &guard_manager,
+    unwindsett &unwindset,
+    unsigned interval)
+  : symex_bmct(
+      message_handler,
+      outer_symbol_table,
+      target,
+      options,
+      path_storage,
+      guard_manager,
+      unwindset),
+    step_counter(0),
+    step_interval(interval)
+{
+}
+
+void concurrent_incremental_symex_checkert::symex_bmc_concurrent_stept::
+  symex_step(const get_goto_functiont &get_goto_function, statet &state)
+{
+  symex_bmct::symex_step(get_goto_function, state);
+
+  ++step_counter;
+  if(step_counter >= step_interval)
+  {
+    should_pause_symex = true;
+    step_counter = 0;
+  }
+}
+
+bool concurrent_incremental_symex_checkert::symex_bmc_concurrent_stept::
+  from_entry_point_of(
+    const get_goto_functiont &get_goto_function,
+    symbol_tablet &new_symbol_table)
+{
+  state = initialize_entry_point_state(get_goto_function);
+
+  new_symbol_table = symex_with_state(*state, get_goto_function);
+
+  return should_pause_symex;
+}
+
+bool concurrent_incremental_symex_checkert::symex_bmc_concurrent_stept::resume(
+  const get_goto_functiont &get_goto_function)
+{
+  should_pause_symex = false;
+
+  state->symbol_table = symex_with_state(*state, get_goto_function);
+
+  return should_pause_symex;
+}
+
+// --- concurrent_incremental_symex_checkert implementation ---
+
+concurrent_incremental_symex_checkert::concurrent_incremental_symex_checkert(
+  const optionst &options,
+  ui_message_handlert &ui_message_handler,
+  abstract_goto_modelt &goto_model)
+  : incremental_goto_checkert(options, ui_message_handler),
+    goto_model(goto_model),
+    ns(goto_model.get_symbol_table(), symex_symbol_table),
+    equation(ui_message_handler),
+    symex(
+      ui_message_handler,
+      goto_model.get_symbol_table(),
+      equation,
+      options,
+      path_storage,
+      guard_manager,
+      unwindset,
+      static_cast<unsigned>(
+        options.get_signed_int_option("incremental-check-interval"))),
+    property_decider(options, ui_message_handler, equation, ns)
+{
+  unwindset.parse_unwind(options.get_option("unwind"));
+  unwindset.parse_unwindset(
+    options.get_list_option("unwindset"), goto_model, ui_message_handler);
+
+  // Freeze all symbols if we are using a prop_conv_solvert
+  prop_conv_solvert *prop_conv_solver = dynamic_cast<prop_conv_solvert *>(
+    &property_decider.get_decision_procedure());
+  if(prop_conv_solver != nullptr)
+    prop_conv_solver->set_all_frozen();
+}
+
+incremental_goto_checkert::resultt
+concurrent_incremental_symex_checkert::operator()(propertiest &properties)
+{
+  resultt result(resultt::progresst::DONE);
+
+  std::chrono::duration<double> solver_runtime(0);
+
+  unsigned solver_calls = 0;
+
+  const auto get_goto_function = goto_symext::get_goto_function(goto_model);
+
+  // On first invocation, launch symex in a separate thread.
+  if(!initial_equation_generated)
+  {
+    // Reset sync state
+    sync.symex_paused = false;
+    sync.symex_done = false;
+    sync.solver_done = false;
+    sync.stop_symex = false;
+    sync.symex_exception = nullptr;
+
+    symex_thread = std::make_unique<std::thread>(
+      [&]()
+      {
+        try
+        {
+          // Start symex from entry point
+          bool can_resume =
+            symex.from_entry_point_of(get_goto_function, symex_symbol_table);
+
+          {
+            std::lock_guard<std::mutex> lock(sync.mtx);
+            if(can_resume)
+            {
+              sync.symex_paused = true;
+            }
+            else
+            {
+              sync.symex_done = true;
+            }
+          }
+          sync.cv.notify_one();
+
+          // Loop: wait for solver, then resume symex
+          while(can_resume)
+          {
+            {
+              std::unique_lock<std::mutex> lock(sync.mtx);
+              sync.cv.wait(
+                lock, [this] { return sync.solver_done || sync.stop_symex; });
+              sync.solver_done = false;
+              if(sync.stop_symex)
+                break;
+            }
+
+            can_resume = symex.resume(get_goto_function);
+
+            {
+              std::lock_guard<std::mutex> lock(sync.mtx);
+              if(can_resume)
+              {
+                sync.symex_paused = true;
+              }
+              else
+              {
+                sync.symex_done = true;
+              }
+            }
+            sync.cv.notify_one();
+          }
+        }
+        catch(...)
+        {
+          std::lock_guard<std::mutex> lock(sync.mtx);
+          sync.symex_exception = std::current_exception();
+          sync.symex_done = true;
+          sync.cv.notify_one();
+        }
+      });
+
+    // Wait for the first batch from symex
+    {
+      std::unique_lock<std::mutex> lock(sync.mtx);
+      sync.cv.wait(
+        lock, [this] { return sync.symex_paused || sync.symex_done; });
+      if(sync.symex_exception)
+        std::rethrow_exception(sync.symex_exception);
+    }
+
+    // Record whether symex completed entirely
+    full_equation_generated = sync.symex_done;
+
+    update_properties_status_from_symex_target_equation(
+      properties, result.updated_properties, equation);
+
+    initial_equation_generated = true;
+  }
+
+  // Main solving loop
+  while(has_properties_to_check(properties))
+  {
+    if(count_properties(properties, property_statust::UNKNOWN) > 0)
+    {
+      const auto solver_start = std::chrono::steady_clock::now();
+
+      if(!current_equation_converted)
+      {
+        postprocess_equation(symex, equation, options, ns, ui_message_handler);
+
+        solver_runtime += prepare_property_decider_incremental(
+          properties, equation, property_decider, ui_message_handler);
+
+        current_equation_converted = true;
+      }
+
+      property_decider.add_incremental_constraint_from_goals(
+        [&properties](const irep_idt &property_id)
+        { return is_property_to_check(properties.at(property_id).status); });
+
+      ++solver_calls;
+      log.status()
+        << "Concurrent check #" << solver_calls << ": running "
+        << property_decider.get_decision_procedure().decision_procedure_text()
+        << messaget::eom;
+
+      decision_proceduret::resultt dec_result;
+      // Pipeline: let symex resume during solve().
+      if(!full_equation_generated)
+      {
+        {
+          std::lock_guard<std::mutex> lock(sync.mtx);
+          sync.symex_paused = false;
+          sync.solver_done = true;
+        }
+        sync.cv.notify_one();
+
+        dec_result = property_decider.solve();
+
+        // Wait for symex to pause before continuing.
+        {
+          std::unique_lock<std::mutex> lock(sync.mtx);
+          sync.cv.wait(
+            lock, [this] { return sync.symex_paused || sync.symex_done; });
+          if(sync.symex_exception)
+          {
+            if(symex_thread && symex_thread->joinable())
+              symex_thread->join();
+            std::rethrow_exception(sync.symex_exception);
+          }
+          full_equation_generated = sync.symex_done;
+        }
+      }
+      else
+      {
+        dec_result = property_decider.solve();
+      }
+
+      property_decider.update_properties_status_from_goals(
+        properties, result.updated_properties, dec_result, false);
+
+      const auto solver_stop = std::chrono::steady_clock::now();
+      solver_runtime +=
+        std::chrono::duration<double>(solver_stop - solver_start);
+      log.status() << "Runtime decision procedure: " << solver_runtime.count()
+                   << "s" << messaget::eom;
+
+      result.progress =
+        dec_result == decision_proceduret::resultt::D_SATISFIABLE
+          ? resultt::progresst::FOUND_FAIL
+          : resultt::progresst::DONE;
+
+      if(result.progress == resultt::progresst::FOUND_FAIL)
+      {
+        // Signal symex to stop and join the thread
+        if(!full_equation_generated)
+        {
+          {
+            std::lock_guard<std::mutex> lock(sync.mtx);
+            sync.stop_symex = true;
+            sync.solver_done = true;
+          }
+          sync.cv.notify_one();
+          full_equation_generated = true;
+        }
+        if(symex_thread && symex_thread->joinable())
+          symex_thread->join();
+        break;
+      }
+
+      property_decider.pop_incremental_assumptions();
+    }
+
+    if(full_equation_generated)
+    {
+      update_status_of_unknown_properties(
+        properties, result.updated_properties);
+
+      update_status_of_not_checked_properties(
+        properties, result.updated_properties);
+
+      if(symex_thread && symex_thread->joinable())
+        symex_thread->join();
+      break;
+    }
+
+    // Signal symex to continue
+    {
+      std::lock_guard<std::mutex> lock(sync.mtx);
+      sync.symex_paused = false;
+      sync.solver_done = true;
+    }
+    sync.cv.notify_one();
+
+    // Wait for symex to pause or finish
+    {
+      std::unique_lock<std::mutex> lock(sync.mtx);
+      sync.cv.wait(
+        lock, [this] { return sync.symex_paused || sync.symex_done; });
+      if(sync.symex_exception)
+      {
+        if(symex_thread && symex_thread->joinable())
+          symex_thread->join();
+        std::rethrow_exception(sync.symex_exception);
+      }
+    }
+
+    full_equation_generated = sync.symex_done;
+
+    revert_slice(equation);
+
+    update_properties_status_from_symex_target_equation(
+      properties, result.updated_properties, equation);
+
+    current_equation_converted = false;
+  }
+
+  return result;
+}
+
+goto_tracet concurrent_incremental_symex_checkert::build_full_trace() const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation,
+    equation.SSA_steps.end(),
+    property_decider.get_decision_procedure(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet concurrent_incremental_symex_checkert::build_shortest_trace() const
+{
+  if(options.get_bool_option("beautify"))
+  {
+    // NOLINTNEXTLINE(whitespace/braces)
+    counterexample_beautificationt{ui_message_handler}(
+      property_decider.get_boolbv_decision_procedure(), equation);
+  }
+
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation, property_decider.get_decision_procedure(), ns, goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet concurrent_incremental_symex_checkert::build_trace(
+  const irep_idt &property_id) const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation,
+    ssa_step_matches_failing_property(property_id),
+    property_decider.get_decision_procedure(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+const namespacet &concurrent_incremental_symex_checkert::get_namespace() const
+{
+  return ns;
+}
+
+void concurrent_incremental_symex_checkert::output_proof()
+{
+  output_graphml(equation, ns, options);
+}
+
+void concurrent_incremental_symex_checkert::output_error_witness(
+  const goto_tracet &error_trace)
+{
+  output_graphml(error_trace, ns, options);
+}

--- a/src/goto-checker/concurrent_incremental_symex_checker.h
+++ b/src/goto-checker/concurrent_incremental_symex_checker.h
@@ -1,0 +1,134 @@
+/*******************************************************************\
+
+Module: Goto Checker using Multi-Path Symbolic Execution
+        with Concurrent SAT Solving
+
+Author: CBMC Contributors
+
+\*******************************************************************/
+
+/// \file
+/// Goto Checker using multi-path symbolic execution with concurrent
+/// SAT solving in a separate thread
+
+#ifndef CPROVER_GOTO_CHECKER_CONCURRENT_INCREMENTAL_SYMEX_CHECKER_H
+#define CPROVER_GOTO_CHECKER_CONCURRENT_INCREMENTAL_SYMEX_CHECKER_H
+
+
+#include <goto-programs/unwindset.h>
+
+#include <goto-symex/path_storage.h>
+
+#include "goto_symex_property_decider.h"
+#include "goto_trace_provider.h"
+#include "incremental_goto_checker.h"
+#include "symex_bmc.h"
+#include "witness_provider.h"
+
+#include <condition_variable>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+/// Performs a multi-path symbolic execution using goto-symex
+/// in a separate thread while the main thread runs the SAT solver.
+/// The symex thread pauses every N steps and hands off new equation
+/// steps to the solver thread via mutex and condition variable
+/// synchronization.
+class concurrent_incremental_symex_checkert : public incremental_goto_checkert,
+                                              public goto_trace_providert,
+                                              public witness_providert
+{
+public:
+  concurrent_incremental_symex_checkert(
+    const optionst &options,
+    ui_message_handlert &ui_message_handler,
+    abstract_goto_modelt &goto_model);
+
+  /// \copydoc incremental_goto_checkert::operator()(propertiest &properties)
+  ///
+  /// Note: This operator can handle shrinking and expanding sets of
+  ///   properties in repeated invocations.
+  resultt operator()(propertiest &) override;
+
+  goto_tracet build_full_trace() const override;
+  goto_tracet build_trace(const irep_idt &) const override;
+  goto_tracet build_shortest_trace() const override;
+  const namespacet &get_namespace() const override;
+
+  void output_error_witness(const goto_tracet &) override;
+  void output_proof() override;
+
+protected:
+  abstract_goto_modelt &goto_model;
+  symbol_tablet symex_symbol_table;
+  namespacet ns;
+  symex_target_equationt equation;
+  path_fifot path_storage;
+  guard_managert guard_manager;
+  unwindsett unwindset;
+
+  /// Symex subclass that pauses every N steps for concurrent solving
+  class symex_bmc_concurrent_stept : public symex_bmct
+  {
+  public:
+    symex_bmc_concurrent_stept(
+      message_handlert &message_handler,
+      const symbol_tablet &outer_symbol_table,
+      symex_target_equationt &target,
+      const optionst &options,
+      path_storaget &path_storage,
+      guard_managert &guard_manager,
+      unwindsett &unwindset,
+      unsigned interval);
+
+    /// Start symex from program entry point.
+    /// \return true if symex can be resumed (was paused)
+    bool from_entry_point_of(
+      const get_goto_functiont &get_goto_function,
+      symbol_tablet &new_symbol_table);
+
+    /// Resume symex after a pause.
+    /// \return true if symex can be resumed (was paused again)
+    bool resume(const get_goto_functiont &get_goto_function);
+
+  protected:
+    unsigned step_counter;
+    const unsigned step_interval;
+
+    std::unique_ptr<goto_symext::statet> state;
+
+    void symex_step(const get_goto_functiont &get_goto_function, statet &state)
+      override;
+  };
+
+  symex_bmc_concurrent_stept symex;
+  bool initial_equation_generated = false;
+  bool full_equation_generated = false;
+  bool current_equation_converted = false;
+  goto_symex_property_decidert property_decider;
+
+  /// Thread running symbolic execution concurrently
+  std::unique_ptr<std::thread> symex_thread;
+
+  /// Shared synchronization state between symex and solver threads.
+  /// Pipelined: symex is signaled to resume before solve() so it runs
+  /// concurrently with SAT solving. After solve() returns, the solver
+  /// waits for symex to pause, then the original bottom-of-loop
+  /// signal/wait handles the next iteration's conversion phase.
+  struct sync_statet
+  {
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool symex_paused = false;
+    bool symex_done = false;
+    bool solver_done = false;
+    bool stop_symex = false;
+    std::exception_ptr symex_exception;
+  };
+
+  sync_statet sync;
+};
+
+#endif // CPROVER_GOTO_CHECKER_CONCURRENT_INCREMENTAL_SYMEX_CHECKER_H

--- a/src/goto-checker/concurrent_incremental_symex_checker.h
+++ b/src/goto-checker/concurrent_incremental_symex_checker.h
@@ -14,7 +14,6 @@ Author: CBMC Contributors
 #ifndef CPROVER_GOTO_CHECKER_CONCURRENT_INCREMENTAL_SYMEX_CHECKER_H
 #define CPROVER_GOTO_CHECKER_CONCURRENT_INCREMENTAL_SYMEX_CHECKER_H
 
-
 #include <goto-programs/unwindset.h>
 
 #include <goto-symex/path_storage.h>

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -128,6 +128,56 @@ symex_target_equationt &goto_symex_property_decidert::get_equation() const
   return equation;
 }
 
+std::optional<exprt> goto_symex_property_decidert::convert_goals_incremental()
+{
+  decision_proceduret &decision_procedure = solver->decision_procedure();
+  equation.convert_assertions_incremental(decision_procedure);
+  current_goal_extender_handle = std::nullopt;
+  return current_goal_extender_handle;
+}
+
+void goto_symex_property_decidert::add_incremental_constraint_from_goals(
+  std::function<bool(const irep_idt &)> select_property)
+{
+  // Pop any previously active assumptions first
+  pop_incremental_assumptions();
+
+  std::vector<exprt> assumptions;
+
+  // Build a goal selection assumption: at least one selected
+  // property must have a failing assertion instance.
+  exprt::operandst disjuncts;
+  for(const auto &goal_pair : goal_map)
+  {
+    if(select_property(goal_pair.first) && goal_pair.second.condition != false)
+    {
+      disjuncts.push_back(goal_pair.second.condition);
+    }
+  }
+
+  exprt goal_disjunction = disjunction(disjuncts);
+  assumptions.push_back(solver->decision_procedure().handle(goal_disjunction));
+
+  // The goal extender must be false to close the extensible
+  // assertion disjunction.
+  if(current_goal_extender_handle.has_value())
+  {
+    assumptions.push_back(not_exprt(current_goal_extender_handle.value()));
+  }
+
+  solver->decision_procedure().push(assumptions);
+  incremental_assumptions_active = true;
+}
+
+void goto_symex_property_decidert::pop_incremental_assumptions()
+{
+  if(incremental_assumptions_active)
+  {
+    solver->decision_procedure().pop();
+    incremental_assumptions_active = false;
+  }
+}
+
 void goto_symex_property_decidert::update_properties_status_from_goals(
   propertiest &properties,
   std::unordered_set<irep_idt> &updated_properties,

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -17,6 +17,8 @@ Author: Daniel Kroening, Peter Schrammel
 #include "properties.h"
 #include "solver_factory.h"
 
+#include <optional>
+
 class ui_message_handlert;
 
 /// Provides management of goal variables that encode properties
@@ -53,6 +55,20 @@ public:
   /// Return the equation associated with this instance
   symex_target_equationt &get_equation() const;
 
+  /// Convert goals incrementally using the extensible goal
+  /// construction. Returns the goal extender handle to be assumed
+  /// false, or empty if there are no assertions to convert.
+  std::optional<exprt> convert_goals_incremental();
+
+  /// Add constraint from goals and push the goal extender assumption
+  /// onto the decision procedure stack via push(assumptions).
+  void add_incremental_constraint_from_goals(
+    std::function<bool(const irep_idt &property_id)> select_property);
+
+  /// Pop the incremental assumption that was pushed by
+  /// add_incremental_constraint_from_goals.
+  void pop_incremental_assumptions();
+
   /// Update the property status from the truth value of the goal variable
   /// \param [inout] properties: The status is updated in this data structure
   /// \param [inout] updated_properties: The set of property IDs of
@@ -87,6 +103,9 @@ protected:
   /// the property. Uses `std::string` to maintain consistent (lexicographic)
   /// ordering as we iterate over this map to produce constraints.
   std::map<std::string, goalt> goal_map;
+
+  std::optional<exprt> current_goal_extender_handle;
+  bool incremental_assumptions_active = false;
 };
 
 #endif // CPROVER_GOTO_CHECKER_GOTO_SYMEX_PROPERTY_DECIDER_H

--- a/src/goto-checker/periodic_incremental_symex_checker.cpp
+++ b/src/goto-checker/periodic_incremental_symex_checker.cpp
@@ -1,0 +1,408 @@
+/*******************************************************************\
+
+Module: Goto Checker using Multi-Path Symbolic Execution
+        with Periodic SAT Solver Invocation
+
+Author: CBMC Contributors
+
+\*******************************************************************/
+
+/// \file
+/// Goto Checker using multi-path symbolic execution with periodic
+/// SAT solver invocation every N symex steps
+
+#include "periodic_incremental_symex_checker.h"
+
+#include <util/ui_message.h>
+
+#include <goto-symex/slice.h>
+
+#include "bmc_util.h"
+#include "solver_factory.h"
+#include <sstream>
+#include <solvers/prop/prop_conv_solver.h>
+#include "counterexample_beautification.h"
+
+// --- symex_bmc_periodic_stept implementation ---
+
+periodic_incremental_symex_checkert::symex_bmc_periodic_stept::
+  symex_bmc_periodic_stept(
+    message_handlert &message_handler,
+    const symbol_tablet &outer_symbol_table,
+    symex_target_equationt &target,
+    const optionst &options,
+    path_storaget &path_storage,
+    guard_managert &guard_manager,
+    unwindsett &unwindset,
+    unsigned interval)
+  : symex_bmct(
+      message_handler,
+      outer_symbol_table,
+      target,
+      options,
+      path_storage,
+      guard_manager,
+      unwindset),
+    step_counter(0),
+    step_interval(interval),
+    last_assertion_count(0)
+{
+}
+
+void periodic_incremental_symex_checkert::symex_bmc_periodic_stept::symex_step(
+  const get_goto_functiont &get_goto_function,
+  statet &state)
+{
+  symex_bmct::symex_step(get_goto_function, state);
+
+  ++step_counter;
+
+  if(step_counter >= step_interval)
+  {
+    should_pause_symex = true;
+    step_counter = 0;
+    last_assertion_count = target.count_assertions();
+  }
+  else if(step_counter >= step_interval / 4)
+  {
+    // Adaptive: also pause early when new assertions have appeared,
+    // but only after at least 1/4 of the interval to limit overhead.
+    std::size_t current = target.count_assertions();
+    if(current > last_assertion_count)
+    {
+      should_pause_symex = true;
+      step_counter = 0;
+      last_assertion_count = current;
+    }
+  }
+}
+
+bool periodic_incremental_symex_checkert::symex_bmc_periodic_stept::
+  from_entry_point_of(
+    const get_goto_functiont &get_goto_function,
+    symbol_tablet &new_symbol_table)
+{
+  state = initialize_entry_point_state(get_goto_function);
+
+  new_symbol_table = symex_with_state(*state, get_goto_function);
+
+  return should_pause_symex;
+}
+
+bool periodic_incremental_symex_checkert::symex_bmc_periodic_stept::resume(
+  const get_goto_functiont &get_goto_function)
+{
+  should_pause_symex = false;
+
+  state->symbol_table = symex_with_state(*state, get_goto_function);
+
+  return should_pause_symex;
+}
+
+// --- periodic_incremental_symex_checkert implementation ---
+
+periodic_incremental_symex_checkert::periodic_incremental_symex_checkert(
+  const optionst &options,
+  ui_message_handlert &ui_message_handler,
+  abstract_goto_modelt &goto_model)
+  : incremental_goto_checkert(options, ui_message_handler),
+    goto_model(goto_model),
+    ns(goto_model.get_symbol_table(), symex_symbol_table),
+    equation(ui_message_handler),
+    symex(
+      ui_message_handler,
+      goto_model.get_symbol_table(),
+      equation,
+      options,
+      path_storage,
+      guard_manager,
+      unwindset,
+      static_cast<unsigned>(
+        options.get_signed_int_option("incremental-check-interval"))),
+    property_decider(options, ui_message_handler, equation, ns)
+{
+  unwindset.parse_unwind(options.get_option("unwind"));
+  unwindset.parse_unwindset(
+    options.get_list_option("unwindset"), goto_model, ui_message_handler);
+
+  // Freeze all symbols if we are using a prop_conv_solvert
+  prop_conv_solvert *prop_conv_solver = dynamic_cast<prop_conv_solvert *>(
+    &property_decider.get_decision_procedure());
+  if(prop_conv_solver != nullptr)
+    prop_conv_solver->set_all_frozen();
+}
+
+incremental_goto_checkert::resultt
+periodic_incremental_symex_checkert::operator()(propertiest &properties)
+{
+  resultt result(resultt::progresst::DONE);
+
+  std::chrono::duration<double> solver_runtime(0);
+
+  unsigned solver_calls = 0;
+
+  // we haven't got an equation yet
+  if(!initial_equation_generated)
+  {
+    full_equation_generated = !symex.from_entry_point_of(
+      goto_symext::get_goto_function(goto_model), symex_symbol_table);
+
+    // This might add new properties such as unwinding assertions.
+    update_properties_status_from_symex_target_equation(
+      properties, result.updated_properties, equation);
+
+    initial_equation_generated = true;
+  }
+
+  while(has_properties_to_check(properties))
+  {
+    if(count_properties(properties, property_statust::UNKNOWN) > 0)
+    {
+      if(full_equation_generated)
+      {
+        // Full equation: definitive check with the main solver.
+        const auto solver_start = std::chrono::steady_clock::now();
+
+        if(!current_equation_converted)
+        {
+          postprocess_equation(
+            symex, equation, options, ns, ui_message_handler);
+
+          solver_runtime += prepare_property_decider_incremental(
+            properties, equation, property_decider, ui_message_handler);
+
+          current_equation_converted = true;
+        }
+
+        property_decider.add_incremental_constraint_from_goals(
+          [&properties](const irep_idt &property_id)
+          { return is_property_to_check(properties.at(property_id).status); });
+
+        ++solver_calls;
+        log.status()
+          << "Periodic check #" << solver_calls << ": running "
+          << property_decider.get_decision_procedure()
+               .decision_procedure_text()
+          << messaget::eom;
+
+        decision_proceduret::resultt dec_result = property_decider.solve();
+
+        property_decider.update_properties_status_from_goals(
+          properties, result.updated_properties, dec_result, false);
+
+        const auto solver_stop = std::chrono::steady_clock::now();
+        solver_runtime +=
+          std::chrono::duration<double>(solver_stop - solver_start);
+        log.status() << "Runtime decision procedure: "
+                     << solver_runtime.count() << "s" << messaget::eom;
+
+        result.progress =
+          dec_result == decision_proceduret::resultt::D_SATISFIABLE
+            ? resultt::progresst::FOUND_FAIL
+            : resultt::progresst::DONE;
+
+        if(result.progress == resultt::progresst::FOUND_FAIL)
+          break;
+
+        property_decider.pop_incremental_assumptions();
+      }
+      else
+      {
+        // Partial equation: launch speculative check in a thread.
+        // Save equation state before the speculative check modifies it.
+        saved_step_state.clear();
+        saved_step_state.reserve(equation.SSA_steps.size());
+        for(const auto &step : equation.SSA_steps)
+          saved_step_state.push_back(
+            {step.converted, step.cond_handle, step.guard_handle});
+
+        ++solver_calls;
+        log.status() << "Speculative check #" << solver_calls
+                     << " on partial equation (" << equation.SSA_steps.size()
+                     << " steps)" << messaget::eom;
+
+        speculative_sat = false;
+        // Snapshot the current equation size. The speculative thread
+        // will only process steps up to this point. Symex may append
+        // new steps concurrently, but the thread won't see them.
+        const std::size_t snapshot_size = equation.SSA_steps.size();
+        speculative_thread = std::make_unique<std::thread>(
+          [this, snapshot_size]()
+          {
+            std::ostringstream spec_log_stream;
+            stream_message_handlert spec_mh(spec_log_stream);
+            spec_mh.set_verbosity(
+              ui_message_handler.get_verbosity());
+
+            solver_factoryt solvers(
+              options, ns, spec_mh, false);
+            auto spec_solver = solvers.get_solver();
+            auto &spec_dp = spec_solver->decision_procedure();
+
+            auto *prop_conv =
+              dynamic_cast<prop_conv_solvert *>(&spec_dp);
+            if(prop_conv)
+              prop_conv->set_all_frozen();
+
+            // Only convert the snapshot (existing steps).
+            // New steps appended by symex are not touched.
+            std::size_t count = 0;
+            for(auto &step : equation.SSA_steps)
+            {
+              if(count >= snapshot_size)
+                break;
+              if(!step.ignore)
+              {
+                step.guard_handle = spec_dp.handle(step.guard);
+                if(step.is_assume())
+                  step.cond_handle = spec_dp.handle(step.cond_expr);
+                else if(step.is_assignment() || step.is_constraint())
+                  spec_dp.set_to_true(step.cond_expr);
+                else if(step.is_assert())
+                {
+                  step.cond_handle = spec_dp.handle(step.cond_expr);
+                  spec_dp.set_to_false(step.cond_expr);
+                }
+              }
+              ++count;
+            }
+
+            auto r = spec_solver->decision_procedure()();
+            speculative_sat =
+              (r == decision_proceduret::resultt::D_SATISFIABLE);
+
+            speculative_log_output = spec_log_stream.str();
+          });
+        // Symex continues immediately — speculative thread runs concurrently.
+      }
+    }
+
+    if(full_equation_generated)
+    {
+      update_status_of_unknown_properties(
+        properties, result.updated_properties);
+
+      update_status_of_not_checked_properties(
+        properties, result.updated_properties);
+
+      break;
+    }
+
+    // We continue symbolic execution
+    if(!full_equation_generated)
+    {
+      // Give symex a fresh merge_irep so new steps don't share
+      // the hash table with existing steps. This allows the
+      // speculative thread to safely read existing steps' ireps
+      // while symex appends new ones.
+      merge_irept saved_merge_irep =
+        equation.swap_merge_irep(merge_irept{});
+
+      // Resume symex concurrently with the speculative thread.
+      full_equation_generated =
+        !symex.resume(goto_symext::get_goto_function(goto_model));
+
+      // Join speculative thread after symex pauses.
+      if(speculative_thread)
+      {
+        speculative_thread->join();
+        speculative_thread.reset();
+
+        auto sit = saved_step_state.begin();
+        for(auto &step : equation.SSA_steps)
+        {
+          if(sit == saved_step_state.end())
+            break;
+          step.converted = sit->converted;
+          step.cond_handle = sit->cond_handle;
+          step.guard_handle = sit->guard_handle;
+          ++sit;
+        }
+
+        if(speculative_sat)
+        {
+          log.status() << "Speculative check found potential failure"
+                       << messaget::eom;
+        }
+
+        equation.set_message_handler(ui_message_handler);
+        if(!speculative_log_output.empty())
+        {
+          log.debug() << speculative_log_output << messaget::eom;
+        }
+      }
+
+      // Restore the original merge_irep (merges both pools).
+      equation.swap_merge_irep(std::move(saved_merge_irep));
+
+      revert_slice(equation);
+
+      // This might add new properties such as unwinding assertions.
+      update_properties_status_from_symex_target_equation(
+        properties, result.updated_properties, equation);
+
+      current_equation_converted = false;
+    }
+  }
+
+  return result;
+}
+
+goto_tracet periodic_incremental_symex_checkert::build_full_trace() const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation,
+    equation.SSA_steps.end(),
+    property_decider.get_decision_procedure(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet periodic_incremental_symex_checkert::build_shortest_trace() const
+{
+  if(options.get_bool_option("beautify"))
+  {
+    // NOLINTNEXTLINE(whitespace/braces)
+    counterexample_beautificationt{ui_message_handler}(
+      property_decider.get_boolbv_decision_procedure(), equation);
+  }
+
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation, property_decider.get_decision_procedure(), ns, goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet periodic_incremental_symex_checkert::build_trace(
+  const irep_idt &property_id) const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation,
+    ssa_step_matches_failing_property(property_id),
+    property_decider.get_decision_procedure(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+const namespacet &periodic_incremental_symex_checkert::get_namespace() const
+{
+  return ns;
+}
+
+void periodic_incremental_symex_checkert::output_proof()
+{
+  output_graphml(equation, ns, options);
+}
+
+void periodic_incremental_symex_checkert::output_error_witness(
+  const goto_tracet &error_trace)
+{
+  output_graphml(error_trace, ns, options);
+}

--- a/src/goto-checker/periodic_incremental_symex_checker.cpp
+++ b/src/goto-checker/periodic_incremental_symex_checker.cpp
@@ -13,15 +13,17 @@ Author: CBMC Contributors
 
 #include "periodic_incremental_symex_checker.h"
 
+#include <util/std_expr.h>
 #include <util/ui_message.h>
 
 #include <goto-symex/slice.h>
+#include <solvers/prop/prop_conv_solver.h>
 
 #include "bmc_util.h"
-#include "solver_factory.h"
-#include <sstream>
-#include <solvers/prop/prop_conv_solver.h>
 #include "counterexample_beautification.h"
+#include "solver_factory.h"
+
+#include <sstream>
 
 // --- symex_bmc_periodic_stept implementation ---
 
@@ -119,6 +121,7 @@ periodic_incremental_symex_checkert::periodic_incremental_symex_checkert(
       unwindset,
       static_cast<unsigned>(
         options.get_signed_int_option("incremental-check-interval"))),
+    speculative_checking_enabled(options.get_bool_option("speculative-check")),
     property_decider(options, ui_message_handler, equation, ns)
 {
   unwindset.parse_unwind(options.get_option("unwind"));
@@ -147,7 +150,6 @@ periodic_incremental_symex_checkert::operator()(propertiest &properties)
     full_equation_generated = !symex.from_entry_point_of(
       goto_symext::get_goto_function(goto_model), symex_symbol_table);
 
-    // This might add new properties such as unwinding assertions.
     update_properties_status_from_symex_target_equation(
       properties, result.updated_properties, equation);
 
@@ -181,8 +183,7 @@ periodic_incremental_symex_checkert::operator()(propertiest &properties)
         ++solver_calls;
         log.status()
           << "Periodic check #" << solver_calls << ": running "
-          << property_decider.get_decision_procedure()
-               .decision_procedure_text()
+          << property_decider.get_decision_procedure().decision_procedure_text()
           << messaget::eom;
 
         decision_proceduret::resultt dec_result = property_decider.solve();
@@ -193,8 +194,8 @@ periodic_incremental_symex_checkert::operator()(propertiest &properties)
         const auto solver_stop = std::chrono::steady_clock::now();
         solver_runtime +=
           std::chrono::duration<double>(solver_stop - solver_start);
-        log.status() << "Runtime decision procedure: "
-                     << solver_runtime.count() << "s" << messaget::eom;
+        log.status() << "Runtime decision procedure: " << solver_runtime.count()
+                     << "s" << messaget::eom;
 
         result.progress =
           dec_result == decision_proceduret::resultt::D_SATISFIABLE
@@ -206,74 +207,80 @@ periodic_incremental_symex_checkert::operator()(propertiest &properties)
 
         property_decider.pop_incremental_assumptions();
       }
-      else
+      else if(speculative_checking_enabled)
       {
-        // Partial equation: launch speculative check in a thread.
-        // Save equation state before the speculative check modifies it.
-        saved_step_state.clear();
-        saved_step_state.reserve(equation.SSA_steps.size());
-        for(const auto &step : equation.SSA_steps)
-          saved_step_state.push_back(
-            {step.converted, step.cond_handle, step.guard_handle});
+        // Speculative cone-of-influence check on partial equation.
+        // Only check the most recently discovered assertion to
+        // minimize overhead.
+        const std::size_t current_assertions = equation.count_assertions();
+        if(current_assertions > last_speculative_assertion_count)
+        {
+          last_speculative_assertion_count = current_assertions;
 
-        ++solver_calls;
-        log.status() << "Speculative check #" << solver_calls
-                     << " on partial equation (" << equation.SSA_steps.size()
-                     << " steps)" << messaget::eom;
+          ++solver_calls;
+          log.status() << "Speculative check #" << solver_calls
+                       << " on partial equation (" << equation.SSA_steps.size()
+                       << " steps)" << messaget::eom;
 
-        speculative_sat = false;
-        // Snapshot the current equation size. The speculative thread
-        // will only process steps up to this point. Symex may append
-        // new steps concurrently, but the thread won't see them.
-        const std::size_t snapshot_size = equation.SSA_steps.size();
-        speculative_thread = std::make_unique<std::thread>(
-          [this, snapshot_size]()
-          {
-            std::ostringstream spec_log_stream;
-            stream_message_handlert spec_mh(spec_log_stream);
-            spec_mh.set_verbosity(
-              ui_message_handler.get_verbosity());
-
-            solver_factoryt solvers(
-              options, ns, spec_mh, false);
-            auto spec_solver = solvers.get_solver();
-            auto &spec_dp = spec_solver->decision_procedure();
-
-            auto *prop_conv =
-              dynamic_cast<prop_conv_solvert *>(&spec_dp);
-            if(prop_conv)
-              prop_conv->set_all_frozen();
-
-            // Only convert the snapshot (existing steps).
-            // New steps appended by symex are not touched.
-            std::size_t count = 0;
-            for(auto &step : equation.SSA_steps)
+          speculative_sat = false;
+          const std::size_t snapshot_size = equation.SSA_steps.size();
+          speculative_thread = std::make_unique<std::thread>(
+            [this, snapshot_size]()
             {
-              if(count >= snapshot_size)
-                break;
-              if(!step.ignore)
+              std::ostringstream spec_log_stream;
+              stream_message_handlert spec_mh(spec_log_stream);
+              spec_mh.set_verbosity(ui_message_handler.get_verbosity());
+
+              // Find the last assertion in the snapshot.
+              symex_target_equationt::SSA_stepst::const_iterator last_assert;
+              bool found = false;
+              std::size_t count = 0;
+              for(auto it = equation.SSA_steps.begin();
+                  it != equation.SSA_steps.end() && count < snapshot_size;
+                  ++it, ++count)
               {
-                step.guard_handle = spec_dp.handle(step.guard);
-                if(step.is_assume())
-                  step.cond_handle = spec_dp.handle(step.cond_expr);
-                else if(step.is_assignment() || step.is_constraint())
-                  spec_dp.set_to_true(step.cond_expr);
-                else if(step.is_assert())
+                if(it->is_assert() && !it->ignore)
                 {
-                  step.cond_handle = spec_dp.handle(step.cond_expr);
-                  spec_dp.set_to_false(step.cond_expr);
+                  last_assert = it;
+                  found = true;
                 }
               }
-              ++count;
-            }
 
-            auto r = spec_solver->decision_procedure()();
-            speculative_sat =
-              (r == decision_proceduret::resultt::D_SATISFIABLE);
+              if(!found)
+              {
+                speculative_log_output = spec_log_stream.str();
+                return;
+              }
 
-            speculative_log_output = spec_log_stream.str();
-          });
-        // Symex continues immediately — speculative thread runs concurrently.
+              auto cone = cone_of_influence(
+                equation.SSA_steps, last_assert, snapshot_size);
+
+              solver_factoryt solvers(options, ns, spec_mh, false);
+              auto spec_solver = solvers.get_solver();
+              auto &dp = spec_solver->decision_procedure();
+
+              for(const auto *step : cone)
+              {
+                if(step->is_assignment() || step->is_constraint())
+                  dp.set_to_true(step->cond_expr);
+                else if(step->is_assume())
+                {
+                  exprt g = dp.handle(step->guard);
+                  dp.set_to_true(implies_exprt(g, step->cond_expr));
+                }
+                else if(step->is_assert())
+                {
+                  exprt g = dp.handle(step->guard);
+                  dp.set_to_true(implies_exprt(g, not_exprt(step->cond_expr)));
+                }
+              }
+
+              if(dp() == decision_proceduret::resultt::D_SATISFIABLE)
+                speculative_sat = true;
+
+              speculative_log_output = spec_log_stream.str();
+            });
+        }
       }
     }
 
@@ -288,56 +295,44 @@ periodic_incremental_symex_checkert::operator()(propertiest &properties)
       break;
     }
 
-    // We continue symbolic execution
+    // Resume symbolic execution
     if(!full_equation_generated)
     {
-      // Give symex a fresh merge_irep so new steps don't share
-      // the hash table with existing steps. This allows the
-      // speculative thread to safely read existing steps' ireps
-      // while symex appends new ones.
-      merge_irept saved_merge_irep =
-        equation.swap_merge_irep(merge_irept{});
-
-      // Resume symex concurrently with the speculative thread.
-      full_equation_generated =
-        !symex.resume(goto_symext::get_goto_function(goto_model));
-
-      // Join speculative thread after symex pauses.
-      if(speculative_thread)
+      if(speculative_checking_enabled)
       {
-        speculative_thread->join();
-        speculative_thread.reset();
+        // Swap merge_irep so speculative thread can safely read
+        // existing steps while symex appends new ones.
+        merge_irept saved = equation.swap_merge_irep(merge_irept{});
 
-        auto sit = saved_step_state.begin();
-        for(auto &step : equation.SSA_steps)
+        full_equation_generated =
+          !symex.resume(goto_symext::get_goto_function(goto_model));
+
+        if(speculative_thread)
         {
-          if(sit == saved_step_state.end())
-            break;
-          step.converted = sit->converted;
-          step.cond_handle = sit->cond_handle;
-          step.guard_handle = sit->guard_handle;
-          ++sit;
+          speculative_thread->join();
+          speculative_thread.reset();
+
+          if(speculative_sat)
+          {
+            log.status() << "Speculative check found potential failure"
+                         << messaget::eom;
+          }
+
+          equation.set_message_handler(ui_message_handler);
+          if(!speculative_log_output.empty())
+            log.debug() << speculative_log_output << messaget::eom;
         }
 
-        if(speculative_sat)
-        {
-          log.status() << "Speculative check found potential failure"
-                       << messaget::eom;
-        }
-
-        equation.set_message_handler(ui_message_handler);
-        if(!speculative_log_output.empty())
-        {
-          log.debug() << speculative_log_output << messaget::eom;
-        }
+        equation.swap_merge_irep(std::move(saved));
       }
-
-      // Restore the original merge_irep (merges both pools).
-      equation.swap_merge_irep(std::move(saved_merge_irep));
+      else
+      {
+        full_equation_generated =
+          !symex.resume(goto_symext::get_goto_function(goto_model));
+      }
 
       revert_slice(equation);
 
-      // This might add new properties such as unwinding assertions.
       update_properties_status_from_symex_target_equation(
         properties, result.updated_properties, equation);
 

--- a/src/goto-checker/periodic_incremental_symex_checker.h
+++ b/src/goto-checker/periodic_incremental_symex_checker.h
@@ -14,9 +14,6 @@ Author: CBMC Contributors
 #ifndef CPROVER_GOTO_CHECKER_PERIODIC_INCREMENTAL_SYMEX_CHECKER_H
 #define CPROVER_GOTO_CHECKER_PERIODIC_INCREMENTAL_SYMEX_CHECKER_H
 
-#include <memory>
-#include <thread>
-
 #include <goto-programs/unwindset.h>
 
 #include <goto-symex/path_storage.h>
@@ -26,6 +23,9 @@ Author: CBMC Contributors
 #include "incremental_goto_checker.h"
 #include "symex_bmc.h"
 #include "witness_provider.h"
+
+#include <memory>
+#include <thread>
 
 /// Performs a multi-path symbolic execution using goto-symex
 /// that periodically pauses every N steps
@@ -100,19 +100,15 @@ protected:
   symex_bmc_periodic_stept symex;
   bool initial_equation_generated = false;
   bool full_equation_generated = false;
+  bool current_equation_converted = false;
 
-  /// State saved before a speculative check, restored after.
-  struct step_statet
-  {
-    bool converted;
-    exprt cond_handle;
-    exprt guard_handle;
-  };
-  std::vector<step_statet> saved_step_state;
+  /// Speculative checking state (only active with --speculative-check)
+  bool speculative_checking_enabled = false;
   std::unique_ptr<std::thread> speculative_thread;
   bool speculative_sat = false;
   std::string speculative_log_output;
-  bool current_equation_converted = false;
+  std::size_t last_speculative_assertion_count = 0;
+
   goto_symex_property_decidert property_decider;
 };
 

--- a/src/goto-checker/periodic_incremental_symex_checker.h
+++ b/src/goto-checker/periodic_incremental_symex_checker.h
@@ -1,0 +1,119 @@
+/*******************************************************************\
+
+Module: Goto Checker using Multi-Path Symbolic Execution
+        with Periodic SAT Solver Invocation
+
+Author: CBMC Contributors
+
+\*******************************************************************/
+
+/// \file
+/// Goto Checker using multi-path symbolic execution with periodic
+/// SAT solver invocation every N symex steps
+
+#ifndef CPROVER_GOTO_CHECKER_PERIODIC_INCREMENTAL_SYMEX_CHECKER_H
+#define CPROVER_GOTO_CHECKER_PERIODIC_INCREMENTAL_SYMEX_CHECKER_H
+
+#include <memory>
+#include <thread>
+
+#include <goto-programs/unwindset.h>
+
+#include <goto-symex/path_storage.h>
+
+#include "goto_symex_property_decider.h"
+#include "goto_trace_provider.h"
+#include "incremental_goto_checker.h"
+#include "symex_bmc.h"
+#include "witness_provider.h"
+
+/// Performs a multi-path symbolic execution using goto-symex
+/// that periodically pauses every N steps
+/// and calls a SAT/SMT solver to check the status of the properties
+/// after each pause.
+class periodic_incremental_symex_checkert : public incremental_goto_checkert,
+                                            public goto_trace_providert,
+                                            public witness_providert
+{
+public:
+  periodic_incremental_symex_checkert(
+    const optionst &options,
+    ui_message_handlert &ui_message_handler,
+    abstract_goto_modelt &goto_model);
+
+  /// \copydoc incremental_goto_checkert::operator()(propertiest &properties)
+  ///
+  /// Note: This operator can handle shrinking and expanding sets of
+  ///   properties in repeated invocations.
+  resultt operator()(propertiest &) override;
+
+  goto_tracet build_full_trace() const override;
+  goto_tracet build_trace(const irep_idt &) const override;
+  goto_tracet build_shortest_trace() const override;
+  const namespacet &get_namespace() const override;
+
+  void output_error_witness(const goto_tracet &) override;
+  void output_proof() override;
+
+protected:
+  abstract_goto_modelt &goto_model;
+  symbol_tablet symex_symbol_table;
+  namespacet ns;
+  symex_target_equationt equation;
+  path_fifot path_storage;
+  guard_managert guard_manager;
+  unwindsett unwindset;
+
+  /// Symex subclass that pauses every N steps
+  class symex_bmc_periodic_stept : public symex_bmct
+  {
+  public:
+    symex_bmc_periodic_stept(
+      message_handlert &message_handler,
+      const symbol_tablet &outer_symbol_table,
+      symex_target_equationt &target,
+      const optionst &options,
+      path_storaget &path_storage,
+      guard_managert &guard_manager,
+      unwindsett &unwindset,
+      unsigned interval);
+
+    /// Return true if symex can be resumed
+    bool from_entry_point_of(
+      const get_goto_functiont &get_goto_function,
+      symbol_tablet &new_symbol_table);
+
+    /// Return true if symex can be resumed
+    bool resume(const get_goto_functiont &get_goto_function);
+
+  protected:
+    unsigned step_counter;
+    const unsigned step_interval;
+    std::size_t last_assertion_count;
+
+    std::unique_ptr<goto_symext::statet> state;
+
+    void symex_step(const get_goto_functiont &get_goto_function, statet &state)
+      override;
+  };
+
+  symex_bmc_periodic_stept symex;
+  bool initial_equation_generated = false;
+  bool full_equation_generated = false;
+
+  /// State saved before a speculative check, restored after.
+  struct step_statet
+  {
+    bool converted;
+    exprt cond_handle;
+    exprt guard_handle;
+  };
+  std::vector<step_statet> saved_step_state;
+  std::unique_ptr<std::thread> speculative_thread;
+  bool speculative_sat = false;
+  std::string speculative_log_output;
+  bool current_equation_converted = false;
+  goto_symex_property_decidert property_decider;
+};
+
+#endif // CPROVER_GOTO_CHECKER_PERIODIC_INCREMENTAL_SYMEX_CHECKER_H

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -96,37 +96,21 @@ operator()(propertiest &properties)
       // We have UNKNOWN properties, i.e. properties that we can check
       // on the current equation.
 
-      log.status()
-        << "Passing problem to "
-        << property_decider.get_decision_procedure().decision_procedure_text()
-        << messaget::eom;
-
       const auto solver_start = std::chrono::steady_clock::now();
 
       if(!current_equation_converted)
       {
         postprocess_equation(symex, equation, options, ns, ui_message_handler);
 
-        log.status() << "converting SSA" << messaget::eom;
-        equation.convert_without_assertions(
-          property_decider.get_decision_procedure());
-
-        property_decider.update_properties_goals_from_symex_target_equation(
-          properties);
-
-        // We convert the assertions in a new context.
-        property_decider.get_decision_procedure().push();
-        equation.convert_assertions(
-          property_decider.get_decision_procedure(), false);
-        property_decider.convert_goals();
+        solver_runtime += prepare_property_decider_incremental(
+          properties, equation, property_decider, ui_message_handler);
 
         current_equation_converted = true;
       }
 
-      property_decider.add_constraint_from_goals(
-        [&properties](const irep_idt &property_id) {
-          return is_property_to_check(properties.at(property_id).status);
-        });
+      property_decider.add_incremental_constraint_from_goals(
+        [&properties](const irep_idt &property_id)
+        { return is_property_to_check(properties.at(property_id).status); });
 
       log.status()
         << "Running "
@@ -153,9 +137,8 @@ operator()(propertiest &properties)
       if(result.progress == resultt::progresst::FOUND_FAIL)
         break;
 
-      // Nothing else to do with the current set of assertions.
-      // Let's pop them.
-      property_decider.get_decision_procedure().pop();
+      // Pop incremental assumptions for the next iteration.
+      property_decider.pop_incremental_assumptions();
     }
 
     // Now we are finally done.

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -266,3 +266,63 @@ void revert_slice(symex_target_equationt &equation)
     step.ignore = false;
   }
 }
+
+std::vector<const SSA_stept *> cone_of_influence(
+  const std::list<SSA_stept> &steps,
+  std::list<SSA_stept>::const_iterator assertion_step,
+  std::size_t num_steps)
+{
+  PRECONDITION(assertion_step->is_assert());
+
+  symbol_sett depends;
+  find_symbols(assertion_step->cond_expr, depends);
+  find_symbols(assertion_step->guard, depends);
+
+  // Collect iterators up to num_steps into a vector for reverse traversal.
+  std::vector<std::list<SSA_stept>::const_iterator> step_iters;
+  step_iters.reserve(num_steps);
+  {
+    auto it = steps.begin();
+    for(std::size_t i = 0; i < num_steps && it != steps.end(); ++i, ++it)
+      step_iters.push_back(it);
+  }
+
+  // Walk backwards, collecting steps in the cone.
+  std::vector<const SSA_stept *> cone;
+  cone.push_back(&*assertion_step);
+
+  for(auto rit = step_iters.rbegin(); rit != step_iters.rend(); ++rit)
+  {
+    const SSA_stept &step = **rit;
+    if(&step == &*assertion_step || step.ignore)
+      continue;
+
+    if(step.is_assignment() || step.is_decl())
+    {
+      const irep_idt &id = step.ssa_lhs.get_identifier();
+      auto entry = depends.find(id);
+      if(entry != depends.end())
+      {
+        depends.erase(entry);
+        find_symbols(step.ssa_rhs, depends);
+        find_symbols(step.guard, depends);
+        cone.push_back(&step);
+      }
+    }
+    else if(step.is_assume())
+    {
+      // Include assumptions — they constrain the path.
+      find_symbols(step.cond_expr, depends);
+      find_symbols(step.guard, depends);
+      cone.push_back(&step);
+    }
+    else if(step.is_constraint())
+    {
+      // Constraints are always relevant.
+      find_symbols(step.cond_expr, depends);
+      cone.push_back(&step);
+    }
+  }
+
+  return cone;
+}

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -12,13 +12,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_SYMEX_SLICE_H
 #define CPROVER_GOTO_SYMEX_SLICE_H
 
+#include <util/irep.h>
+
 #include <list>
 #include <unordered_set>
-
-#include <util/irep.h>
+#include <vector>
 
 class exprt;
 class symex_target_equationt;
+class SSA_stept; // IWYU pragma: keep
 
 // slice an equation with respect to the assertions contained therein
 void slice(symex_target_equationt &equation);
@@ -41,5 +43,18 @@ typedef std::unordered_set<irep_idt> symbol_sett;
 void collect_open_variables(
   const symex_target_equationt &equation,
   symbol_sett &open_variables);
+
+/// Compute the cone of influence for a single assertion.
+/// Walks backwards from \p assertion_step through \p steps, collecting
+/// all steps that the assertion depends on (assignments defining symbols
+/// used in the assertion condition/guard, assumptions, and constraints).
+/// \param steps: the SSA steps to search (up to \p num_steps entries)
+/// \param assertion_step: iterator pointing to the assertion
+/// \param num_steps: number of steps to consider from the beginning
+/// \return pointers to the steps in the cone (including the assertion)
+std::vector<const SSA_stept *> cone_of_influence(
+  const std::list<SSA_stept> &steps,
+  std::list<SSA_stept>::const_iterator assertion_step,
+  std::size_t num_steps);
 
 #endif // CPROVER_GOTO_SYMEX_SLICE_H

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -616,6 +616,117 @@ void symex_target_equationt::convert_assertions(
     });
 }
 
+std::optional<symbol_exprt>
+symex_target_equationt::convert_assertions_incremental(
+  decision_proceduret &decision_procedure)
+{
+  // Always iterate from the beginning to re-convert all assertions
+  // with the current (complete) assumption. Earlier assertions may
+  // have been converted with a partial assumption that was missing
+  // later SSA constraints.
+  SSA_stepst::iterator start = SSA_steps.begin();
+
+  // Count unconverted assertions from where we left off
+  std::size_t number_of_new_assertions = 0;
+  for(auto it = start; it != SSA_steps.end(); ++it)
+  {
+    if(it->is_assert() && !it->ignore && !it->converted)
+      ++number_of_new_assertions;
+  }
+
+  if(number_of_new_assertions == 0)
+    return current_goal_extender;
+
+  // Rebuild the full assumption from ALL assume steps from the beginning
+  // up to the start of the new batch. We must use the current cond_handle
+  // values (set by convert_assumptions) rather than cached ones, because
+  // convert_without_assertions may have been called between incremental
+  // calls, potentially changing the handles.
+  exprt assumption = true_exprt();
+  for(auto it = SSA_steps.begin(); it != start; ++it)
+  {
+    if(it->is_assume() && !it->ignore)
+    {
+      if(assumption.id() == ID_and)
+        assumption.copy_to_operands(it->cond_handle);
+      else
+        assumption = and_exprt(assumption, it->cond_handle);
+    }
+  }
+
+  // Build disjuncts for the new assertions
+  or_exprt::operandst disjuncts;
+  disjuncts.reserve(number_of_new_assertions + 1);
+
+  // On subsequent calls, link to the previous goal extender.
+  // NOT(old_goal_extender) means: if we drop the old extender
+  // (by NOT assuming it false), the old assertions must still
+  // be checked.
+  if(current_goal_extender.has_value())
+    disjuncts.push_back(not_exprt(current_goal_extender.value()));
+
+  std::vector<goto_programt::const_targett> involved_steps;
+
+  SSA_stepst::iterator last_it = start;
+  for(auto it = start; it != SSA_steps.end(); ++it)
+  {
+    auto &step = *it;
+    last_it = it;
+
+    // hide already converted assertions in the error trace
+    if(step.is_assert() && step.converted)
+      step.hidden = true;
+
+    if(step.is_assert() && !step.ignore && !step.converted)
+    {
+
+      log.conditional_output(
+        log.debug(),
+        [&step](messaget::mstreamt &mstream)
+        {
+          step.output(mstream);
+          mstream << messaget::eom;
+        });
+
+      implies_exprt implication(assumption, step.cond_expr);
+
+      // do the conversion
+      step.cond_handle = decision_procedure.handle(implication);
+
+      with_solver_hardness(
+        decision_procedure,
+        [&involved_steps, &step](solver_hardnesst &hardness)
+        { involved_steps.push_back(step.source.pc); });
+
+      // store disjunct
+      disjuncts.push_back(not_exprt(step.cond_handle));
+    }
+    else if(step.is_assume())
+    {
+      // the assumptions have been converted before
+      // avoid deep nesting of ID_and expressions
+      if(assumption.id() == ID_and)
+        assumption.copy_to_operands(step.cond_handle);
+      else
+      {
+        assumption =
+          and_exprt(assumption, step.cond_handle);
+      }
+
+      with_solver_hardness(
+        decision_procedure,
+        [&involved_steps, &step](solver_hardnesst &hardness)
+        { involved_steps.push_back(step.source.pc); });
+    }
+  }
+
+  // Save iterator to the last element we processed
+  if(!SSA_steps.empty())
+    incremental_last_converted = std::prev(SSA_steps.end());
+
+  return std::nullopt;
+}
+
 void symex_target_equationt::convert_function_calls(
   decision_proceduret &decision_procedure)
 {

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -679,7 +679,6 @@ symex_target_equationt::convert_assertions_incremental(
 
     if(step.is_assert() && !step.ignore && !step.converted)
     {
-
       log.conditional_output(
         log.debug(),
         [&step](messaget::mstreamt &mstream)
@@ -709,8 +708,7 @@ symex_target_equationt::convert_assertions_incremental(
         assumption.copy_to_operands(step.cond_handle);
       else
       {
-        assumption =
-          and_exprt(assumption, step.cond_handle);
+        assumption = and_exprt(assumption, step.cond_handle);
       }
 
       with_solver_hardness(

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -294,7 +294,10 @@ public:
       step.validate(ns, vm);
   }
 
-  void set_message_handler(message_handlert &mh) { log.set_message_handler(mh); }
+  void set_message_handler(message_handlert &mh)
+  {
+    log.set_message_handler(mh);
+  }
 
   /// Swap the merge_irep instance. Returns the old one.
   /// Used to isolate irep sharing during concurrent access.
@@ -303,6 +306,7 @@ public:
     std::swap(merge_irep, other);
     return other;
   }
+
 protected:
   messaget log;
 

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -12,10 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_SYMEX_SYMEX_TARGET_EQUATION_H
 #define CPROVER_GOTO_SYMEX_SYMEX_TARGET_EQUATION_H
 
-#include <algorithm>
-#include <iosfwd>
-#include <list>
-
 #include <util/invariant.h>
 #include <util/merge_irep.h>
 #include <util/message.h>
@@ -23,6 +19,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ssa_step.h"
 #include "symex_target.h"
+
+#include <algorithm>
+#include <iosfwd>
+#include <list>
+#include <optional>
 
 class decision_proceduret;
 class namespacet;
@@ -206,6 +207,17 @@ public:
     decision_proceduret &decision_procedure,
     bool optimized_for_single_assertions = true);
 
+  /// Convert assertions incrementally, returning a goal extender variable.
+  /// The caller should assume the returned symbol to be false when invoking
+  /// the solver. On subsequent calls, new assertions are linked to the
+  /// previous goal extender, enabling incremental extension of the
+  /// assertion disjunction without rebuilding it from scratch.
+  /// \param decision_procedure: A handle to a decision procedure interface
+  /// \return The goal extender symbol that should be assumed false, or
+  ///   empty if there are no assertions to convert
+  std::optional<symbol_exprt>
+  convert_assertions_incremental(decision_proceduret &decision_procedure);
+
   /// Converts constraints: set the represented condition to _True_.
   /// \param decision_procedure: A handle to a decision procedure interface
   void convert_constraints(decision_proceduret &decision_procedure);
@@ -282,6 +294,15 @@ public:
       step.validate(ns, vm);
   }
 
+  void set_message_handler(message_handlert &mh) { log.set_message_handler(mh); }
+
+  /// Swap the merge_irep instance. Returns the old one.
+  /// Used to isolate irep sharing during concurrent access.
+  merge_irept swap_merge_irep(merge_irept other)
+  {
+    std::swap(merge_irep, other);
+    return other;
+  }
 protected:
   messaget log;
 
@@ -294,6 +315,11 @@ protected:
 
   // for unique function call argument identifiers
   std::size_t argument_count = 0;
+
+  // for incremental goal construction
+  std::size_t goal_extender_counter = 0;
+  std::optional<symbol_exprt> current_goal_extender;
+  std::optional<SSA_stepst::iterator> incremental_last_converted;
 };
 
 inline bool operator<(

--- a/src/goto-synthesizer/Makefile
+++ b/src/goto-synthesizer/Makefile
@@ -38,7 +38,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
 
 INCLUDES= -I ..
 
-LIBS =
+LIBS = -lpthread
 
 CLEANFILES = goto-synthesizer$(EXEEXT) goto-synthesizer$(LIBEXT)
 

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -10,11 +10,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_IREP_H
 #define CPROVER_UTIL_IREP_H
 
-#include <string>
-#include <vector>
-
 #include "invariant.h"
 #include "irep_ids.h"
+
+#include <atomic>
+#include <string>
+#include <vector>
 
 #define SHARING
 #ifndef HASH_CODE
@@ -64,7 +65,17 @@ struct ref_count_ift
 template <>
 struct ref_count_ift<true>
 {
-  unsigned ref_count = 1;
+  mutable std::atomic<unsigned> ref_count{1};
+
+  ref_count_ift() = default;
+  ref_count_ift(const ref_count_ift &) : ref_count{1}
+  {
+  }
+  ref_count_ift &operator=(const ref_count_ift &)
+  {
+    // Don't copy ref_count — new copy starts at 1.
+    return *this;
+  }
 };
 
 /// A node with data in a tree, it contains:
@@ -557,8 +568,7 @@ void sharing_treet<derivedt, named_subtreest>::remove_ref(dt *old_data)
   std::cout << "R: " << old_data << " " << old_data->ref_count << '\n';
 #endif
 
-  old_data->ref_count--;
-  if(old_data->ref_count == 0)
+  if(old_data->ref_count.fetch_sub(1) == 1)
   {
 #ifdef IREP_DEBUG
     std::cout << "D: " << pretty() << '\n';
@@ -593,9 +603,8 @@ void sharing_treet<derivedt, named_subtreest>::nonrecursive_destructor(
       continue;
 
     INVARIANT(d->ref_count != 0, "All contents of the stack must be in use");
-    d->ref_count--;
 
-    if(d->ref_count == 0)
+    if(d->ref_count.fetch_sub(1) == 1)
     {
       stack.reserve(
         stack.size() + std::distance(d->named_sub.begin(), d->named_sub.end()) +

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -317,6 +317,8 @@ memory-analyzer/test.inc: memory-analyzer/test.c
 
 memory-analyzer/gdb_api$(OBJEXT): memory-analyzer/input.inc memory-analyzer/test.inc
 
+LIBS = -lpthread
+
 CLEANFILES = $(CATCH_TEST) testing-utils/testing-utils$(LIBEXT) \
              memory-analyzer/input.inc memory-analyzer/test.inc gdb.txt
 


### PR DESCRIPTION
This PR implements incremental symbolic execution where the SAT solver can be invoked at intermediate points during symex, as described in tautschnig/cbmc-private#880.

## Changes

### Incremental goal construction (`convert_assertions_incremental`)

Assertions are converted with proper path assumptions, allowing the equation to grow incrementally without rebuilding earlier clauses. The existing `--incremental-loop` checker is updated to use this.

### Periodic checker (`--incremental-check-interval N`)

Pauses symex every N steps. Includes adaptive early pausing when new assertions appear. Assertions are checked definitively only on the complete equation (checking partial equations creates permanent Tseitin clauses that corrupt the formula — see commit message for details).

Speculative checks run on partial equations using a fresh solver instance that is discarded after the check, providing early hints about potential failures without polluting the main solver.

### Concurrent checker (`--concurrent-incremental`)

Runs symex in a separate thread. Pipelined: symex resumes during `solve()`, overlapping compute-bound work. Reduced solver iterations from 5 to 3 on test programs.

### Thread-safe irept

`irept` reference counting uses `std::atomic<unsigned>` (~2% overhead, within noise). Per-thread `merge_irept` isolation and thread-local `stream_message_handlert` enable the speculative solver thread to run concurrently with symex.

## Testing

- 10 new regression tests (pass/fail for periodic, concurrent, equivalence, early detection)
- Verified sound on aws-c-common `aws_array_list_back` proof (0 of 3947 false positives)
- All existing `cbmc-incr-oneloop` and `cbmc` CORE tests pass
- Benchmark script (`scripts/bench_incremental.sh`) for aws-c-common

## Performance

| Mode | aws_array_list_back (3947 props) |
|------|----------------------------------|
| Baseline | 3.2s |
| `--concurrent-incremental` | 2.8s (12% faster) |
| `--incremental-check-interval` (speculative) | 6.9s (overhead from fresh solver per check) |

## Limitations

- Speculative checks on partial equations are hints only (not definitive) due to missing SSA constraints
- The speculative solver overhead (~2x) comes from creating a fresh solver instance per check; reusing solvers incrementally is future work
- `--incremental-loop` takes priority when combined with `--incremental-check-interval`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
