### PR TITLE
Simplify shifts of concatenations

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -168,6 +168,7 @@ public:
   [[nodiscard]] resultt<>
   simplify_floatbv_typecast(const floatbv_typecast_exprt &);
   [[nodiscard]] resultt<> simplify_shifts(const shift_exprt &);
+  [[nodiscard]] resultt<> simplify_shift_of_concatenation(const shift_exprt &);
   [[nodiscard]] resultt<> simplify_power(const power_exprt &);
   [[nodiscard]] resultt<> simplify_bitwise(const multi_ary_exprt &);
   [[nodiscard]] resultt<> simplify_if_preorder(const if_exprt &expr);

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1046,6 +1046,100 @@ simplify_exprt::simplify_zero_extend(const zero_extend_exprt &expr)
 }
 
 simplify_exprt::resultt<>
+simplify_exprt::simplify_shift_of_concatenation(const shift_exprt &expr)
+{
+  // Shifts of a concatenation by an amount that lines up with an operand
+  // boundary can be rewritten by dropping operands and padding with zeros:
+  //   concat(op_0, ..., op_{n-1}) >> d == concat(0_d, op_0, ..., op_{k-1})
+  //   concat(op_0, ..., op_{n-1}) << d == concat(op_{k+1}, ..., op_{n-1}, 0_d)
+  // where k is the unique index for which the widths of op_k..op_{n-1}
+  // (resp. op_0..op_k) sum to d. We only fire when d aligns exactly with an
+  // operand boundary; mis-aligned cases fall through to the caller's other
+  // simplifications.
+  PRECONDITION(expr.op().id() == ID_concatenation);
+  PRECONDITION(expr.id() == ID_lshr || expr.id() == ID_shl);
+
+  const auto distance = numeric_cast<mp_integer>(expr.distance());
+  if(!distance.has_value() || *distance <= 0)
+    return unchanged(expr);
+
+  const mp_integer total_width =
+    to_bitvector_type(expr.op().type()).get_width();
+
+  // A shift by at least the full width discards every operand: collapse to a
+  // bare zero rather than producing the morally-equivalent but ugly
+  // concat(0_W) (simplify_concatenation does not fold single-operand concats).
+  if(*distance >= total_width)
+    return changed(from_integer(0, expr.type()));
+
+  // Walk the operands left-to-right, maintaining two complementary cursors:
+  //   offset: bits remaining to the right of the current operand boundary,
+  //           shrinking from total_width to 0;
+  //   bits_seen: bits already passed on the left, growing from 0 to
+  //              total_width.
+  // The lshr check fires *before* consuming op[i] (so the kept operands
+  // ops[0..i) are still intact), while the shl check fires *after* consuming
+  // op[i] (so the dropped operands ops[0..i] are excluded and ops[i+1..n)
+  // remain). bv_typet is used for the zero pad as the canonical opaque
+  // bit-vector type, mirroring simplify_concatenation's neighbour-merging
+  // logic; it avoids committing to unsignedbv/signedbv when the surviving
+  // siblings might have heterogeneous bitvector types.
+  mp_integer offset = total_width;
+  mp_integer bits_seen = 0;
+  for(std::size_t i = 0; i < expr.op().operands().size(); ++i)
+  {
+    if(expr.id() == ID_lshr && offset == *distance)
+    {
+      // ops[0..i) survive on the right; ops[i..n) are shifted out, replaced
+      // by a zero pad of width d on the left.
+      exprt::operandst new_operands;
+      new_operands.reserve(i + 1);
+      new_operands.push_back(
+        from_integer(0, bv_typet{numeric_cast_v<std::size_t>(*distance)}));
+      new_operands.insert(
+        new_operands.end(),
+        expr.op().operands().begin(),
+        expr.op().operands().begin() + i);
+      concatenation_exprt new_concat = to_concatenation_expr(expr.op());
+      new_concat.operands() = std::move(new_operands);
+      return changed(simplify_concatenation(new_concat));
+    }
+
+    const auto op_width =
+      pointer_offset_bits(expr.op().operands()[i].type(), ns);
+
+    // If we cannot determine an operand width, both cursors become unreliable
+    // from this point onwards (offset for lshr's "ops[0..i) intact" property,
+    // bits_seen for shl's running offset), so abort the whole simplification
+    // rather than guessing.
+    if(!op_width.has_value())
+      return unchanged(expr);
+
+    offset -= *op_width;
+    bits_seen += *op_width;
+
+    if(expr.id() == ID_shl && bits_seen == *distance)
+    {
+      // ops[i+1..n) survive on the left; ops[0..i] are shifted out, replaced
+      // by a zero pad of width d on the right.
+      exprt::operandst new_operands;
+      new_operands.reserve(expr.op().operands().size() - i);
+      new_operands.insert(
+        new_operands.end(),
+        expr.op().operands().begin() + i + 1,
+        expr.op().operands().end());
+      new_operands.push_back(
+        from_integer(0, bv_typet{numeric_cast_v<std::size_t>(*distance)}));
+      concatenation_exprt new_concat = to_concatenation_expr(expr.op());
+      new_concat.operands() = std::move(new_operands);
+      return changed(simplify_concatenation(new_concat));
+    }
+  }
+
+  return unchanged(expr);
+}
+
+simplify_exprt::resultt<>
 simplify_exprt::simplify_shifts(const shift_exprt &expr)
 {
   if(!can_cast_type<bitvector_typet>(expr.type()))
@@ -1058,6 +1152,15 @@ simplify_exprt::simplify_shifts(const shift_exprt &expr)
 
   if(*distance == 0)
     return expr.op();
+
+  if(
+    expr.op().id() == ID_concatenation &&
+    (expr.id() == ID_lshr || expr.id() == ID_shl))
+  {
+    auto r = simplify_shift_of_concatenation(expr);
+    if(r.has_changed())
+      return r;
+  }
 
   auto value = numeric_cast<mp_integer>(expr.op());
 

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -769,3 +769,142 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, ns) == true_exprt{});
 }
+
+TEST_CASE("Simplify lshr of concatenation", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const unsignedbv_typet u4{4};
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u12{12};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+
+  SECTION("aligned 8-bit shift on a 16-bit two-operand concat")
+  {
+    // (concat(a, b)) >> 8 -> concat(0x00, a)
+    const concatenation_exprt cat{{a, b}, u16};
+    const lshr_exprt lshr{cat, from_integer(8, u16)};
+    const concatenation_exprt expected{{from_integer(0, bv_typet{8}), a}, u16};
+    REQUIRE(simplify_expr(lshr, ns) == expected);
+  }
+
+  SECTION("3-operand concat with the boundary in the middle")
+  {
+    // (concat(a4, b4, c8)) >> 8 -> concat(0x00, a4, b4)
+    const symbol_exprt a4{"a4", u4};
+    const symbol_exprt b4{"b4", u4};
+    const symbol_exprt c8{"c8", u8};
+    const concatenation_exprt cat{{a4, b4, c8}, u16};
+    const lshr_exprt lshr{cat, from_integer(8, u16)};
+    const concatenation_exprt expected{
+      {from_integer(0, bv_typet{8}), a4, b4}, u16};
+    REQUIRE(simplify_expr(lshr, ns) == expected);
+  }
+
+  SECTION("asymmetric operand widths")
+  {
+    // (concat(a4, b12)) >> 12 -> concat(0_12, a4)
+    const symbol_exprt a4{"a4", u4};
+    const symbol_exprt b12{"b12", u12};
+    const concatenation_exprt cat{{a4, b12}, u16};
+    const lshr_exprt lshr{cat, from_integer(12, u16)};
+    const concatenation_exprt expected{
+      {from_integer(0, bv_typet{12}), a4}, u16};
+    REQUIRE(simplify_expr(lshr, ns) == expected);
+  }
+
+  SECTION("mis-aligned distance must not fire")
+  {
+    // (concat(a, b)) >> 4 must not be rewritten by this rule.
+    const concatenation_exprt cat{{a, b}, u16};
+    const lshr_exprt lshr{cat, from_integer(4, u16)};
+    const exprt result = simplify_expr(lshr, ns);
+    // It must NOT be a concat whose first (leftmost) operand is the
+    // 4-bit zero pad we'd have introduced on a successful rewrite.
+    if(result.id() == ID_concatenation)
+    {
+      REQUIRE(
+        to_concatenation_expr(result).op0() != from_integer(0, bv_typet{4}));
+    }
+  }
+
+  SECTION("ashr of a concatenation must not fire (sign-bit semantics)")
+  {
+    // ashr(concat(a, b), 8) must not be rewritten by this code.
+    const concatenation_exprt cat{{a, b}, u16};
+    const ashr_exprt ashr{cat, from_integer(8, u16)};
+    const exprt result = simplify_expr(ashr, ns);
+    const concatenation_exprt forbidden{{from_integer(0, bv_typet{8}), a}, u16};
+    REQUIRE(result != forbidden);
+  }
+
+  SECTION("full-width and over-width shifts collapse to zero")
+  {
+    const concatenation_exprt cat{{a, b}, u16};
+    const lshr_exprt lshr_full{cat, from_integer(16, u16)};
+    REQUIRE(simplify_expr(lshr_full, ns) == from_integer(0, u16));
+    const lshr_exprt lshr_over{cat, from_integer(20, u16)};
+    REQUIRE(simplify_expr(lshr_over, ns) == from_integer(0, u16));
+  }
+}
+
+TEST_CASE("Simplify shl of concatenation", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const unsignedbv_typet u4{4};
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const symbol_exprt a{"a", u8};
+  const symbol_exprt b{"b", u8};
+
+  SECTION("aligned 8-bit shift on a 16-bit two-operand concat")
+  {
+    // (concat(a, b)) << 8 -> concat(b, 0x00)
+    const concatenation_exprt cat{{a, b}, u16};
+    const shl_exprt shl{cat, from_integer(8, u16)};
+    const concatenation_exprt expected{{b, from_integer(0, bv_typet{8})}, u16};
+    REQUIRE(simplify_expr(shl, ns) == expected);
+  }
+
+  SECTION("3-operand concat with the boundary in the middle")
+  {
+    // (concat(a4, b4, c8)) << 8 -> concat(c8, 0_8)
+    const symbol_exprt a4{"a4", u4};
+    const symbol_exprt b4{"b4", u4};
+    const symbol_exprt c8{"c8", u8};
+    const concatenation_exprt cat{{a4, b4, c8}, u16};
+    const shl_exprt shl{cat, from_integer(8, u16)};
+    const concatenation_exprt expected{{c8, from_integer(0, bv_typet{8})}, u16};
+    REQUIRE(simplify_expr(shl, ns) == expected);
+  }
+
+  SECTION("mis-aligned distance must not fire")
+  {
+    // (concat(a, b)) << 4 must not be rewritten by this rule.
+    const concatenation_exprt cat{{a, b}, u16};
+    const shl_exprt shl{cat, from_integer(4, u16)};
+    const exprt result = simplify_expr(shl, ns);
+    // It must NOT be a concat whose last (rightmost) operand is the
+    // 4-bit zero pad we'd have introduced on a successful rewrite.
+    if(result.id() == ID_concatenation)
+    {
+      REQUIRE(
+        to_concatenation_expr(result).operands().back() !=
+        from_integer(0, bv_typet{4}));
+    }
+  }
+
+  SECTION("full-width and over-width shifts collapse to zero")
+  {
+    const concatenation_exprt cat{{a, b}, u16};
+    const shl_exprt shl_full{cat, from_integer(16, u16)};
+    REQUIRE(simplify_expr(shl_full, ns) == from_integer(0, u16));
+    const shl_exprt shl_over{cat, from_integer(20, u16)};
+    REQUIRE(simplify_expr(shl_over, ns) == from_integer(0, u16));
+  }
+}


### PR DESCRIPTION
We may be able to drop some of the operands of the concatenation and use all-zeros instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
