### PR TITLE
Decompose byte_extract from union through widest member

### DIFF
--- a/regression/cbmc/union_performance1/main.c
+++ b/regression/cbmc/union_performance1/main.c
@@ -1,0 +1,22 @@
+// Test that byte_extract from a union does not cause performance explosion.
+// See GitHub issue diffblue/cbmc#8813.
+#include <assert.h>
+#include <stdint.h>
+
+typedef struct
+{
+  int32_t data[8];
+} arr;
+
+int main()
+{
+  union
+  {
+    arr a;
+    arr b;
+  } u;
+  unsigned i;
+  __CPROVER_assume(i < 8);
+  u.a.data[i] = 42;
+  assert(u.b.data[i] == 42);
+}

--- a/regression/cbmc/union_performance1/test.desc
+++ b/regression/cbmc/union_performance1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Union of same-typed members should not cause performance explosion.
+See GitHub issue diffblue/cbmc#8813.

--- a/regression/cbmc/union_performance2/main.c
+++ b/regression/cbmc/union_performance2/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdint.h>
+
+typedef struct
+{
+  int32_t coeffs[256];
+} poly;
+
+typedef struct
+{
+  poly vec[8];
+} polyvec;
+
+int main()
+{
+  union
+  {
+    polyvec y;
+    polyvec h;
+  } yh;
+
+  unsigned k;
+  __CPROVER_assume(k < 256);
+
+  polyvec nondet_val;
+  yh.y = nondet_val;
+
+  __CPROVER_assume(yh.y.vec[0].coeffs[k] > -100 && yh.y.vec[0].coeffs[k] < 100);
+
+  assert(yh.h.vec[0].coeffs[k] > -100 && yh.h.vec[0].coeffs[k] < 100);
+}

--- a/regression/cbmc/union_performance2/test.desc
+++ b/regression/cbmc/union_performance2/test.desc
@@ -1,0 +1,12 @@
+CORE no-new-smt
+main.c
+--no-array-field-sensitivity --z3
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Union with nested struct/array should not cause performance explosion
+when accessed with a non-constant offset smaller than the array element size.
+See GitHub issue diffblue/cbmc#8813.

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -886,6 +886,32 @@ std::optional<exprt> get_subexpression_at_offset(
 
       return {};
     }
+    else if(expr.type().id() == ID_union || expr.type().id() == ID_union_tag)
+    {
+      // For union-typed expressions with non-constant offset, access
+      // through the widest member to avoid expensive byte_extract lowering.
+      // This is safe when the widest member covers the full union (no
+      // trailing padding beyond it), since all members start at offset 0.
+      if(expr.id() == ID_symbol || expr.id() == ID_member)
+      {
+        const union_typet &union_type =
+          expr.type().id() == ID_union_tag
+            ? ns.follow_tag(to_union_tag_type(expr.type()))
+            : to_union_type(expr.type());
+
+        const auto union_size = pointer_offset_bits(union_type, ns);
+        const auto widest_member = union_type.find_widest_union_component(ns);
+        if(
+          widest_member.has_value() && union_size.has_value() &&
+          widest_member->second == *union_size)
+        {
+          const member_exprt member(
+            expr, widest_member->first.get_name(), widest_member->first.type());
+          return get_subexpression_at_offset(member, offset, target_type, ns);
+        }
+      }
+      return {};
+    }
     else
       return {};
   }


### PR DESCRIPTION
When byte_extract is applied to a union-typed expression with a non-constant computed offset, the byte_extract lowering creates a massive expression because it must consider all possible byte layouts. For unions where the widest member covers the entire union, we can instead decompose the access through that member, avoiding the
expensive lowering.

Add union handling to the non-constant-offset overload of get_subexpression_at_offset: for symbol and member expressions of union type, recurse into the widest member. Guard this on the widest member's size equalling the union's size (no trailing padding).

The constant-offset overload is left unchanged to preserve existing simplification behavior (e.g., byte_extract(byte_update(...)) patterns used during constant propagation).

On the reproducer from #8813, the union version now takes 1.0s (previously 94s), matching the struct version at 1.0s.

On the union_performance2 test (poly vec[8] with int32_t coeffs[256], accessed through a union with --z3), the union version completes in 0.08s matching the struct equivalent. Without this fix combined with the multi-dimensional array rewrite from #8705, the byte_extract lowering would not terminate within reasonable time.

Fixes: #8813

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
