### PR TITLE
Decompose non-constant-offset byte_extract from union in field sensitivity

### DIFF
--- a/regression/contracts-dfcc/union_quantifier_performance/main.c
+++ b/regression/contracts-dfcc/union_quantifier_performance/main.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+
+#define __contract__(x) x
+#define requires(...) __CPROVER_requires(__VA_ARGS__)
+#define ensures(...) __CPROVER_ensures(__VA_ARGS__)
+#define assigns(...) __CPROVER_assigns(__VA_ARGS__)
+
+/* clang-format off */
+#define array_bound(arr, n, lo, hi, qvar)              \
+  __CPROVER_forall {                                   \
+    unsigned qvar; ((qvar) >= (n)) || ((arr)[(qvar)] >= (int)(lo) && (arr)[(qvar)] < (int)(hi)) \
+  }
+/* clang-format on */
+
+#define N 256
+#define K 8
+
+typedef struct
+{
+  int32_t coeffs[N];
+} poly;
+typedef struct
+{
+  poly vec[K];
+} polyveck;
+
+typedef union
+{
+  polyveck a;
+  polyveck b;
+} ab_t;
+
+/* clang-format off */
+void stub(polyveck *v)
+__contract__(
+  requires(__CPROVER_is_fresh(v, sizeof(polyveck)))
+  assigns(__CPROVER_object_upto(v, sizeof(polyveck)))
+  ensures(array_bound(v->vec[0].coeffs, N, 0, 100, _i0))
+  ensures(array_bound(v->vec[1].coeffs, N, 0, 100, _i1))
+);
+/* clang-format on */
+
+void harness(void)
+{
+  ab_t arr[1];
+  ab_t *p = arr;
+  stub(&p->a);
+  stub(&p->b);
+}
+
+int main(void)
+{
+  harness();
+}

--- a/regression/contracts-dfcc/union_quantifier_performance/no-array-fs.desc
+++ b/regression/contracts-dfcc/union_quantifier_performance/no-array-fs.desc
@@ -1,0 +1,12 @@
+THOROUGH dfcc-only smt-backend
+main.c
+--dfcc harness --replace-call-with-contract stub _ --slice-formula --z3 --no-array-field-sensitivity
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Without array field sensitivity the array-of-1 union is a single SSA
+symbol, so the WITH-update equation still materialises the full union
+as a bitvector (~45s vs ~1s for struct). The forall body is properly
+decomposed, but the remaining overhead makes this too slow for CORE.

--- a/regression/contracts-dfcc/union_quantifier_performance/test.desc
+++ b/regression/contracts-dfcc/union_quantifier_performance/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only smt-backend
+main.c
+--dfcc harness --replace-call-with-contract stub _ --slice-formula --z3
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Union with quantified contract postconditions and array-of-1 pointer
+indirection should not cause performance explosion.
+See GitHub issue diffblue/cbmc#8813.

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -37,17 +37,14 @@ exprt field_sensitivityt::apply_byte_extract(
   const byte_extract_exprt &be,
   bool write) const
 {
-  if(
-    (be.op().type().id() != ID_union && be.op().type().id() != ID_union_tag) ||
-    !is_ssa_expr(be.op()))
-  {
+  if(be.op().type().id() != ID_union && be.op().type().id() != ID_union_tag)
     return be;
-  }
 
   // For non-constant offsets, decompose through the widest union member so
   // that field sensitivity can process the resulting struct/array expression.
   // This avoids materialising the full union as a flat bitvector in the SMT
-  // encoding.
+  // encoding. The operand need not be an SSA expression (e.g., it may be an
+  // index into an array of unions when array field sensitivity is disabled).
   if(!be.offset().is_constant())
   {
     const union_typet &union_type =
@@ -61,24 +58,9 @@ exprt field_sensitivityt::apply_byte_extract(
       widest.has_value() && union_size.has_value() &&
       widest->second == *union_size)
     {
-      ssa_exprt tmp = to_ssa_expr(be.op());
-      bool was_l2 = !tmp.get_level_2().empty();
-      tmp.remove_level_2();
-      const member_exprt member{
-        tmp.get_original_expr(),
-        widest->first.get_name(),
-        widest->first.type()};
-      tmp.set_expression(member);
-
-      exprt member_ssa;
-      if(was_l2)
-        member_ssa = state.rename(std::move(tmp), ns).get();
-      else
-        member_ssa = std::move(tmp);
-
       byte_extract_exprt new_be{
         be.id(),
-        std::move(member_ssa),
+        member_exprt{be.op(), widest->first.get_name(), widest->first.type()},
         be.offset(),
         be.get_bits_per_byte(),
         be.type()};
@@ -87,6 +69,9 @@ exprt field_sensitivityt::apply_byte_extract(
 
     return be;
   }
+
+  if(!is_ssa_expr(be.op()))
+    return be;
 
   const union_typet &type = be.op().type().id() == ID_union_tag
                               ? ns.follow_tag(to_union_tag_type(be.op().type()))

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -39,8 +39,52 @@ exprt field_sensitivityt::apply_byte_extract(
 {
   if(
     (be.op().type().id() != ID_union && be.op().type().id() != ID_union_tag) ||
-    !is_ssa_expr(be.op()) || !be.offset().is_constant())
+    !is_ssa_expr(be.op()))
   {
+    return be;
+  }
+
+  // For non-constant offsets, decompose through the widest union member so
+  // that field sensitivity can process the resulting struct/array expression.
+  // This avoids materialising the full union as a flat bitvector in the SMT
+  // encoding.
+  if(!be.offset().is_constant())
+  {
+    const union_typet &union_type =
+      be.op().type().id() == ID_union_tag
+        ? ns.follow_tag(to_union_tag_type(be.op().type()))
+        : to_union_type(be.op().type());
+
+    const auto union_size = pointer_offset_bits(union_type, ns);
+    const auto widest = union_type.find_widest_union_component(ns);
+    if(
+      widest.has_value() && union_size.has_value() &&
+      widest->second == *union_size)
+    {
+      ssa_exprt tmp = to_ssa_expr(be.op());
+      bool was_l2 = !tmp.get_level_2().empty();
+      tmp.remove_level_2();
+      const member_exprt member{
+        tmp.get_original_expr(),
+        widest->first.get_name(),
+        widest->first.type()};
+      tmp.set_expression(member);
+
+      exprt member_ssa;
+      if(was_l2)
+        member_ssa = state.rename(std::move(tmp), ns).get();
+      else
+        member_ssa = std::move(tmp);
+
+      byte_extract_exprt new_be{
+        be.id(),
+        std::move(member_ssa),
+        be.offset(),
+        be.get_bits_per_byte(),
+        be.type()};
+      return apply(ns, state, std::move(new_be), write);
+    }
+
     return be;
   }
 


### PR DESCRIPTION
When a byte_extract with a non-constant offset is applied to a union-typed SSA expression (e.g., from a pointer dereference inside a quantified contract postcondition), field sensitivity previously returned the expression unchanged. This left the full union symbol referenced in the SSA equation, forcing the SMT2 converter to materialise the entire union as a flat bitvector concatenation (e.g., 65536 bits for polyveck with 8x256 int32 elements).

Extend apply_byte_extract to handle non-constant offsets by decomposing through the widest union member, analogous to the get_subexpression_at_offset fix in pointer_offset_size.cpp. This creates a field-sensitive SSA symbol for the member and wraps it in a new byte_extract, which apply then processes recursively through the struct/array decomposition.

On the reproducer from
github.com/diffblue/cbmc/issues/8813#issuecomment-4234622724:

  Without --slice-formula:
    struct: 1.8s    union before: 44s    union after: 50s
  With --slice-formula:
    struct: 1.1s    union before: 21s    union after: 1.1s

The remaining gap without --slice-formula is due to the union definition equation still being emitted (it is no longer referenced by the forall expressions, but the slicer is needed to remove it).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
