### PR TITLE
Make function pointer removal deterministic

### DIFF
--- a/regression/goto-instrument/restrict-function-pointer-deterministic-order/test.c
+++ b/regression/goto-instrument/restrict-function-pointer-deterministic-order/test.c
@@ -1,0 +1,22 @@
+typedef int (*fptr_t)(int);
+
+int alpha(int x)
+{
+  return x + 1;
+}
+
+int beta(int x)
+{
+  return x + 2;
+}
+
+int gamma(int x)
+{
+  return x + 3;
+}
+
+int main(void)
+{
+  fptr_t fp;
+  return fp(0);
+}

--- a/regression/goto-instrument/restrict-function-pointer-deterministic-order/test.desc
+++ b/regression/goto-instrument/restrict-function-pointer-deterministic-order/test.desc
@@ -1,0 +1,13 @@
+CORE
+test.c
+--restrict-function-pointer main.function_pointer_call.1/gamma,alpha,beta _ --no-standard-checks
+activate-multi-line-match
+IF main.function_pointer_call.1 = address_of\(alpha\)(?s:.)*IF main.function_pointer_call.1 = address_of\(beta\)(?s:.)*IF main.function_pointer_call.1 = address_of\(gamma\)
+dereferenced function pointer must be one of \[alpha, beta, gamma\]
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Tests that function pointer targets are emitted in sorted order regardless of
+the order in which they are specified on the command line. This ensures
+deterministic output that does not depend on internal hash table ordering.

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -344,8 +344,8 @@ void remove_function_pointerst::remove_function_pointer(
     functions);
 }
 
-static std::string function_pointer_assertion_comment(
-  const std::unordered_set<symbol_exprt, irep_hash> &candidates)
+static std::string
+function_pointer_assertion_comment(const std::vector<symbol_exprt> &candidates)
 {
   std::stringstream comment;
 
@@ -382,8 +382,17 @@ void remove_function_pointer(
   goto_programt &goto_program,
   const irep_idt &function_id,
   goto_programt::targett target,
-  const std::unordered_set<symbol_exprt, irep_hash> &functions)
+  const std::unordered_set<symbol_exprt, irep_hash> &functions_set)
 {
+  // Sort by identifier to ensure deterministic output regardless of
+  // internal hash ordering.
+  std::vector<symbol_exprt> functions(
+    functions_set.begin(), functions_set.end());
+  std::sort(
+    functions.begin(),
+    functions.end(),
+    [](const symbol_exprt &a, const symbol_exprt &b)
+    { return id2string(a.get_identifier()) < id2string(b.get_identifier()); });
   const exprt &function = target->call_function();
   const exprt &pointer = to_dereference_expr(function).pointer();
 


### PR DESCRIPTION
Sort function pointer candidates by identifier name before generating the dispatch code. This ensures the order of IF/GOTO branches in the resulting GOTO program is independent of internal hash table ordering, which can vary when irep IDs are added or removed.

Without this fix, unrelated changes to irep_ids.def can cause different function pointer dispatch orderings, leading to different symbolic execution paths and dramatically different SAT solver performance.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
