### PR TITLE
Simplify more cases of extractbits over concatenation

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -155,6 +155,8 @@ public:
   [[nodiscard]] resultt<> simplify_typecast_preorder(const typecast_exprt &);
   [[nodiscard]] resultt<> simplify_extractbit(const extractbit_exprt &);
   [[nodiscard]] resultt<> simplify_extractbits(const extractbits_exprt &);
+  [[nodiscard]] resultt<>
+  simplify_extractbits_over_concatenation(const extractbits_exprt &);
   [[nodiscard]] resultt<> simplify_concatenation(const concatenation_exprt &);
   [[nodiscard]] resultt<> simplify_zero_extend(const zero_extend_exprt &);
   [[nodiscard]] resultt<> simplify_mult(const mult_exprt &);

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1231,30 +1231,18 @@ simplify_exprt::simplify_extractbits(const extractbits_exprt &expr)
 
     return std::move(*result);
   }
+  else if(*end == 0 && *start + 1 == *width)
+  {
+    // This must precede the concatenation case below: that case recurses on a
+    // smaller extract over a reduced concatenation, and when the reduced
+    // extract covers the whole reduced concatenation it relies on this branch
+    // to collapse to a typecast/identity.
+    typecast_exprt tc{expr.src(), expr.type()};
+    return changed(simplify_typecast(tc));
+  }
   else if(expr.src().id() == ID_concatenation)
   {
-    // the most-significant bit comes first in an concatenation_exprt, hence we
-    // count down
-    mp_integer offset = *width;
-
-    for(const auto &op : expr.src().operands())
-    {
-      auto op_width = pointer_offset_bits(op.type(), ns);
-
-      if(!op_width.has_value() || *op_width <= 0)
-        return unchanged(expr);
-
-      if(*start < offset && offset <= *end + *op_width)
-      {
-        extractbits_exprt result = expr;
-        result.src() = op;
-        result.index() =
-          from_integer(*end - (offset - *op_width), expr.index().type());
-        return changed(simplify_extractbits(result));
-      }
-
-      offset -= *op_width;
-    }
+    return simplify_extractbits_over_concatenation(expr);
   }
   else if(auto eb_src = expr_try_dynamic_cast<extractbits_exprt>(expr.src()))
   {
@@ -1268,10 +1256,76 @@ simplify_exprt::simplify_extractbits(const extractbits_exprt &expr)
       return changed(simplify_extractbits(result));
     }
   }
-  else if(*end == 0 && *start + 1 == *width)
+
+  return unchanged(expr);
+}
+
+simplify_exprt::resultt<>
+simplify_exprt::simplify_extractbits_over_concatenation(
+  const extractbits_exprt &expr)
+{
+  PRECONDITION(expr.src().id() == ID_concatenation);
+
+  const auto end = numeric_cast<mp_integer>(expr.index());
+  const auto width = pointer_offset_bits(expr.src().type(), ns);
+  const auto result_width = pointer_offset_bits(expr.type(), ns);
+  // these are all guaranteed by simplify_extractbits, which is our only caller
+  PRECONDITION(
+    end.has_value() && width.has_value() && result_width.has_value());
+  const mp_integer start = *end + *result_width - 1;
+
+  // the most-significant bit comes first in an concatenation_exprt, hence we
+  // count down
+  mp_integer offset = *width;
+
+  exprt::operandst new_operands;
+  new_operands.reserve(expr.src().operands().size());
+  mp_integer new_index = *end;
+  mp_integer new_concat_width = 0;
+
+  for(const auto &op : expr.src().operands())
   {
-    typecast_exprt tc{expr.src(), expr.type()};
-    return changed(simplify_typecast(tc));
+    auto op_width = pointer_offset_bits(op.type(), ns);
+
+    if(!op_width.has_value() || *op_width <= 0)
+      return unchanged(expr);
+
+    // current value of offset is the index (within the concatenated
+    // expression) of the most-significant bit of op plus 1
+    if(*end >= offset)
+    {
+      // Operand is entirely below the extracted range.
+      // Adjust new_index to account for the removed operand.
+      new_index -= *op_width;
+    }
+    else if(offset - *op_width <= start)
+    {
+      new_operands.push_back(op);
+      new_concat_width += *op_width;
+    }
+
+    offset -= *op_width;
+  }
+
+  if(new_operands.size() == 1)
+  {
+    extractbits_exprt result = expr;
+    result.src() = new_operands.front();
+    result.index() = from_integer(new_index, expr.index().type());
+    return changed(simplify_extractbits(result));
+  }
+  else if(
+    !new_operands.empty() && new_operands.size() < expr.src().operands().size())
+  {
+    bitvector_typet new_type = to_bitvector_type(expr.src().type());
+    new_type.set_width(numeric_cast_v<std::size_t>(new_concat_width));
+    concatenation_exprt new_concat{
+      std::move(new_operands), std::move(new_type)};
+    extractbits_exprt result{
+      std::move(new_concat),
+      from_integer(new_index, expr.index().type()),
+      expr.type()};
+    return changed(simplify_extractbits(result));
   }
 
   return unchanged(expr);

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -710,3 +710,82 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, empty_namespace) == true_exprt{});
 }
+
+TEST_CASE("Simplify extractbits over concatenation", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // extractbits(concat(a, b), 0, u8) where a,b are 8-bit -> b
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const extractbits_exprt extract{cat, from_integer(0, u16), u8};
+  const auto result = simplify_expr(extract, ns);
+  REQUIRE(result == b);
+}
+
+TEST_CASE("Simplify extractbits dropping trailing operand", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // extractbits(concat(a, b, c), start=23, end=8) where a,b,c are 8-bit
+  // should drop c and simplify to concat(a, b) or equivalent
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const unsignedbv_typet u24{24};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const symbol_exprt c{"c", u8};
+  const concatenation_exprt cat{{a, b, c}, u24};
+  const extractbits_exprt extract{cat, from_integer(8, u24), u16};
+  const auto result = simplify_expr(extract, ns);
+  // c is entirely below the extracted range and should be dropped
+  const concatenation_exprt expected{{a, b}, u16};
+  REQUIRE(result == expected);
+}
+
+TEST_CASE(
+  "Simplify extractbits dropping leading and trailing operands",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // extractbits(concat(a, b, c), end=8, u8) where a,b,c are 8-bit -> b:
+  // a is entirely above and c entirely below the extracted range, so both
+  // are dropped in a single call (exercises the new_index decrement together
+  // with reducing the concatenation to a single surviving operand).
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u24{24};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const symbol_exprt c{"c", u8};
+  const concatenation_exprt cat{{a, b, c}, u24};
+  const extractbits_exprt extract{cat, from_integer(8, u24), u8};
+  REQUIRE(simplify_expr(extract, ns) == b);
+}
+
+TEST_CASE(
+  "Simplify extractbits within a single operand of a concatenation",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  // extractbits(concat(a, b), end=2, u4) where a,b are 8-bit: the extracted
+  // range lies entirely within b, so this reduces to extractbits(b, 2, u4).
+  // Guards the pre-existing single-operand simplification.
+  const unsignedbv_typet u4{4};
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+  const concatenation_exprt cat{{a, b}, u16};
+  const extractbits_exprt extract{cat, from_integer(2, u16), u4};
+  const extractbits_exprt expected{b, from_integer(2, u16), u4};
+  REQUIRE(simplify_expr(extract, ns) == expected);
+}


### PR DESCRIPTION
We may be able to drop some of the operands of a concatenation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
