### PR TITLE
Connect let-bound arrays to originals in array theory

### DIFF
--- a/regression/smt2_solver/let-array/let-array.desc
+++ b/regression/smt2_solver/let-array/let-array.desc
@@ -1,0 +1,11 @@
+CORE
+let-array.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--
+^sat$
+--
+Let-bound arrays must be connected to the original array in the
+array theory so that element-wise constraints propagate correctly.

--- a/regression/smt2_solver/let-array/let-array.smt2
+++ b/regression/smt2_solver/let-array/let-array.smt2
@@ -1,0 +1,11 @@
+; Test that let-bound arrays are properly connected to the original
+; array in the array theory. A let binding creates a fresh symbol
+; internally; without proper connection, the element-wise constraints
+; on the original array don't propagate to the let-bound copy.
+(set-option :produce-models true)
+(declare-fun arr () (Array (_ BitVec 32) (_ BitVec 32)))
+(assert (= (select arr (_ bv0 32)) (_ bv42 32)))
+(assert (= (select arr (_ bv1 32)) (_ bv99 32)))
+(assert (not (= (let ((?a arr)) (select ?a (_ bv1 32))) (_ bv99 32))))
+(check-sat)
+(exit)

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -80,6 +80,19 @@ literalt arrayst::record_array_equality(
   return array_equalities.back().l;
 }
 
+void arrayst::record_array_let_binding(
+  const symbol_exprt &symbol,
+  const exprt &value)
+{
+  DATA_INVARIANT(
+    symbol.type().id() == ID_array,
+    "record_array_let_binding parameter should be array-typed");
+
+  const equal_exprt eq{symbol, value};
+  const literalt eq_lit = record_array_equality(eq);
+  prop.l_set_to_true(eq_lit);
+}
+
 void arrayst::collect_indices()
 {
   for(std::size_t i=0; i<arrays.size(); i++)

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -26,6 +26,7 @@ class array_of_exprt;
 class equal_exprt;
 class if_exprt;
 class index_exprt;
+class symbol_exprt;
 class with_exprt;
 class update_exprt;
 
@@ -51,6 +52,12 @@ public:
 
   literalt record_array_equality(const equal_exprt &expr);
   void record_array_index(const index_exprt &expr);
+
+  /// Record that \p symbol is equal to \p value for the purposes of the
+  /// array theory. For unbounded-array-typed bindings this connects the
+  /// two expressions in the union-find so that element-wise constraints
+  /// propagate correctly.
+  void record_array_let_binding(const symbol_exprt &symbol, const exprt &value);
 
 protected:
   const namespacet &ns;

--- a/src/solvers/flattening/boolbv_let.cpp
+++ b/src/solvers/flattening/boolbv_let.cpp
@@ -6,11 +6,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include "boolbv.h"
-
+#include <util/byte_operators.h>
 #include <util/range.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
+
+#include "boolbv.h"
 
 bvt boolbvt::convert_let(const let_exprt &expr)
 {
@@ -68,6 +69,20 @@ bvt boolbvt::convert_let(const let_exprt &expr)
 
   for(const auto &pair : make_range(variables).zip(fresh_variables))
     replace_symbol.insert(pair.first, pair.second);
+
+  // Connect fresh let-bound symbols to their values in the array theory.
+  for(const auto &pair : make_range(fresh_variables).zip(values))
+  {
+    if(
+      pair.first.type().id() == ID_array &&
+      is_unbounded_array(to_array_type(pair.first.type())))
+    {
+      const exprt lowered_value = has_byte_operator(pair.second)
+                                    ? lower_byte_operators(pair.second, ns)
+                                    : pair.second;
+      record_array_let_binding(pair.first, pair.second);
+    }
+  }
 
   // rename the bound symbols in 'where'
   exprt where_renamed = expr.where();


### PR DESCRIPTION
When a let expression binds a variable to an array value, the fresh symbol and the original array are disconnected in the array theory's union-find. This means Ackermann constraints and element-wise equality constraints don't propagate between them, causing spurious counterexamples in smt2_solver.

Fix: in convert_let, for array-typed bindings with unbounded array type, call record_array_equality to create an element-wise equality between the fresh variable and the bound value, and assert it as true. This connects the two representations so the array theory generates proper constraints.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
