### PR TITLE
Simplify bitwise operations over concatenation and a constant

### DIFF
--- a/regression/cbmc/simplify-bitand-concat/main.c
+++ b/regression/cbmc/simplify-bitand-concat/main.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <stdint.h>
+
+// Reinterpreting the bytes of a multi-byte integer produces, during symbolic
+// execution, a bitwise-and of a concatenation of the individual bytes with a
+// constant mask.  The simplifier distributes the mask over the concatenation
+// and simplifies each slice (an all-zero mask slice yields a zero byte, an
+// all-one slice yields the byte unchanged).  This test exercises that path
+// end-to-end.
+
+union u32_bytes
+{
+  uint32_t value;
+  uint8_t bytes[4];
+};
+
+int main()
+{
+  union u32_bytes u;
+  uint8_t b0, b1, b2, b3;
+  u.bytes[0] = b0;
+  u.bytes[1] = b1;
+  u.bytes[2] = b2;
+  u.bytes[3] = b3;
+
+  // Little-endian: bytes[0] is the least significant byte.  The mask keeps
+  // bytes 0 and 2 (all-one slices) and clears bytes 1 and 3 (all-zero slices).
+  const uint32_t masked = u.value & 0x00FF00FFu;
+
+  assert((masked & 0xFFu) == b0);
+  assert(((masked >> 8) & 0xFFu) == 0u);
+  assert(((masked >> 16) & 0xFFu) == b2);
+  assert(((masked >> 24) & 0xFFu) == 0u);
+
+  return 0;
+}

--- a/regression/cbmc/simplify-bitand-concat/test.desc
+++ b/regression/cbmc/simplify-bitand-concat/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -858,6 +858,65 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
   if(new_expr.operands().size() == 1)
     return new_expr.op0();
 
+  // distribute bitwise op over concatenation when the other operand is
+  // constant: apply the op point-wise to each concatenation operand and the
+  // matching slice of the constant, so that constant operands (or all-zero /
+  // all-one slices of the mask) yield simplified slices
+  if(
+    new_expr.operands().size() == 2 &&
+    (new_expr.operands().front().is_constant() ||
+     new_expr.operands().back().is_constant()) &&
+    (new_expr.operands().front().id() == ID_concatenation ||
+     new_expr.operands().back().id() == ID_concatenation))
+  {
+    const exprt &op0 = new_expr.operands().front();
+    const exprt &op1 = new_expr.operands().back();
+    const exprt &constant = op0.is_constant() ? op0 : op1;
+    const auto svalue = expr2bits(constant, true, ns);
+    if(!svalue.has_value() || svalue->size() != width)
+      return unchanged(expr);
+
+    concatenation_exprt new_concat =
+      to_concatenation_expr(op0.id() == ID_concatenation ? op0 : op1);
+    // the most-significant bit comes first in an concatenation_exprt, hence we
+    // count down
+    std::size_t offset = width;
+    // only rewrite if at least one slice actually simplifies, to avoid growing
+    // the expression for a "neutral" mask over non-constant operands
+    bool any_simplified = false;
+    for(auto &op : new_concat.operands())
+    {
+      auto op_width = pointer_offset_bits(op.type(), ns);
+      if(!op_width.has_value() || *op_width <= 0 || *op_width > offset)
+        return unchanged(expr);
+      std::size_t op_width_int = numeric_cast_v<std::size_t>(*op_width);
+
+      std::string extracted_value =
+        svalue->substr(offset - op_width_int, op_width_int);
+
+      // a slice of all-zeros or all-ones, or a constant concatenation operand,
+      // collapses under the bitwise op
+      if(
+        extracted_value.find('1') == std::string::npos ||
+        extracted_value.find('0') == std::string::npos || op.is_constant())
+      {
+        any_simplified = true;
+      }
+
+      auto op_bits = bits2expr(extracted_value, op.type(), true, ns);
+      if(!op_bits.has_value())
+        return unchanged(expr);
+      op = simplify_bitwise(multi_ary_exprt{op, expr.id(), *op_bits}).expr;
+
+      offset -= op_width_int;
+    }
+
+    if(!any_simplified)
+      return unchanged(expr);
+
+    return changed(simplify_concatenation(new_concat));
+  }
+
   if(no_change)
     return unchanged(expr);
   else

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -769,3 +769,127 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, ns) == true_exprt{});
 }
+
+TEST_CASE("Simplify bitand over concatenation and constant", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // (concat(a, b)) & 0x00FF -> concat(0x00, b & 0xFF)
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const constant_exprt mask = from_integer(0xFF, u16);
+  const bitand_exprt band{cat, mask};
+  const auto result = simplify_expr(band, ns);
+
+  // Expect concat(0x00, b) because a & 0x00 -> 0x00 and b & 0xFF -> b
+  const constant_exprt zero8 = from_integer(0, u8);
+  const concatenation_exprt expected{{zero8, b}, u16};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE("Simplify bitor over concatenation and constant", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // concat(a, b) | 0xFF00 -> concat(0xFF, b)
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const bitor_exprt expr{cat, from_integer(0xFF00, u16)};
+  const auto result = simplify_expr(expr, ns);
+
+  // a | 0xFF -> 0xFF and b | 0x00 -> b
+  const concatenation_exprt expected{{from_integer(0xFF, u8), b}, u16};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE("Simplify bitxor over concatenation and constant", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // concat(a, b) ^ 0x00FF -> concat(a, b ^ 0xFF)
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const bitxor_exprt expr{cat, from_integer(0x00FF, u16)};
+  const auto result = simplify_expr(expr, ns);
+
+  // a ^ 0x00 -> a; b ^ 0xFF does not reduce further
+  const bitxor_exprt b_masked{b, from_integer(0xFF, u8)};
+  const concatenation_exprt expected{{a, b_masked}, u16};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE(
+  "Simplify bitand over concatenation and constant (constant on the left)",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // 0x00FF & concat(a, b) -> concat(0x00, b), exercising the constant-on-LHS
+  // branch
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const bitand_exprt expr{from_integer(0x00FF, u16), cat};
+  const auto result = simplify_expr(expr, ns);
+
+  const concatenation_exprt expected{{from_integer(0, u8), b}, u16};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE(
+  "Simplify bitand over a three-operand concatenation and constant",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // concat(a, b, c) & 0x00FF00 -> concat(0x00, b, 0x00)
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u24{24};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const symbol_exprt c{"c", u8};
+  const concatenation_exprt cat{{a, b, c}, u24};
+  const bitand_exprt expr{cat, from_integer(0x00FF00, u24)};
+  const auto result = simplify_expr(expr, ns);
+
+  const constant_exprt zero8 = from_integer(0, u8);
+  const concatenation_exprt expected{{zero8, b, zero8}, u24};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE(
+  "Simplify bitand over concatenation leaves a neutral mask unchanged",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // concat(a, b) & 0xABCD has no all-zero / all-one slice and no constant
+  // operand, so distributing it would only grow the expression: it is left
+  // unchanged.
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const bitand_exprt expr{cat, from_integer(0xABCD, u16)};
+  const auto result = simplify_expr(expr, ns);
+
+  REQUIRE(result == expr);
+}


### PR DESCRIPTION
Perform point-wise application of the bitwise operation and concatenate the result: if some of the operands of the concatenation were constants the bitwise operation will yield modified constants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
