### PR TITLE
Initialize nondet locals in regression tests

### DIFF
--- a/regression/cbmc/ACSL/operators.c
+++ b/regression/cbmc/ACSL/operators.c
@@ -1,6 +1,6 @@
 void boolean()
 {
-  __CPROVER_bool a, b;
+  __CPROVER_bool a = __VERIFIER_nondet__Bool(), b = __VERIFIER_nondet__Bool();
   __CPROVER_assert((a ≡ b) == (a == b), "≡");
   __CPROVER_assert((a ≢ b) == (a != b), "≢");
   __CPROVER_assert((a ⇒ b) == (!a || b), "⇒");
@@ -13,7 +13,7 @@ void boolean()
 
 void relations()
 {
-  int a, b;
+  int a = __VERIFIER_nondet_int(), b = __VERIFIER_nondet_int();
   __CPROVER_assert((a ≥ b) == (a >= b), "≥");
   __CPROVER_assert((a ≤ b) == (a <= b), "≤");
   __CPROVER_assert((a ≡ b) == (a == b), "≡");

--- a/regression/cbmc/Array_Pointer3/main.c
+++ b/regression/cbmc/Array_Pointer3/main.c
@@ -62,7 +62,7 @@ int f(int j, int k)
 
 int main()
 {
-  int x, y;
+  int x = __VERIFIER_nondet_int(), y = __VERIFIER_nondet_int();
   __CPROVER_assume(x > y);
   __CPROVER_assume(x >= 0);
   __CPROVER_assume((y > 15) && (y < 18));

--- a/regression/cbmc/Array_UF1/main.c
+++ b/regression/cbmc/Array_UF1/main.c
@@ -1,7 +1,8 @@
 int main()
 {
   int a[10], b[10];
-  int x, y, z;
+  int x = __VERIFIER_nondet_int(), y = __VERIFIER_nondet_int(),
+      z = __VERIFIER_nondet_int();
   __CPROVER_assume(2 <= y && y <= 4);
   __CPROVER_assume(6 <= z && z <= 8);
   b[y] = x;

--- a/regression/cbmc/Array_UF2/main.c
+++ b/regression/cbmc/Array_UF2/main.c
@@ -1,7 +1,8 @@
 int main()
 {
   int a[4], b[4];
-  int x, y, z;
+  int x = __VERIFIER_nondet_int(), y = __VERIFIER_nondet_int(),
+      z = __VERIFIER_nondet_int();
   __CPROVER_assume(1 <= y && y <= 3);
   __CPROVER_assume(0 <= z && z <= 2);
   b[y] = x;

--- a/regression/cbmc/Array_operations1/main.c
+++ b/regression/cbmc/Array_operations1/main.c
@@ -2,7 +2,7 @@ void test_equal()
 {
   char array1[100], array2[100];
   _Bool cmp;
-  int index;
+  int index = __VERIFIER_nondet_int();
 
   cmp = __CPROVER_array_equal(array1, array2);
 

--- a/regression/cbmc/Array_operations2/main.c
+++ b/regression/cbmc/Array_operations2/main.c
@@ -11,7 +11,7 @@ int main()
 {
   my_struct arr[3] = {0};
   char *ptr = &(arr[1].c[2]);
-  int offset;
+  int offset = __VERIFIER_nondet_int();
   __CPROVER_assume(offset < 1 && offset > -1);
   void *ptr_plus = ptr + offset;
   char nondet[3];

--- a/regression/cbmc/Array_operations4/main.c
+++ b/regression/cbmc/Array_operations4/main.c
@@ -3,7 +3,7 @@ int main()
   char source[8];
   int int_source[2];
   int target[4];
-  int n;
+  int n = __VERIFIER_nondet_int();
   if(n >= 0 && n < 3)
   {
     __CPROVER_array_replace(&target[n], source);

--- a/regression/cbmc/Associativity1/main.c
+++ b/regression/cbmc/Associativity1/main.c
@@ -1,11 +1,12 @@
 #include <assert.h>
 
 int main (void) {
-	int x;
+  int x = __VERIFIER_nondet_int();
 
-	while ((x + 1) -x != 1) {
-		assert(0);
-	}
+  while((x + 1) - x != 1)
+  {
+    assert(0);
+  }
 
-	return 0;
+  return 0;
 }

--- a/regression/cbmc/BV_Arithmetic6/main.c
+++ b/regression/cbmc/BV_Arithmetic6/main.c
@@ -1,7 +1,7 @@
 int main()
 {
   {
-    unsigned i, j, k, l;
+    unsigned i, j, k = __VERIFIER_nondet_unsigned(), l;
 
     j=k;
     i=j/2;
@@ -15,7 +15,7 @@ int main()
   }
 
   {
-    signed int i, j, k, l;
+    signed int i, j, k = __VERIFIER_nondet_signed_int(), l;
 
     // shifting rounds into the wrong direction
     __CPROVER_assume(!(k&1));

--- a/regression/cbmc/Bitfields1/main.c
+++ b/regression/cbmc/Bitfields1/main.c
@@ -30,7 +30,8 @@ struct bft {
 };
 
 int main() {
-  struct bft bf;
+  struct bft nondet_bft(void);
+  struct bft bf = nondet_bft();
 
   assert(bf.a<=7);
   assert(bf.b<=1);

--- a/regression/cbmc/Bitfields2/main.c
+++ b/regression/cbmc/Bitfields2/main.c
@@ -40,7 +40,8 @@ unsigned foo(union U u, struct S0 s)
 int main()
 {
   struct S0 main_s = { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
-  union U main_u;
+  union U nondet_U(void);
+  union U main_u = nondet_U();
 
   assert(8==foo(main_u, main_s));
 

--- a/regression/cbmc/Boolean_Guards1/main.c
+++ b/regression/cbmc/Boolean_Guards1/main.c
@@ -1,18 +1,20 @@
-int main() {
-  unsigned x;
-  int i;
+int main()
+{
+  unsigned x = __VERIFIER_nondet_unsigned();
+  int i = __VERIFIER_nondet_int();
   int a[100];
+  __CPROVER_havoc_object(a);
 
   // this is guaranteed not to be a buffer overflow
-  if(x<100 && a[x])
+  if(x < 100 && a[x])
   {
     i++;
   }
 
-  __CPROVER_assume(i<100);
+  __CPROVER_assume(i < 100);
 
   // this is guaranteed not to be a buffer underflow
-  if(i>=0 && a[i])
+  if(i >= 0 && a[i])
   {
     i++;
   }

--- a/regression/cbmc/Computed-Goto1/main.c
+++ b/regression/cbmc/Computed-Goto1/main.c
@@ -1,7 +1,7 @@
 int main()
 {
   static void *table[] = {&&l0, &&l1, &&l2};
-  int in, out;
+  int in = __VERIFIER_nondet_int(), out;
 
   if(in>=0 && in<=2)
   {

--- a/regression/cbmc/Ellipsis2/main.c
+++ b/regression/cbmc/Ellipsis2/main.c
@@ -7,8 +7,8 @@ int foo(int a, ...)
 
 int main()
 {
-  char c;
-  long l;
+  char c = __VERIFIER_nondet_char();
+  long l = __VERIFIER_nondet_long();
 
   if(c<l)
     l=foo(c, c);

--- a/regression/cbmc/Empty_struct1/main.c
+++ b/regression/cbmc/Empty_struct1/main.c
@@ -7,7 +7,7 @@ struct empty
 int main()
 {
   struct empty e1, e2, e3;
-  _Bool b, c=b;
+  _Bool b = __VERIFIER_nondet__Bool(), c = b;
   e1=e2;
   if(b)
     e3=e2;

--- a/regression/cbmc/End_thread1/main.c
+++ b/regression/cbmc/End_thread1/main.c
@@ -10,7 +10,7 @@ void pthread_exit(void *value_ptr);
 
 int main()
 {
-  int i;
+  int i = __VERIFIER_nondet_int();
 
   if(i == 100)
   {

--- a/regression/cbmc/Fixedbv4/main.c
+++ b/regression/cbmc/Fixedbv4/main.c
@@ -4,7 +4,8 @@ typedef __CPROVER_fixedbv[32][16] fbvt;
 
 int main()
 {
-  fbvt f;
+  fbvt nondet_fbvt(void);
+  fbvt f = nondet_fbvt();
 
   // addition
   assert(100.0+10==110);

--- a/regression/cbmc/Fixedbv5/main.c
+++ b/regression/cbmc/Fixedbv5/main.c
@@ -1,11 +1,12 @@
 int main()
 {
   typedef __CPROVER_fixedbv[32][16] ft;
-  ft a, b;
+  ft nondet_ft(void);
+  ft a = nondet_ft(), b;
 
-  __CPROVER_assume(a==1 || a==(ft)0.5 || a==2 || a==3 || a==(ft)0.25);
-  b=a;
-  a/=2;
-  a*=2;
-  __CPROVER_assert(a==b, "fixedbv div works");
+  __CPROVER_assume(a == 1 || a == (ft)0.5 || a == 2 || a == 3 || a == (ft)0.25);
+  b = a;
+  a /= 2;
+  a *= 2;
+  __CPROVER_assert(a == b, "fixedbv div works");
 }

--- a/regression/cbmc/Fixedbv6/main.c
+++ b/regression/cbmc/Fixedbv6/main.c
@@ -23,7 +23,8 @@ int main()
   assert(!((fbvt)-2.0>=(fbvt)-1.0));
 
   // variables
-  fbvt a, b, _a=a, _b=b;
+  fbvt nondet_fbvt(void);
+  fbvt a = nondet_fbvt(), b = nondet_fbvt(), _a = a, _b = b;
   __CPROVER_assume(a==1 && b==2);
 
   assert(a!=b);

--- a/regression/cbmc/Float-equality1/main.c
+++ b/regression/cbmc/Float-equality1/main.c
@@ -2,7 +2,8 @@
 
 void main()
 {
-  double a, b, c;
+  double a = __VERIFIER_nondet_double(), b = __VERIFIER_nondet_double(),
+         c = __VERIFIER_nondet_double();
   __CPROVER_assume(a + b > c);
 #ifdef EQUALITY
   double x = a, y = b, z = c;

--- a/regression/cbmc/Float-equality2/main.c
+++ b/regression/cbmc/Float-equality2/main.c
@@ -3,8 +3,8 @@
 
 int main()
 {
-  float a;
-  float b;
+  float a = __VERIFIER_nondet_float();
+  float b = __VERIFIER_nondet_float();
   // We could do "if (isnormal(a) && isnormal(b))", but __CPROVER_isnanf(a+b)
   // will permit solving this entirely via the simplifier, if, and only if, the
   // equality is successfully simplified (despite the different order of

--- a/regression/cbmc/Float-flags-no-simp1/main.c
+++ b/regression/cbmc/Float-flags-no-simp1/main.c
@@ -4,7 +4,7 @@
 
 int main()
 {
-  double d;
+  double d = __VERIFIER_nondet_double();
 
 #ifndef _MSC_VER
 

--- a/regression/cbmc/Float-flags-simp1/main.c
+++ b/regression/cbmc/Float-flags-simp1/main.c
@@ -4,7 +4,7 @@
 
 int main()
 {
-  double d;
+  double d = __VERIFIER_nondet_double();
 
 #ifndef _MSC_VER
 

--- a/regression/cbmc/Float-no-simp2/main.c
+++ b/regression/cbmc/Float-no-simp2/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  double f, f2;
+  double f, f2 = __VERIFIER_nondet_double();
   // the following rely on f not being a NaN
   __CPROVER_assume(!__CPROVER_isnand(f2));
   __CPROVER_assume(__CPROVER_isfinited(f2));

--- a/regression/cbmc/Float-no-simp4/main.c
+++ b/regression/cbmc/Float-no-simp4/main.c
@@ -2,33 +2,33 @@
 
 int main()
 {
-  double d1, _d1;
+  double d1, _d1 = __VERIFIER_nondet_double();
   d1=_d1;
   __CPROVER_assume(__CPROVER_isnormald(d1));
   assert(!__CPROVER_isnand(d1));
   assert(!__CPROVER_isinfd(d1));
   assert(__CPROVER_isfinited(d1));
 
-  double d2, _d2;
+  double d2, _d2 = __VERIFIER_nondet_double();
   d2=_d2;
   __CPROVER_assume(__CPROVER_isinfd(d2));
   assert(!__CPROVER_isnormald(d2));
   assert(!__CPROVER_isnand(d2));
 
-  double d3, _d3;
+  double d3, _d3 = __VERIFIER_nondet_double();
   d3=_d3;
   __CPROVER_assume(__CPROVER_isnand(d3));
   assert(!__CPROVER_isnormald(d3));
   assert(!__CPROVER_isinfd(d3));
   assert(d3!=d3);
 
-  double d4, _d4;
+  double d4, _d4 = __VERIFIER_nondet_double();
   d4=_d4;
   __CPROVER_assume(__CPROVER_isfinited(d4));
   assert(!__CPROVER_isnand(d4));
   assert(!__CPROVER_isinfd(d4));
 
-  double d5, _d5;
+  double d5, _d5 = __VERIFIER_nondet_double();
   d5=_d5;
   __CPROVER_assume(!__CPROVER_isnand(d5) && !__CPROVER_isinfd(d5));
   assert(__CPROVER_isfinited(d5));

--- a/regression/cbmc/Float-no-simp5/main.c
+++ b/regression/cbmc/Float-no-simp5/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  double a, b;
+  double a = __VERIFIER_nondet_double(), b = __VERIFIER_nondet_double();
 
   union {
     double f;

--- a/regression/cbmc/Float-rounding2/main.c
+++ b/regression/cbmc/Float-rounding2/main.c
@@ -6,7 +6,7 @@ int main()
   // examples of constants that previously exhibited wrong behaviour
   union U
   {
-    double d;
+    double d = __VERIFIER_nondet_double();
     uint64_t b;
   };
   union U u = {
@@ -15,7 +15,7 @@ int main()
     .b = 0b0000000000000000000000000000001111111111111111111111111000000000};
   double d = u.d;
 #else
-  double d;
+  double d = __VERIFIER_nondet_double();
 #endif
   float f;
   if(d > 0.0 && d < 1.0)

--- a/regression/cbmc/Float12/main.c
+++ b/regression/cbmc/Float12/main.c
@@ -1,8 +1,8 @@
 int main()
 {
-  float f;
+  float f = __VERIFIER_nondet_float();
   double d;
-  unsigned char x;
+  unsigned char x = __VERIFIER_nondet_char();
 
   d=f;
 

--- a/regression/cbmc/Float20/main.c
+++ b/regression/cbmc/Float20/main.c
@@ -42,13 +42,13 @@ void bugCasting (double d) {
 }
 
 int main (void) {
-  float f;
+  float f = __VERIFIER_nondet_float();
   bug(f);
 
-  float g;
+  float g = __VERIFIER_nondet_float();
   bugBrokenOut(g);
 
-  double d;
+  double d = __VERIFIER_nondet_double();
   bugCasting(d);
 
   return 1;

--- a/regression/cbmc/Float22/main.c
+++ b/regression/cbmc/Float22/main.c
@@ -25,35 +25,35 @@ typedef union _ieee754_float {
 
 
 float returnsField (uint32_t index) {
-    ieee754_float c;
+  ieee754_float c;
 
-    c.ieee.negative = index & 0x1;
-    c.ieee.exponent = 0;
-    c.ieee.mantissa = 0;
+  c.ieee.negative = index & 0x1;
+  c.ieee.exponent = 0;
+  c.ieee.mantissa = 0;
 
-    return c.f;
+  return c.f;
 }
 
 ieee754_float returnsStructure (uint32_t index) {
-    ieee754_float c;
+  ieee754_float c;
 
-    c.ieee.negative = index & 0x1;
-    c.ieee.exponent = 0;
-    c.ieee.mantissa = 0;
+  c.ieee.negative = index & 0x1;
+  c.ieee.exponent = 0;
+  c.ieee.mantissa = 0;
 
-    return c;
+  return c;
 }
 
 
 void testOne (void) {
-   ieee754_float f1, f2;
+  ieee754_float f1, f2;
 
-   f1 = returnsStructure(0);
-   f2 = returnsStructure(1);
+  f1 = returnsStructure(0);
+  f2 = returnsStructure(1);
 
-   assert(f1.ieee.negative != f2.ieee.negative);
+  assert(f1.ieee.negative != f2.ieee.negative);
 
-   return;
+  return;
 }
 
 

--- a/regression/cbmc/Float23/main.c
+++ b/regression/cbmc/Float23/main.c
@@ -1,5 +1,5 @@
 int main()
 {
-  float a, b;
+  float a = __VERIFIER_nondet_float(), b = __VERIFIER_nondet_float();
   __CPROVER_assert((a>b)==(a-b>0), "theorem");
 }

--- a/regression/cbmc/Float4/main.c
+++ b/regression/cbmc/Float4/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  double f, f2;
+  double f, f2 = __VERIFIER_nondet_double();
   // the following rely on f not being a NaN or Infinity
   __CPROVER_assume(!__CPROVER_isnand(f2));
   __CPROVER_assume(!__CPROVER_isinfd(f2));

--- a/regression/cbmc/Float5/main.c
+++ b/regression/cbmc/Float5/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  float a, b;
+  float a = __VERIFIER_nondet_float(), b;
 
   __CPROVER_assume(a==1 || a==0.5 || a==2 || a==3 || a==0.1);
   b=a;

--- a/regression/cbmc/Float6/main.c
+++ b/regression/cbmc/Float6/main.c
@@ -21,7 +21,8 @@ int main()
   assert(!(-2.0>=-1.0));
 
   // variables
-  float a, b, _a=a, _b=b;
+  float a = __VERIFIER_nondet_float(), b = __VERIFIER_nondet_float(), _a = a,
+        _b = b;
   __CPROVER_assume(a==1 && b==2);
 
   assert(a!=b);

--- a/regression/cbmc/Float8/main.c
+++ b/regression/cbmc/Float8/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  double d, q, r;
+  double d, q = __VERIFIER_nondet_double(), r;
   __CPROVER_assume(__CPROVER_isfinited(q));
   d=q;
   r=d+0;

--- a/regression/cbmc/Function1/main.c
+++ b/regression/cbmc/Function1/main.c
@@ -8,10 +8,10 @@ int f(int);
 int a[1];
 
 int main() {
-	int x, y;
+  int x, y = __VERIFIER_nondet_int();
 
-	a[0] = y;
-	a[0] = f(a[0]);
+  a[0] = y;
+  a[0] = f(a[0]);
 
-	assert(a[0] == y+1);
+  assert(a[0] == y + 1);
 }

--- a/regression/cbmc/Function4/main.c
+++ b/regression/cbmc/Function4/main.c
@@ -2,7 +2,7 @@ int nondet_int();
 
 int f1()
 {
-  int ret;
+  int ret = __VERIFIER_nondet_int();
   return ret;
 }
 

--- a/regression/cbmc/Function_Pointer10/main.c
+++ b/regression/cbmc/Function_Pointer10/main.c
@@ -4,7 +4,7 @@ void fun(int a)
 
 int test1()
 {
-  char i;
+  char i = __VERIFIER_nondet_char();
   void (*fp)()=fun;
   // this requires a type conversion for i
   fp(i);

--- a/regression/cbmc/Function_Pointer2/main.c
+++ b/regression/cbmc/Function_Pointer2/main.c
@@ -13,7 +13,7 @@ void g(int garg)
 int main()
 {
   void (*p)(int);
-  __CPROVER_bool c;
+  __CPROVER_bool c = __VERIFIER_nondet___CPROVER_bool();
 
   p=c?f:g;
 

--- a/regression/cbmc/Function_Pointer6/main.c
+++ b/regression/cbmc/Function_Pointer6/main.c
@@ -18,7 +18,7 @@ int main(void)
 {
   int (*ppp)();
   struct S * ps = (struct S *) malloc(sizeof(struct S));
-  int x, y;
+  int x = __VERIFIER_nondet_int(), y;
 
   ps->func = x?ten:twenty;
 

--- a/regression/cbmc/Malloc11/main.c
+++ b/regression/cbmc/Malloc11/main.c
@@ -2,10 +2,10 @@
 
 int main()
 {
-  int n;
+  int n = __VERIFIER_nondet_int();
   int x;
   int *a;
-  _Bool nondet;
+  _Bool nondet = __VERIFIER_nondet__Bool();
 
   __CPROVER_assume(n <= 10);
 

--- a/regression/cbmc/Malloc13/main.c
+++ b/regression/cbmc/Malloc13/main.c
@@ -1,7 +1,7 @@
 void *malloc(__CPROVER_size_t);
 
 int main(int argc, char* argv[]) {
-  unsigned short len;
+  unsigned short len = __VERIFIER_nondet_short();
   char * str;
   __CPROVER_assume(len > 0);
   str = malloc(len);

--- a/regression/cbmc/Malloc17/main.c
+++ b/regression/cbmc/Malloc17/main.c
@@ -1,6 +1,6 @@
 unsigned char* init1()
 {
-  unsigned long size;
+  unsigned long size = __VERIFIER_nondet_long();
   if (size!=1) return 0;
 
   assert(sizeof(unsigned char)==1);
@@ -14,7 +14,7 @@ unsigned char* init1()
 
 unsigned char* init2()
 {
-  unsigned long size;
+  unsigned long size = __VERIFIER_nondet_long();
   if (size!=1) return 0;
 
   assert(sizeof(unsigned char)==1);
@@ -28,7 +28,7 @@ unsigned char* init2()
 
 unsigned char* init3()
 {
-  unsigned long size;
+  unsigned long size = __VERIFIER_nondet_long();
   if (size!=1) return 0;
 
   assert(sizeof(unsigned char)==1);

--- a/regression/cbmc/Malloc18/main.c
+++ b/regression/cbmc/Malloc18/main.c
@@ -1,6 +1,6 @@
 unsigned char* init()
 {
-  unsigned long buffer_size;
+  unsigned long buffer_size = __VERIFIER_nondet_long();
   if(buffer_size!=1) return 0;
 
   unsigned char* buffer=__CPROVER_allocate(buffer_size, 0);

--- a/regression/cbmc/Malloc9/main.c
+++ b/regression/cbmc/Malloc9/main.c
@@ -17,7 +17,7 @@ struct S2
 
 int main(void)
 {
-  _Bool b;
+  _Bool b = __VERIFIER_nondet__Bool();
 
   if(b)
   {

--- a/regression/cbmc/Minisat_Simp1/main.c
+++ b/regression/cbmc/Minisat_Simp1/main.c
@@ -3,7 +3,7 @@ int isnan(double);
 
 int main()
 {
-  double my_d, dabs;
+  double my_d = __VERIFIER_nondet_double(), dabs;
 
   __CPROVER_assume(!isnan(my_d));
 

--- a/regression/cbmc/Mod2/main.c
+++ b/regression/cbmc/Mod2/main.c
@@ -13,7 +13,7 @@ static int
 
 int main()
 {
- int a, b;
+ int a = __VERIFIER_nondet_int(), b = __VERIFIER_nondet_int();
 #ifdef __CPROVER__
  __CPROVER_assume(a==1);
  __CPROVER_assume(b==-2);

--- a/regression/cbmc/Pointer1/main.c
+++ b/regression/cbmc/Pointer1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int a, b, c, *p;
+  int a, b, c = __VERIFIER_nondet_int(), *p;
 
   if(c)
     p = &a;

--- a/regression/cbmc/Pointer15/main.c
+++ b/regression/cbmc/Pointer15/main.c
@@ -2,7 +2,7 @@ int main()
 {
   const void *p;
   int *q;
-  int c;
+  int c = __VERIFIER_nondet_int();
 
   p = (c ? p : 0);
 

--- a/regression/cbmc/Pointer25/main.c
+++ b/regression/cbmc/Pointer25/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   void *p;
 
   // from integer 0 to NULL

--- a/regression/cbmc/Pointer26/main.c
+++ b/regression/cbmc/Pointer26/main.c
@@ -3,7 +3,7 @@ int main()
   unsigned int *p = (unsigned int *)0xdeadbeef;
   assert(p != 0);
 
-  int zero;
+  int zero = __VERIFIER_nondet_int();
   __CPROVER_assume(zero == 0);
   unsigned int *q = (unsigned int *)zero;
   assert(q == 0);

--- a/regression/cbmc/Pointer9/main.c
+++ b/regression/cbmc/Pointer9/main.c
@@ -16,7 +16,7 @@ void f1(int *px)
 
 main()
 {
-  int flag;
+  int flag = __VERIFIER_nondet_int();
   int *ref = NULL;
   int x = 0;
   st1.x = 0;

--- a/regression/cbmc/Pointer_Arithmetic11/main.c
+++ b/regression/cbmc/Pointer_Arithmetic11/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int i, ii;
+  int i, ii = __VERIFIER_nondet_int();
   int data=0;
   char *p=(char *)&data;
   i=ii;

--- a/regression/cbmc/Pointer_array8/main.c
+++ b/regression/cbmc/Pointer_array8/main.c
@@ -16,6 +16,6 @@ int main()
   arrvec A;
   arrvec *x = &A;
   __CPROVER_assume(x->vec[1].data[0] < 42);
-  unsigned k;
+  unsigned k = __VERIFIER_nondet_unsigned();
   __CPROVER_assert(k != 2 || ((int *)x)[k] < 42, "");
 }

--- a/regression/cbmc/Pointer_byte_extract4/main.c
+++ b/regression/cbmc/Pointer_byte_extract4/main.c
@@ -16,45 +16,45 @@ struct list_head gl_list = { &gl_list, &gl_list };
 
 int main()
 {
-  _Bool maybe_dynamic;
+    _Bool maybe_dynamic = __VERIFIER_nondet__Bool();
 
-  struct node X;
-  struct node *N = maybe_dynamic ? malloc(sizeof(struct node)) : &X;
-  if (!N)
-    return 1;
+    struct node X;
+    struct node *N = maybe_dynamic ? malloc(sizeof(struct node)) : &X;
+    if(!N)
+      return 1;
 
-  N->value = 42;
-	gl_list.prev=&N->linkage;
-	N->linkage.next=&gl_list;
-	N->linkage.prev=&gl_list;
-	gl_list.next=&N->linkage;
-  // we have:
-  // gl_list.prev=&D->linkage;
-  // D->linkage.next=&gl_list
-  // D->linkage.prev=&gl_list;
-  // gl_list.next=&D->linkage;
+    N->value = 42;
+    gl_list.prev = &N->linkage;
+    N->linkage.next = &gl_list;
+    N->linkage.prev = &gl_list;
+    gl_list.next = &N->linkage;
+    // we have:
+    // gl_list.prev=&D->linkage;
+    // D->linkage.next=&gl_list
+    // D->linkage.prev=&gl_list;
+    // gl_list.next=&D->linkage;
 
-	N->nested.next = &(N->nested);
-  N->nested.prev = &(N->nested);
+    N->nested.next = &(N->nested);
+    N->nested.prev = &(N->nested);
 
-  const struct list_head *head=&gl_list;
+    const struct list_head *head = &gl_list;
 
-  // go one step backward
-  head = head->prev;
-  // we have:
-  // head=&D->linkage
+    // go one step backward
+    head = head->prev;
+    // we have:
+    // head=&D->linkage
 
-  // resolve root
-  const struct node *node =
-    (struct node *) ((char *)(head) -
-                     (unsigned long)(&((struct node *)0)->linkage));
-  // we have:
-  // node=&D (==&D->value)
-  __CPROVER_assert(node == N, "");
-  __CPROVER_assert(head == N->linkage.next->prev, "");
-  __CPROVER_assert(head == N->linkage.prev->next, "");
-  __CPROVER_assert(head == node->linkage.next->prev, "");
-  __CPROVER_assert(head == node->linkage.prev->next, "");
+    // resolve root
+    const struct node *node =
+      (struct node
+         *)((char *)(head) - (unsigned long)(&((struct node *)0)->linkage));
+    // we have:
+    // node=&D (==&D->value)
+    __CPROVER_assert(node == N, "");
+    __CPROVER_assert(head == N->linkage.next->prev, "");
+    __CPROVER_assert(head == N->linkage.prev->next, "");
+    __CPROVER_assert(head == node->linkage.next->prev, "");
+    __CPROVER_assert(head == node->linkage.prev->next, "");
 
-  return 0;
+    return 0;
 }

--- a/regression/cbmc/Pointer_comparison3/main.c
+++ b/regression/cbmc/Pointer_comparison3/main.c
@@ -13,7 +13,7 @@ int main()
 
   assert(p1 != p2);
 
-  _Bool nondet;
+  _Bool nondet = __VERIFIER_nondet__Bool();
   // In the current implementation, CBMC always produces "false" for a
   // comparison over different objects. This could change at any time, which
   // would require updating this test.

--- a/regression/cbmc/Pointer_difference2/main.c
+++ b/regression/cbmc/Pointer_difference2/main.c
@@ -6,7 +6,7 @@ int main()
   __CPROVER_assert(&array[0] - &array[2] == -2, "correct");
 
   int diff = array - other_array;
-  _Bool nondet;
+  _Bool nondet = __VERIFIER_nondet__Bool();
   if(nondet)
     __CPROVER_assert(diff != 42, "undefined behavior");
   else
@@ -21,7 +21,7 @@ int main()
   __CPROVER_assert(p - &array[0] == 4, "end plus one works");
   __CPROVER_assert(p - &array[0] != 3, "end plus one works");
   ++p;
-  _Bool nondet_branch;
+  _Bool nondet_branch = __VERIFIER_nondet__Bool();
   if(nondet_branch)
     __CPROVER_assert(p - &array[0] == 5, "end plus 2 is nondet");
   else

--- a/regression/cbmc/Quantifiers-expr-cleaning/main.c
+++ b/regression/cbmc/Quantifiers-expr-cleaning/main.c
@@ -8,7 +8,7 @@ int main()
 
   // make value sets produce a derefd_pointer object for ((const char*)p)[i]
   // below
-  _Bool nondet;
+  _Bool nondet = __VERIFIER_nondet__Bool();
   int *p = nondet ? &x : &y;
 
   // clang-format off

--- a/regression/cbmc/Quantifiers-simplify/rewrite_exists.c
+++ b/regression/cbmc/Quantifiers-simplify/rewrite_exists.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int k;
+  int k = __VERIFIER_nondet_int();
 
   __CPROVER_assume(__CPROVER_exists {
     int i;

--- a/regression/cbmc/Quantifiers-statement-expression3/main.c
+++ b/regression/cbmc/Quantifiers-statement-expression3/main.c
@@ -2,7 +2,7 @@ int main()
 {
   // clang-format off
   // no side effects!
-  int j;
+  int j = __VERIFIER_nondet_int();
   int a[5] = {0 , 0, 0, 0, 0};
   assert(__CPROVER_forall { int i;  ({ ( 0 <= i && i < 4) ==> ({ int k = j; if(j < 0 || j > i) k = 1;  ( a[k] == 0); }); }) });
   // clang-format on

--- a/regression/cbmc/Recursion2/main.c
+++ b/regression/cbmc/Recursion2/main.c
@@ -5,7 +5,7 @@ void f(unsigned int counter) {
 }
 
 int main() {
-  unsigned int x;
+  unsigned int x = __VERIFIER_nondet_int();
   __CPROVER_assume(x<=10);
 
   f(x);

--- a/regression/cbmc/String8/main.c
+++ b/regression/cbmc/String8/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  _Bool branch;
+  _Bool branch = __VERIFIER_nondet__Bool();
   const char *str = 0;
 
   if(branch)

--- a/regression/cbmc/String_Abstraction14/pass-in-implicit.c
+++ b/regression/cbmc/String_Abstraction14/pass-in-implicit.c
@@ -7,7 +7,7 @@ void use_str(char *s)
 
 int main(int argc, char *argv[])
 {
-  unsigned short len;
+  unsigned short len = __VERIFIER_nondet_short();
   char *str;
   __CPROVER_assume(len > 0);
   str = malloc(len);

--- a/regression/cbmc/String_Abstraction15/pass-in.c
+++ b/regression/cbmc/String_Abstraction15/pass-in.c
@@ -7,7 +7,7 @@ void use_str(char *s)
 
 int main(int argc, char *argv[])
 {
-  unsigned short len;
+  unsigned short len = __VERIFIER_nondet_short();
   char *str;
   __CPROVER_assume(len > 0);
   str = malloc(len);

--- a/regression/cbmc/String_Abstraction18/strcpy.c
+++ b/regression/cbmc/String_Abstraction18/strcpy.c
@@ -4,7 +4,7 @@ void *malloc(__CPROVER_size_t);
 
 char *make_str()
 {
-  unsigned short len;
+  unsigned short len = __VERIFIER_nondet_short();
   char *str;
 
   __CPROVER_assume(len > 0);

--- a/regression/cbmc/String_Abstraction21/strcpy2.c
+++ b/regression/cbmc/String_Abstraction21/strcpy2.c
@@ -4,7 +4,7 @@ void *malloc(__CPROVER_size_t);
 
 char *make_str()
 {
-  unsigned short len;
+  unsigned short len = __VERIFIER_nondet_short();
   char *str;
 
   __CPROVER_assume(len > 0);

--- a/regression/cbmc/String_Abstraction22/main.c
+++ b/regression/cbmc/String_Abstraction22/main.c
@@ -3,7 +3,7 @@
 int main()
 {
   char a[100], *p;
-  _Bool x;
+  _Bool x = __VERIFIER_nondet__Bool();
 
   p = x ? strcpy(a, "asd") : strcpy(a, "abc");
   assert(p == a);

--- a/regression/cbmc/Struct_Initialization2/main.c
+++ b/regression/cbmc/Struct_Initialization2/main.c
@@ -15,7 +15,7 @@ int main()
   assert(str_array[0].b==0);
   assert(str_array[1].b==4);
 
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   // this also exists (GCC)
   str_array[0] = (struct teststr){ .a=1, .c=x };

--- a/regression/cbmc/Struct_Initialization5/main.c
+++ b/regression/cbmc/Struct_Initialization5/main.c
@@ -8,7 +8,8 @@ struct Y {
 
 int main()
 {
-  struct X foo1;
+  struct X nondet_X(void);
+  struct X foo1 = nondet_X();
   struct Y foo2;
 
   foo2=(struct Y){ foo1 };

--- a/regression/cbmc/Struct_Propagation1/main.c
+++ b/regression/cbmc/Struct_Propagation1/main.c
@@ -24,7 +24,7 @@ int main()
 
   __CPROVER_assert(works.inner.x == 0, "");
 
-  _Bool b;
+  _Bool b = __VERIFIER_nondet__Bool();
   if(b)
   {
     struct S s = {42, {42}};

--- a/regression/cbmc/Typecast1/main.c
+++ b/regression/cbmc/Typecast1/main.c
@@ -4,7 +4,7 @@ int main()
 {
   assert(((long long int)(unsigned long long)-1)==-1);
 
-  int a;
+  int a = __VERIFIER_nondet_int();
   __CPROVER_assume(a==-1);
   unsigned long long x = (unsigned long long) a;
   assert(x == -1);

--- a/regression/cbmc/Unbounded_Array1/main.c
+++ b/regression/cbmc/Unbounded_Array1/main.c
@@ -1,6 +1,8 @@
 int main()
 {
-  unsigned int n, i, j, ai, aj;
+  unsigned int n = __VERIFIER_nondet_int(),
+               i = __VERIFIER_nondet_unsigned_int(),
+               j = __VERIFIER_nondet_unsigned_int(), ai, aj;
   int a[n];
 
   __CPROVER_assume(n > 10 && n < 10000000);

--- a/regression/cbmc/Unbounded_Array5/main.c
+++ b/regression/cbmc/Unbounded_Array5/main.c
@@ -2,7 +2,7 @@ int mem[__CPROVER_constant_infinity_uint];
 
 int main()
 {
-  int i, j, mem_j;
+  int i = __VERIFIER_nondet_int(), j = __VERIFIER_nondet_int(), mem_j;
 
   mem[0] = 0;
   mem[1] = 1;

--- a/regression/cbmc/Undefined_Shift1/main.c
+++ b/regression/cbmc/Undefined_Shift1/main.c
@@ -1,6 +1,6 @@
 void shift_distance_too_large()
 {
-  unsigned char x;
+  unsigned char x = __VERIFIER_nondet_char();
   unsigned r = x << ((sizeof(unsigned) - 1) * 8);  // ok
   r = x << ((sizeof(unsigned) - 1) * 8 - 1);       // ok
   r = (unsigned)x << ((sizeof(unsigned) - 1) * 8); // ok
@@ -9,7 +9,7 @@ void shift_distance_too_large()
 
 void shift_distance_negative()
 {
-  int dist;
+  int dist = __VERIFIER_nondet_int();
   if(dist >= 10)
     dist = 10;
   unsigned r = 1 << dist; // distance may be negative

--- a/regression/cbmc/array-tests/uf-always.c
+++ b/regression/cbmc/array-tests/uf-always.c
@@ -7,7 +7,7 @@ int uninitializedGlobalArray2[2];
 int main(void)
 {
   // Variable access
-  long directUseReadLocation; // Non-det
+  long directUseReadLocation = __VERIFIER_nondet_long();
 
   long x = directUseReadLocation;
   if(0 <= directUseReadLocation && directUseReadLocation < 2)
@@ -16,7 +16,7 @@ int main(void)
   /*** Variable non-redundant update ***/
   // No obvious simplifications to writes
 
-  long nonRedundantWriteLocation;
+  long nonRedundantWriteLocation = __VERIFIER_nondet_long();
 
   if(
     0 <= nonRedundantWriteLocation && nonRedundantWriteLocation < 2 &&

--- a/regression/cbmc/array-tests/zero-sized.c
+++ b/regression/cbmc/array-tests/zero-sized.c
@@ -1,7 +1,7 @@
 int main()
 {
   int A[0] = {};
-  int i;
+  int i = __VERIFIER_nondet_int();
   if(A[i] == 1)
     __CPROVER_assert(0, "");
 }

--- a/regression/cbmc/atomic_X_fetch-1/main.c
+++ b/regression/cbmc/atomic_X_fetch-1/main.c
@@ -2,18 +2,18 @@
 
 void int_test()
 {
-  int *p, v, x, x_before;
+  int *p, v = __VERIFIER_nondet_int(), x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 
-  int result = __atomic_add_fetch(p, v, 0);
+  int result = __atomic_add_fetch(p, v = __VERIFIER_nondet_int(), 0);
   assert(result == x);
   assert(x == x_before + v);
 }
 
 void long_test()
 {
-  long *p, v, x, x_before;
+  long *p, v = __VERIFIER_nondet_long(), x = __VERIFIER_nondet_long(), x_before;
   x_before = x;
   p = &x;
 
@@ -24,8 +24,8 @@ void long_test()
 
 void mixed_test()
 {
-  int *p, x, x_before;
-  long v;
+  int *p, x = __VERIFIER_nondet_int(), x_before;
+  long v = __VERIFIER_nondet_long();
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/atomic_fetch_X-1/main.c
+++ b/regression/cbmc/atomic_fetch_X-1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int *p, v, x, x_before;
+  int *p, v = __VERIFIER_nondet_int(), x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/aws-byte-buf-regression/main.c
+++ b/regression/cbmc/aws-byte-buf-regression/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  unsigned size;
+  unsigned size = __VERIFIER_nondet_unsigned();
   __CPROVER_assume(size >= sizeof(short));
   char *buf = __CPROVER_allocate(size, 0);
 

--- a/regression/cbmc/big-endian-array1/main.c
+++ b/regression/cbmc/big-endian-array1/main.c
@@ -4,7 +4,7 @@ int *array;
 
 int main()
 {
-  unsigned size;
+  unsigned size = __VERIFIER_nondet_unsigned();
   __CPROVER_assume(size==1);
 
   // produce unbounded array that does not have byte granularity

--- a/regression/cbmc/bounds_check1/main.c
+++ b/regression/cbmc/bounds_check1/main.c
@@ -41,7 +41,10 @@ typedef struct _eth_frame_with_control
 void stack()
 {
   eth_frame_with_control f;
-  unsigned i, i2, j, j2, k, k2, l, l2;
+  unsigned i = __VERIFIER_nondet_unsigned(), i2 = __VERIFIER_nondet_unsigned(),
+           j = __VERIFIER_nondet_unsigned(), j2 = __VERIFIER_nondet_unsigned(),
+           k = __VERIFIER_nondet_unsigned(), k2 = __VERIFIER_nondet_unsigned(),
+           l = __VERIFIER_nondet_unsigned(), l2 = __VERIFIER_nondet_unsigned();
 
   // Safe if 0 <= i < FRAME_LENGTH, viable attack over FRAME_LENGTH
   __CPROVER_assume(i < FRAME_LENGTH);
@@ -76,7 +79,10 @@ void stack()
 void heap()
 {
   eth_frame_with_control *f_heap = malloc(sizeof(eth_frame_with_control));
-  unsigned i, i2, j, j2, k, k2, l, l2;
+  unsigned i = __VERIFIER_nondet_unsigned(), i2 = __VERIFIER_nondet_unsigned(),
+           j = __VERIFIER_nondet_unsigned(), j2 = __VERIFIER_nondet_unsigned(),
+           k = __VERIFIER_nondet_unsigned(), k2 = __VERIFIER_nondet_unsigned(),
+           l = __VERIFIER_nondet_unsigned(), l2 = __VERIFIER_nondet_unsigned();
 
   // Safe if 0 <= i < FRAME_LENGTH, viable attack over FRAME_LENGTH
   __CPROVER_assume(i < FRAME_LENGTH);

--- a/regression/cbmc/byte_update11/main.c
+++ b/regression/cbmc/byte_update11/main.c
@@ -5,7 +5,7 @@ struct S
 
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   __CPROVER_assume(x >= 0);
   __CPROVER_assume(x % sizeof(int) == 0);
   struct S A[x];

--- a/regression/cbmc/byte_update12/main.c
+++ b/regression/cbmc/byte_update12/main.c
@@ -8,7 +8,7 @@ struct S
 
 int main()
 {
-  unsigned x;
+  unsigned x = __VERIFIER_nondet_unsigned();
   char A[x];
   __CPROVER_assume(x == sizeof(int));
   A[0] = 42;

--- a/regression/cbmc/byte_update15/main.c
+++ b/regression/cbmc/byte_update15/main.c
@@ -3,7 +3,7 @@
 
 int main(void)
 {
-  int src[8], dst[8], delta;
+  int src[8], dst[8], delta = __VERIFIER_nondet_int();
   if(delta == 3 || delta == 4)
   {
     memcpy(dst, src, sizeof(int) * delta);

--- a/regression/cbmc/byte_update16/main.c
+++ b/regression/cbmc/byte_update16/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  unsigned len;
+  unsigned len = __VERIFIER_nondet_unsigned();
   unsigned A[len];
   if(len > 1 || len == 0 || sizeof(unsigned) != 4)
     return 0;

--- a/regression/cbmc/byte_update17/main.c
+++ b/regression/cbmc/byte_update17/main.c
@@ -9,7 +9,7 @@ union U
 
 int main()
 {
-  unsigned char size;
+  unsigned char size = __VERIFIER_nondet_char();
   __CPROVER_assume(size > 1);
   __CPROVER_assume(size < 5);
   __CPROVER_assume(size % 4 == 0);

--- a/regression/cbmc/byte_update18/main.c
+++ b/regression/cbmc/byte_update18/main.c
@@ -13,7 +13,7 @@ struct O
 int main()
 {
   struct O t = {{{{0}, 2}, {{42}, 2}}, 2};
-  unsigned n;
+  unsigned n = __VERIFIER_nondet_unsigned();
   __CPROVER_assume(n < 2);
   __CPROVER_assume(n > 0);
   char src_n[n];

--- a/regression/cbmc/clang_builtins/bitreverse.c
+++ b/regression/cbmc/clang_builtins/bitreverse.c
@@ -29,28 +29,28 @@ unsigned long long __builtin_bitreverse64(unsigned long long);
 
 void check_8(void)
 {
-  uint8_t op;
+  uint8_t op = __VERIFIER_nondet_uint8_t();
   assert(__builtin_bitreverse8(op) == test_bit_reverse8(op));
   assert(__builtin_bitreverse8(1) == 0x80);
 }
 
 void check_16(void)
 {
-  uint16_t op;
+  uint16_t op = __VERIFIER_nondet_uint16_t();
   assert(__builtin_bitreverse16(op) == test_bit_reverse16(op));
   assert(__builtin_bitreverse16(1) == 0x8000);
 }
 
 void check_32(void)
 {
-  uint32_t op;
+  uint32_t op = __VERIFIER_nondet_uint32_t();
   assert(__builtin_bitreverse32(op) == test_bit_reverse32(op));
   assert(__builtin_bitreverse32(1) == 0x80000000);
 }
 
 void check_64(void)
 {
-  uint64_t op;
+  uint64_t op = __VERIFIER_nondet_uint64_t();
   assert(__builtin_bitreverse64(op) == test_bit_reverse64(op));
   assert(__builtin_bitreverse64(1) == 0x8000000000000000ULL);
 }

--- a/regression/cbmc/clang_builtins/rotate.c
+++ b/regression/cbmc/clang_builtins/rotate.c
@@ -24,7 +24,7 @@ __builtin_rotateright64(unsigned long long, unsigned long long);
 
 void check_left8(void)
 {
-  uint8_t op;
+  uint8_t op = __VERIFIER_nondet_uint8_t();
   assert(__builtin_rotateleft8(op, 1) == rol(uint8_t, op, 1));
   assert(__builtin_rotateleft8(op, 2) == rol(uint8_t, op, 2));
   assert(__builtin_rotateleft8(op, 3) == rol(uint8_t, op, 3));
@@ -33,7 +33,7 @@ void check_left8(void)
 
 void check_left16(void)
 {
-  uint16_t op;
+  uint16_t op = __VERIFIER_nondet_uint16_t();
   assert(__builtin_rotateleft16(op, 1) == rol(uint16_t, op, 1));
   assert(__builtin_rotateleft16(op, 2) == rol(uint16_t, op, 2));
   assert(__builtin_rotateleft16(op, 3) == rol(uint16_t, op, 3));
@@ -42,7 +42,7 @@ void check_left16(void)
 
 void check_left32(void)
 {
-  uint32_t op;
+  uint32_t op = __VERIFIER_nondet_uint32_t();
   assert(__builtin_rotateleft32(op, 1) == rol(uint32_t, op, 1));
   assert(__builtin_rotateleft32(op, 2) == rol(uint32_t, op, 2));
   assert(__builtin_rotateleft32(op, 3) == rol(uint32_t, op, 3));
@@ -51,7 +51,7 @@ void check_left32(void)
 
 void check_left64(void)
 {
-  uint64_t op;
+  uint64_t op = __VERIFIER_nondet_uint64_t();
   assert(__builtin_rotateleft64(op, 1) == rol(uint64_t, op, 1));
   assert(__builtin_rotateleft64(op, 2) == rol(uint64_t, op, 2));
   assert(__builtin_rotateleft64(op, 3) == rol(uint64_t, op, 3));
@@ -60,7 +60,7 @@ void check_left64(void)
 
 void check_right8(void)
 {
-  uint8_t op;
+  uint8_t op = __VERIFIER_nondet_uint8_t();
   assert(__builtin_rotateright8(op, 1) == ror(uint8_t, op, 1));
   assert(__builtin_rotateright8(op, 2) == ror(uint8_t, op, 2));
   assert(__builtin_rotateright8(op, 3) == ror(uint8_t, op, 3));
@@ -69,7 +69,7 @@ void check_right8(void)
 
 void check_right16(void)
 {
-  uint16_t op;
+  uint16_t op = __VERIFIER_nondet_uint16_t();
   assert(__builtin_rotateright16(op, 1) == ror(uint16_t, op, 1));
   assert(__builtin_rotateright16(op, 2) == ror(uint16_t, op, 2));
   assert(__builtin_rotateright16(op, 3) == ror(uint16_t, op, 3));
@@ -78,7 +78,7 @@ void check_right16(void)
 
 void check_right32(void)
 {
-  uint32_t op;
+  uint32_t op = __VERIFIER_nondet_uint32_t();
   assert(__builtin_rotateright32(op, 1) == ror(uint32_t, op, 1));
   assert(__builtin_rotateright32(op, 2) == ror(uint32_t, op, 2));
   assert(__builtin_rotateright32(op, 3) == ror(uint32_t, op, 3));
@@ -87,7 +87,7 @@ void check_right32(void)
 
 void check_right64(void)
 {
-  uint64_t op;
+  uint64_t op = __VERIFIER_nondet_uint64_t();
   assert(__builtin_rotateright64(op, 1) == ror(uint64_t, op, 1));
   assert(__builtin_rotateright64(op, 2) == ror(uint64_t, op, 2));
   assert(__builtin_rotateright64(op, 3) == ror(uint64_t, op, 3));

--- a/regression/cbmc/condition-propagation-4/test.c
+++ b/regression/cbmc/condition-propagation-4/test.c
@@ -1,6 +1,6 @@
 int main(int argc, char **argv)
 {
-  int unknown;
+  int unknown = __VERIFIER_nondet_int();
 
   if(argc != 1)
   {

--- a/regression/cbmc/divide-by-one-simplify/main.c
+++ b/regression/cbmc/divide-by-one-simplify/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 
 int main (void) {
-  float f;
+  float f = __VERIFIER_nondet_float();
   float g;
   int i;
 

--- a/regression/cbmc/dynamic_size1/stack_object.c
+++ b/regression/cbmc/dynamic_size1/stack_object.c
@@ -14,7 +14,7 @@ void func(struct S *s)
 
 int main()
 {
-  __CPROVER_size_t buffer_size;
+  __CPROVER_size_t buffer_size = __VERIFIER_nondet___CPROVER_size_t();
   __CPROVER_assume(buffer_size >= 100);
   char buffer[buffer_size];
   struct S s;

--- a/regression/cbmc/dynamic_sizeof1/main.c
+++ b/regression/cbmc/dynamic_sizeof1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  unsigned x;
+  unsigned x = __VERIFIER_nondet_unsigned();
 
   if(x>=0 && x<=1000)
   {

--- a/regression/cbmc/enum9/main.c
+++ b/regression/cbmc/enum9/main.c
@@ -13,13 +13,14 @@ struct B
 
 int main()
 {
-  unsigned __int128 int x;
+  unsigned __int128 int x = __VERIFIER_nondet_int();
   __CPROVER_assume(x < (~(unsigned __int128)0) - 4);
 
-  enum E e;
+  enum E e = __VERIFIER_nondet_int();
   __CPROVER_assume(__CPROVER_enum_is_in_range(e));
   __CPROVER_assert(x + e > x, "long long plus enum");
 
-  struct B b;
+  struct B nondet_B(void);
+  struct B b = nondet_B();
   __CPROVER_assert(x + b.b >= x, "long long plus bitfield");
 }

--- a/regression/cbmc/equality_through_array1/main.c
+++ b/regression/cbmc/equality_through_array1/main.c
@@ -7,8 +7,8 @@ void main ()
   a[2] = 2;
   a[3] = 3;
 
-  int x;
-  int y;
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
 
   __CPROVER_assume(0 <= x && x < 4);
   __CPROVER_assume(0 <= y && y < 4);

--- a/regression/cbmc/equality_through_array2/main.c
+++ b/regression/cbmc/equality_through_array2/main.c
@@ -8,8 +8,8 @@ void main ()
     a[i] = i;
   }
 
-  int x;
-  int y;
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
 
   __CPROVER_assume(0 <= x && x < LIMIT);
   __CPROVER_assume(0 <= y && y < LIMIT);

--- a/regression/cbmc/equality_through_array3/main.c
+++ b/regression/cbmc/equality_through_array3/main.c
@@ -15,8 +15,8 @@ void main ()
 
   fill_array(a,LIMIT);
 
-  int x;
-  int y;
+  int x = __VERIFIER_nondet_int();
+  int y = __VERIFIER_nondet_int();
 
   __CPROVER_assume(0 <= x && x < LIMIT);
   __CPROVER_assume(0 <= y && y < LIMIT);

--- a/regression/cbmc/equality_through_array4/main.c
+++ b/regression/cbmc/equality_through_array4/main.c
@@ -15,7 +15,7 @@ int pass_through_array (int x)
 }
 
 int main (void) {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   assert(x == pass_through_array(x));
 

--- a/regression/cbmc/equality_through_array5/main.c
+++ b/regression/cbmc/equality_through_array5/main.c
@@ -16,7 +16,7 @@ int pass_through_array (int x)
 }
 
 int main (void) {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   assert(x == pass_through_array(x));
 

--- a/regression/cbmc/equality_through_array6/main.c
+++ b/regression/cbmc/equality_through_array6/main.c
@@ -16,7 +16,7 @@ int pass_through_array (int x)
 }
 
 int main (void) {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   assert(x == pass_through_array(x));
 

--- a/regression/cbmc/equality_through_array_of_struct1/main.c
+++ b/regression/cbmc/equality_through_array_of_struct1/main.c
@@ -13,7 +13,7 @@ struct str a[SIZE];
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   a[0].x = q;
   a[1].y = a[0].x;

--- a/regression/cbmc/equality_through_array_of_struct2/main.c
+++ b/regression/cbmc/equality_through_array_of_struct2/main.c
@@ -13,7 +13,7 @@ struct str a[SIZE];
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   for (int i = 0; i < SIZE; ++i)
   {

--- a/regression/cbmc/equality_through_array_of_struct3/main.c
+++ b/regression/cbmc/equality_through_array_of_struct3/main.c
@@ -23,7 +23,7 @@ void pass_through_array_of_struct (int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   pass_through_array_of_struct(q);
 

--- a/regression/cbmc/equality_through_array_of_struct4/main.c
+++ b/regression/cbmc/equality_through_array_of_struct4/main.c
@@ -30,7 +30,7 @@ int pass_through_array_of_struct (int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   assert(q == pass_through_array_of_struct(q));
 

--- a/regression/cbmc/equality_through_struct1/main.c
+++ b/regression/cbmc/equality_through_struct1/main.c
@@ -9,7 +9,7 @@ struct str
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
   struct str s;
 
   s.x = q;

--- a/regression/cbmc/equality_through_struct2/main.c
+++ b/regression/cbmc/equality_through_struct2/main.c
@@ -20,7 +20,7 @@ int pass_through_struct (int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   assert(q == pass_through_struct(q));
 

--- a/regression/cbmc/equality_through_struct3/main.c
+++ b/regression/cbmc/equality_through_struct3/main.c
@@ -20,7 +20,7 @@ struct str pass_through_struct (int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   struct str s = pass_through_struct(q);
 

--- a/regression/cbmc/equality_through_struct4/main.c
+++ b/regression/cbmc/equality_through_struct4/main.c
@@ -18,7 +18,7 @@ void pass_through_struct (struct str *s, int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   struct str s;
 

--- a/regression/cbmc/equality_through_struct_containing_arrays1/main.c
+++ b/regression/cbmc/equality_through_struct_containing_arrays1/main.c
@@ -33,7 +33,7 @@ void pass_through_struct_containing_arrays (int q)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   pass_through_struct_containing_arrays(q);
 

--- a/regression/cbmc/equality_through_struct_containing_arrays2/main.c
+++ b/regression/cbmc/equality_through_struct_containing_arrays2/main.c
@@ -33,7 +33,7 @@ void pass_through_struct_containing_arrays (int q, int j)
 
 int main (void)
 {
-  int q;
+  int q = __VERIFIER_nondet_int();
 
   s[1].z = 0;
 

--- a/regression/cbmc/equality_through_union1/main.c
+++ b/regression/cbmc/equality_through_union1/main.c
@@ -10,21 +10,21 @@ union u
 
 union u pass_through_union (int32_t q)
 {
-  union u un;
+   union u un;
 
-  un.z[0] = 0;
-  un.y = q;
+   un.z[0] = 0;
+   un.y = q;
 
-  return un;
+   return un;
 }
 
 int main (void)
 {
-  int32_t q;
+   int32_t q = __VERIFIER_nondet_int32_t();
 
-  union u un = pass_through_union(q);
+   union u un = pass_through_union(q);
 
-  assert(q == un.y);
+   assert(q == un.y);
 
-  return 1;
+   return 1;
 }

--- a/regression/cbmc/equality_through_union2/main.c
+++ b/regression/cbmc/equality_through_union2/main.c
@@ -10,23 +10,23 @@ union u
 
 union u pass_through_union (int32_t q)
 {
-  union u un;
+   union u un;
 
-  un.z[0] = 0;
-  un.y = q;
+   un.z[0] = 0;
+   un.y = q;
 
-  return un;
+   return un;
 }
 
 int main (void)
 {
-  int32_t q;
+   int32_t q = __VERIFIER_nondet_int32_t();
 
-  __CPROVER_assume(q > 0);
+   __CPROVER_assume(q > 0);
 
-  union u un = pass_through_union(q);
+   union u un = pass_through_union(q);
 
-  assert(q == un.x);
+   assert(q == un.x);
 
-  return 1;
+   return 1;
 }

--- a/regression/cbmc/equality_through_union3/main.c
+++ b/regression/cbmc/equality_through_union3/main.c
@@ -10,26 +10,26 @@ union u
 
 union u pass_through_union (uint32_t q)
 {
-  union u un;
+   union u un;
 
-  un.z[0] = 0x0;
-  un.y = q;
-  un.z[3] = 0x0;
-  un.z[0] = 0x0;
+   un.z[0] = 0x0;
+   un.y = q;
+   un.z[3] = 0x0;
+   un.z[0] = 0x0;
 
-  return un;
+   return un;
 }
 
 int main (void)
 {
-  uint32_t q;
+   uint32_t q = __VERIFIER_nondet_uint32_t();
 
-  __CPROVER_assume((q & q - 1) == 0);
-  __CPROVER_assume(256 <= q && q <= (1 << 23));
+   __CPROVER_assume((q & q - 1) == 0);
+   __CPROVER_assume(256 <= q && q <= (1 << 23));
 
-  union u un = pass_through_union(q);
+   union u un = pass_through_union(q);
 
-  assert(q == un.y);
+   assert(q == un.y);
 
-  return 1;
+   return 1;
 }

--- a/regression/cbmc/exit1/main.c
+++ b/regression/cbmc/exit1/main.c
@@ -1,7 +1,7 @@
 void exit(int status);
 
 int main() {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   if(x==10)
     exit(1);

--- a/regression/cbmc/field-sensitivity15/main.c
+++ b/regression/cbmc/field-sensitivity15/main.c
@@ -18,7 +18,7 @@ union _14237415465709481864_union
 
 void main(void)
 {
-  unsigned int x; // nondet
+  unsigned int x = __VERIFIER_nondet_int(); // nondet
 
   // the following is crucial (else pn trivially simplifies to 0)
   unsigned int var_7 = x;

--- a/regression/cbmc/field-sensitivity16/main.c
+++ b/regression/cbmc/field-sensitivity16/main.c
@@ -33,7 +33,7 @@ union _14237415465709481864_union
 
 void main(void)
 {
-  unsigned int x; // nondet
+  unsigned int x = __VERIFIER_nondet_int(); // nondet
 
   // the following is crucial (else pn trivially simplifies to 0)
   unsigned int var_7 = x;

--- a/regression/cbmc/gcc_switch_case_range1/main.c
+++ b/regression/cbmc/gcc_switch_case_range1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   switch(x)
   {
   case 0:

--- a/regression/cbmc/gcc_switch_case_range2/main.c
+++ b/regression/cbmc/gcc_switch_case_range2/main.c
@@ -8,7 +8,7 @@ typedef enum
 
 int main()
 {
-  unsigned x;
+  unsigned x = __VERIFIER_nondet_unsigned();
   switch(x)
   {
   case VALUE_1:

--- a/regression/cbmc/gcc_vector1/main.c
+++ b/regression/cbmc/gcc_vector1/main.c
@@ -16,7 +16,8 @@ int main()
   assert(sizeof(int)==4);
   assert(sizeof(v4si)==16);
 
-  vector_u x, y, z;
+  vector_u nondet_vu(void);
+  vector_u x = nondet_vu(), y = nondet_vu(), z;
 
   // vector operator vector
   z.v=x.v+y.v;

--- a/regression/cbmc/goto1/main.c
+++ b/regression/cbmc/goto1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int i, j;
+  int i = __VERIFIER_nondet_int(), j = __VERIFIER_nondet_int();
 
   if(i)
     goto l;

--- a/regression/cbmc/goto2/main.c
+++ b/regression/cbmc/goto2/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int i, j;
+  int i, j = __VERIFIER_nondet_int();
 
   i=1;
 

--- a/regression/cbmc/guard1/main.c
+++ b/regression/cbmc/guard1/main.c
@@ -1,15 +1,16 @@
 int main()
 {
-int i;
-int j;
-while(i) j = j + 1;
+  int i = __VERIFIER_nondet_int();
+  int j = __VERIFIER_nondet_int();
+  while(i)
+    j = j + 1;
 }
 
 /*
 #include <assert.h>
 
 int main (void) {
-	int i;
+	int i = __VERIFIER_nondet_int();
 
 	while (1) {
 		i++;

--- a/regression/cbmc/havoc_object1/main.c
+++ b/regression/cbmc/havoc_object1/main.c
@@ -16,7 +16,7 @@ int main()
   __CPROVER_assert(some_struct.j==2, "struct j"); // should fail
 
   // now conditional
-  _Bool c;
+  _Bool c = __VERIFIER_nondet__Bool();
   int *p=c?&i:&some_struct.i;
   i=20;
   some_struct.i=30;

--- a/regression/cbmc/if1/main.c
+++ b/regression/cbmc/if1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int i, j;
+  int i, j = __VERIFIER_nondet_int();
 
   i = 1;
 

--- a/regression/cbmc/if4/main.c
+++ b/regression/cbmc/if4/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   __CPROVER_assume(x==1);
 

--- a/regression/cbmc/inequality-with-constant-normalisation/main.c
+++ b/regression/cbmc/inequality-with-constant-normalisation/main.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 
 int main (void) {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   while ((x >= 10) && (x < 10)) {}
   while ((x >= 10) && (x <= 9)) {}

--- a/regression/cbmc/inequality-with-constant-normalisation1/main.c
+++ b/regression/cbmc/inequality-with-constant-normalisation1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  _Bool b1, b2;
+  _Bool b1 = __VERIFIER_nondet__Bool(), b2 = __VERIFIER_nondet__Bool();
 
   int nc = (b1 ? 1 : 2) == (b2 ? 1 : 2);
   assert(b1 != b2 || nc != 0);

--- a/regression/cbmc/lhs-pointer-aliases-constant/test.c
+++ b/regression/cbmc/lhs-pointer-aliases-constant/test.c
@@ -4,7 +4,7 @@ int main()
 {
   int x;
   const char *c = "Hello world";
-  _Bool dummy;
+  _Bool dummy = __VERIFIER_nondet__Bool();
   __CPROVER_assume(dummy);
 
   int *p = (dummy ? &x : (int *)c);

--- a/regression/cbmc/little-endian-array1/main.c
+++ b/regression/cbmc/little-endian-array1/main.c
@@ -4,7 +4,7 @@ int *array;
 
 int main()
 {
-  unsigned size;
+  unsigned size = __VERIFIER_nondet_unsigned();
   __CPROVER_assume(size==1);
 
   // produce unbounded array that does not have byte granularity

--- a/regression/cbmc/no-propagation/main.c
+++ b/regression/cbmc/no-propagation/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   if(x == 1)
     __CPROVER_assert(x == 1, "");
 }

--- a/regression/cbmc/null7/main.c
+++ b/regression/cbmc/null7/main.c
@@ -16,7 +16,7 @@ int main()
 
   if(s_is_set)
   {
-    unsigned len;
+    unsigned len = __VERIFIER_nondet_unsigned();
     __CPROVER_assume(len < 3);
     s += len;
   }

--- a/regression/cbmc/overflow/leftshift_overflow.c
+++ b/regression/cbmc/overflow/leftshift_overflow.c
@@ -48,7 +48,7 @@ void leftshift_overflow7(unsigned char x)
 void leftshift_overflow8(unsigned char x)
 {
   // overflow in an expression where operand and distance types are different
-  uint32_t u32;
+  uint32_t u32 = __VERIFIER_nondet_uint32_t();
   int64_t i64 = ((int64_t)u32) << 32;
 }
 

--- a/regression/cbmc/overflow/signed_multiplication1.c
+++ b/regression/cbmc/overflow/signed_multiplication1.c
@@ -2,7 +2,7 @@
 
 void main()
 {
-  int x, y, _x, _y;
+  int x, y, _x = __VERIFIER_nondet_int(), _y = __VERIFIER_nondet_int();
 
   x = _x;
   y = _y;

--- a/regression/cbmc/overflow/signed_subtraction1.c
+++ b/regression/cbmc/overflow/signed_subtraction1.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int a, b, neg;
+  int a = __VERIFIER_nondet_int(), b, neg = __VERIFIER_nondet_int();
 
   // this should not overflow, even not for a=INT_MIN
   b = a - a;

--- a/regression/cbmc/pointer-predicates/at_bounds1.c
+++ b/regression/cbmc/pointer-predicates/at_bounds1.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  size_t s;
+  size_t s = __VERIFIER_nondet_size_t();
   char *p = malloc(s);
   // at __CPROVER_max_malloc_size p + s would overflow; all larger values of s
   // make malloc return NULL when using --malloc-fail-null

--- a/regression/cbmc/pragma_cprover1/main.c
+++ b/regression/cbmc/pragma_cprover1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   int y[1];
 
 #pragma CPROVER check push

--- a/regression/cbmc/pragma_cprover2/main.c
+++ b/regression/cbmc/pragma_cprover2/main.c
@@ -5,7 +5,7 @@ int foo(int x)
 
 int main()
 {
-  int m, n;
+  int m, n = __VERIFIER_nondet_int();
 
 #pragma CPROVER check push
 #pragma CPROVER check disable "signed-overflow"

--- a/regression/cbmc/pragma_cprover_enable1/main.c
+++ b/regression/cbmc/pragma_cprover_enable1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   int y[1];
 
 #pragma CPROVER check push

--- a/regression/cbmc/pragma_cprover_enable2/main.c
+++ b/regression/cbmc/pragma_cprover_enable2/main.c
@@ -5,7 +5,7 @@ int foo(int x)
 
 int main()
 {
-  int m, n;
+  int m, n = __VERIFIER_nondet_int();
 
 #pragma CPROVER check push
 #pragma CPROVER check enable "signed-overflow"

--- a/regression/cbmc/r_w_ok1/main.c
+++ b/regression/cbmc/r_w_ok1/main.c
@@ -15,7 +15,7 @@ int main()
   assert(__CPROVER_r_ok(p, sizeof(int)));
   assert(__CPROVER_w_ok(p, sizeof(int)));
 
-  size_t n;
+  size_t n = __VERIFIER_nondet_size_t();
   char *arbitrary_size = malloc(n);
 
   assert(__CPROVER_r_ok(arbitrary_size, n));

--- a/regression/cbmc/r_w_ok7/main.c
+++ b/regression/cbmc/r_w_ok7/main.c
@@ -4,8 +4,8 @@
 
 int main()
 {
-  size_t x;
-  size_t y;
+  size_t x = __VERIFIER_nondet_size_t();
+  size_t y = __VERIFIER_nondet_size_t();
   uint8_t *a;
 
   __CPROVER_assume(x > 0);

--- a/regression/cbmc/return4/main.c
+++ b/regression/cbmc/return4/main.c
@@ -69,7 +69,7 @@ short f1_wh(short x)
 
 int main()
 {
-  int flag;
+  int flag = __VERIFIER_nondet_int();
   short a;
   short res0, res1;
 

--- a/regression/cbmc/runtime-profiling/main.c
+++ b/regression/cbmc/runtime-profiling/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int a;
+  int a = __VERIFIER_nondet_int();
   int temp = a;
   a = a + 1;
   assert(a == temp + 1);

--- a/regression/cbmc/sat-solver-warning/test.c
+++ b/regression/cbmc/sat-solver-warning/test.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  unsigned x;
+  unsigned x = __VERIFIER_nondet_unsigned();
   unsigned y = x;
   x /= 2;
   y /= 2;

--- a/regression/cbmc/simplify-array-size/main.c
+++ b/regression/cbmc/simplify-array-size/main.c
@@ -15,7 +15,7 @@ struct hash_table
 void main(void)
 {
   struct hash_table map;
-  size_t num_entries;
+  size_t num_entries = __VERIFIER_nondet_size_t();
   __CPROVER_assume(num_entries <= 8ul);
   size_t required_bytes = num_entries * sizeof(int) + sizeof(struct state);
   struct state *impl = malloc(required_bytes);

--- a/regression/cbmc/struct1/main.c
+++ b/regression/cbmc/struct1/main.c
@@ -16,7 +16,8 @@ struct y {
 
 int main()
 {
-  struct y Y;
+  struct y nondet_y(void);
+  struct y Y = nondet_y();
 
   {
     struct x tmp;

--- a/regression/cbmc/struct3/main.c
+++ b/regression/cbmc/struct3/main.c
@@ -1,10 +1,15 @@
-int main() {
-  struct
-  {
-    int a, b;
-  } s, q;
+struct ab
+{
+  int a, b;
+};
 
-  s=q;
+struct ab nondet_ab(void);
 
-  assert(s.a==q.a);
+int main()
+{
+  struct ab s, q = nondet_ab();
+
+  s = q;
+
+  assert(s.a == q.a);
 }

--- a/regression/cbmc/struct7/main.c
+++ b/regression/cbmc/struct7/main.c
@@ -16,7 +16,7 @@ void f(int *p)
 
 int main()
 {
-  int ind, x;
+  int ind, x = __VERIFIER_nondet_int();
   ind=x;
   int *p=&s.array[ind];
 

--- a/regression/cbmc/struct8/main.c
+++ b/regression/cbmc/struct8/main.c
@@ -5,7 +5,8 @@ struct X
 
 int main()
 {
-  int aa, bb, cc;
+  int aa = __VERIFIER_nondet_int(), bb = __VERIFIER_nondet_int(),
+      cc = __VERIFIER_nondet_int();
 
   struct X foo;
 

--- a/regression/cbmc/switch1/main.c
+++ b/regression/cbmc/switch1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int i;
+  int i = __VERIFIER_nondet_int();
 
   switch(i)
   {

--- a/regression/cbmc/switch2/main.c
+++ b/regression/cbmc/switch2/main.c
@@ -14,7 +14,7 @@ int f(int j)
 
 int main()
 {
-  int i;
+  int i = __VERIFIER_nondet_int();
 
   __CPROVER_assume(i==3 || i==4);
 

--- a/regression/cbmc/switch4/main.c
+++ b/regression/cbmc/switch4/main.c
@@ -1,6 +1,6 @@
 main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
 
   switch(x)
   {

--- a/regression/cbmc/sync_X_and_fetch-1/main.c
+++ b/regression/cbmc/sync_X_and_fetch-1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int *p, v, x, x_before;
+  int *p, v = __VERIFIER_nondet_int(), x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/sync_bool_compare-1/main.c
+++ b/regression/cbmc/sync_bool_compare-1/main.c
@@ -2,7 +2,8 @@
 
 int main()
 {
-  int *p, o, n, x, x_before;
+  int *p, o = __VERIFIER_nondet_int(), n = __VERIFIER_nondet_int(),
+          x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/sync_fetch_and_X-1/main.c
+++ b/regression/cbmc/sync_fetch_and_X-1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  int *p, v, x, x_before;
+  int *p, v = __VERIFIER_nondet_int(), x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/sync_val_compare-1/main.c
+++ b/regression/cbmc/sync_val_compare-1/main.c
@@ -2,7 +2,8 @@
 
 int main()
 {
-  int *p, o, n, x, x_before;
+  int *p, o = __VERIFIER_nondet_int(), n = __VERIFIER_nondet_int(),
+          x = __VERIFIER_nondet_int(), x_before;
   x_before = x;
   p = &x;
 

--- a/regression/cbmc/uniform_array1/main.c
+++ b/regression/cbmc/uniform_array1/main.c
@@ -1,7 +1,7 @@
 int main()
 {
   int A[] = {1, 1};
-  int i;
+  int i = __VERIFIER_nondet_int();
   __CPROVER_assert(i < 0 || i > 1 || A[i] == 1, "valid access into array of 1");
   __CPROVER_assert(A[i] == 1, "possible out-of-bounds access");
   return 0;

--- a/regression/cbmc/uninterpreted_function/uf2.c
+++ b/regression/cbmc/uninterpreted_function/uf2.c
@@ -3,7 +3,7 @@ __CPROVER_bool __CPROVER_uninterpreted_g(int, int);
 
 main()
 {
-  int a, b;
+  int a = __VERIFIER_nondet_int(), b = __VERIFIER_nondet_int();
 
   int inst1 = __CPROVER_uninterpreted_f(1, a);
   int inst2 = __CPROVER_uninterpreted_f(1, b);

--- a/regression/cbmc/union17/main.c
+++ b/regression/cbmc/union17/main.c
@@ -1,7 +1,7 @@
 int main()
 {
   // create a union type of non-constant, non-zero size
-  unsigned x;
+  unsigned x = __VERIFIER_nondet_unsigned();
   __CPROVER_assume(x > 0);
   union U
   {

--- a/regression/cbmc/union3/main.c
+++ b/regression/cbmc/union3/main.c
@@ -13,7 +13,7 @@ int my_func(int stat_loc)
 int main(void)
 {
   #ifdef __GNUC__
-  int x;
+  int x = __VERIFIER_nondet_int();
   assert(my_func(x)==x);
 
   union my_U

--- a/regression/cbmc/unwind_counters4/main.c
+++ b/regression/cbmc/unwind_counters4/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  int x;
+  int x = __VERIFIER_nondet_int();
   int y;
 
   do
@@ -9,7 +9,7 @@ int main()
     goto label;
     x = 1; // dead code, makes sure the above goto is not removed
   label:;
-    _Bool nondet;
+    _Bool nondet = __VERIFIER_nondet__Bool();
     if(nondet)
       __CPROVER_assert(y != 10, "violated via first loop");
     else

--- a/regression/cbmc/void_pointer3/main.c
+++ b/regression/cbmc/void_pointer3/main.c
@@ -8,7 +8,8 @@ int main()
   // with the object:offset encoding we need to make sure the address arithmetic
   // below will only touch the offset part
   __CPROVER_assume(sizeof(unsigned char)<sizeof(void*));
-  unsigned char o1, o2;
+  unsigned char o1 = __VERIFIER_nondet_char(),
+                o2 = __VERIFIER_nondet_unsigned_char();
 
   p+=o1;
   q+=o2;


### PR DESCRIPTION
Prepares for --uninitialized-check becoming a default check.

Replace bare uninitialized local variable declarations with explicit initialization in ~175 regression test files. These tests use uninitialized locals as a shorthand for nondeterministic values (e.g., int x; __CPROVER_assume(x > 0);). This is undefined behaviour in C that we used to tolerate in CBMC. Once we enable --uninitialized-check by default, however, those would have become (unwanted) verification failures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
