### PR TITLE
Simplify (x * n) % n

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -366,6 +366,21 @@ simplify_exprt::resultt<> simplify_exprt::simplify_div(const div_exprt &expr)
   return unchanged(expr);
 }
 
+/// Is \p expr a binary multiplication that has \p factor as one of its
+/// constant operands?
+static bool
+is_multiplication_with_factor(const exprt &expr, const mp_integer &factor)
+{
+  if(expr.id() != ID_mult || expr.operands().size() != 2)
+    return false;
+  const auto &mul = to_mult_expr(expr);
+  const auto c0 = numeric_cast<mp_integer>(mul.op0());
+  if(c0.has_value() && *c0 == factor)
+    return true;
+  const auto c1 = numeric_cast<mp_integer>(mul.op1());
+  return c1.has_value() && *c1 == factor;
+}
+
 simplify_exprt::resultt<> simplify_exprt::simplify_mod(const mod_exprt &expr)
 {
   if(!is_number(expr.type()))
@@ -396,6 +411,43 @@ simplify_exprt::resultt<> simplify_exprt::simplify_mod(const mod_exprt &expr)
       {
         mp_integer result = *int_value0 % *int_value1;
         return from_integer(result, expr.type());
+      }
+
+      // (x * n) % n simplifies to zero.  Crucially we only ever conclude a
+      // *zero* remainder, and that is independent of the modulo convention:
+      // truncated (C), floored and Euclidean modulo differ only in how they
+      // round a non-integer quotient, i.e. only when the remainder is
+      // non-zero.  They all agree that a % n == 0 exactly when n divides a,
+      // so we need not assume any particular semantics for negative
+      // operands -- it suffices that n divides the value of x * n.
+      //
+      // For mathematical integers x * n is exact and n always divides it,
+      // for any sign of x and n.  For bitvector types multiplication wraps
+      // modulo 2^width; that wrap preserves divisibility by n exactly when
+      // |n| divides 2^width, and then the wrapped product is a multiple of n
+      // for every x.  This is necessary and sufficient and is tested by
+      // power(2, width) % n == 0.  Divisibility is sign-independent, so the
+      // test also admits negative power-of-two-magnitude moduli (e.g.
+      // n == -8: 2^width % -8 == 0, and (x * -8) % -8 is zero under any
+      // convention); hence no sign restriction on the modulus is needed.
+      if(int_value1.has_value())
+      {
+        const auto &type_id = expr.type().id();
+        bool can_simplify = (type_id == ID_integer || type_id == ID_natural);
+
+        if(
+          !can_simplify && (type_id == ID_unsignedbv || type_id == ID_signedbv))
+        {
+          const auto width = to_bitvector_type(expr.type()).get_width();
+          can_simplify = (power(2, width) % *int_value1 == 0);
+        }
+
+        if(
+          can_simplify &&
+          is_multiplication_with_factor(expr.op0(), *int_value1))
+        {
+          return from_integer(0, expr.type());
+        }
       }
     }
   }

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -710,3 +710,90 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, empty_namespace) == true_exprt{});
 }
+
+TEST_CASE("Simplify (x * n) % n", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  SECTION("Integer type: always simplifies")
+  {
+    const integer_typet int_type;
+    const symbol_exprt x{"x", int_type};
+    const auto n = from_integer(7, int_type);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{x, n}, n}, ns) ==
+      from_integer(0, int_type));
+  }
+
+  SECTION("Natural type: always simplifies")
+  {
+    const natural_typet nat_type;
+    const symbol_exprt x{"x", nat_type};
+    const auto n = from_integer(7, nat_type);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{x, n}, n}, ns) ==
+      from_integer(0, nat_type));
+  }
+
+  SECTION("Constant on the left: (n * x) % n simplifies")
+  {
+    const integer_typet int_type;
+    const symbol_exprt x{"x", int_type};
+    const auto n = from_integer(7, int_type);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{n, x}, n}, ns) ==
+      from_integer(0, int_type));
+  }
+
+  SECTION("Unsigned bitvector with power-of-two modulus: simplifies")
+  {
+    const unsignedbv_typet u32{32};
+    const symbol_exprt x{"x", u32};
+    const auto n = from_integer(8, u32);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{x, n}, n}, ns) ==
+      from_integer(0, u32));
+  }
+
+  SECTION("Unsigned bitvector with non-power-of-two modulus: no simplification")
+  {
+    const unsignedbv_typet u32{32};
+    const symbol_exprt x{"x", u32};
+    const auto n = from_integer(7, u32);
+    const mod_exprt mod{mult_exprt{x, n}, n};
+    REQUIRE(simplify_expr(mod, ns) == mod);
+  }
+
+  SECTION("Signed bitvector with power-of-two modulus: simplifies")
+  {
+    const signedbv_typet s32{32};
+    const symbol_exprt x{"x", s32};
+    const auto n = from_integer(8, s32);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{x, n}, n}, ns) ==
+      from_integer(0, s32));
+  }
+
+  SECTION("Signed bitvector with non-power-of-two modulus: no simplification")
+  {
+    const signedbv_typet s32{32};
+    const symbol_exprt x{"x", s32};
+    const auto n = from_integer(7, s32);
+    const mod_exprt mod{mult_exprt{x, n}, n};
+    REQUIRE(simplify_expr(mod, ns) == mod);
+  }
+
+  SECTION("Signed bitvector with negative power-of-two modulus: simplifies")
+  {
+    // |n| divides 2^width, so the wrapped product is a multiple of n and the
+    // remainder is zero under any modulo convention; no positivity of the
+    // modulus is required.
+    const signedbv_typet s32{32};
+    const symbol_exprt x{"x", s32};
+    const auto n = from_integer(-8, s32);
+    REQUIRE(
+      simplify_expr(mod_exprt{mult_exprt{x, n}, n}, ns) ==
+      from_integer(0, s32));
+  }
+}


### PR DESCRIPTION
Multiplying and then taking the modulus always yields zero.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
