### PR TITLE
Fix sub-byte bit placement in boolbv convert_byte_update

### DIFF
--- a/regression/cbmc/byte_update_sub_byte1/main.c
+++ b/regression/cbmc/byte_update_sub_byte1/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  unsigned x;
+  __CPROVER_bitvector[1] *p = (__CPROVER_bitvector[1] *)&x;
+  *p = 0;
+  __CPROVER_assert((x & 0x80u) == 0u, "MSB of byte 0 is cleared");
+}

--- a/regression/cbmc/byte_update_sub_byte1/multibyte-symbolic.c
+++ b/regression/cbmc/byte_update_sub_byte1/multibyte-symbolic.c
@@ -1,0 +1,13 @@
+// As multibyte.c, but with a symbolic (constrained-to-0) byte offset so that
+// the variable-offset branch of convert_byte_update is exercised for a
+// non-byte-aligned update wider than one byte.
+int main()
+{
+  unsigned x = 0xFFFFFFFFu;
+  unsigned offset;
+  __CPROVER_assume(offset == 0);
+  __CPROVER_bitvector[9] *p = (__CPROVER_bitvector[9] *)((char *)&x + offset);
+  *p = 0;
+  __CPROVER_assert(x == 0xFFFF007Fu, "9-bit update matches lower_byte_update");
+  return 0;
+}

--- a/regression/cbmc/byte_update_sub_byte1/multibyte-symbolic.desc
+++ b/regression/cbmc/byte_update_sub_byte1/multibyte-symbolic.desc
@@ -1,0 +1,12 @@
+CORE
+multibyte-symbolic.c
+--little-endian --no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Same as multibyte.c (9-bit case) but with a symbolic (constrained-to-0)
+byte offset, exercising the variable-offset branch of convert_byte_update
+for a non-byte-aligned update wider than one byte.

--- a/regression/cbmc/byte_update_sub_byte1/multibyte.c
+++ b/regression/cbmc/byte_update_sub_byte1/multibyte.c
@@ -1,0 +1,22 @@
+// Non-byte-aligned sub-byte updates whose width exceeds the byte width. These
+// are the cases where placing only the trailing partial byte (rather than
+// shifting the whole value) diverges from lower_byte_update. Writing a zero of
+// the given width over 0xFFFFFFFF must clear the value's bits at the high end
+// of the last partial byte, i.e. bit positions [tail_shift, tail_shift+width).
+int main()
+{
+  // 9-bit zero: tail_shift = 8 - (9 % 8) = 7, so bits [7, 16) are cleared.
+  unsigned x9 = 0xFFFFFFFFu;
+  __CPROVER_bitvector[9] *p9 = (__CPROVER_bitvector[9] *)&x9;
+  *p9 = 0;
+  __CPROVER_assert(x9 == 0xFFFF007Fu, "9-bit update matches lower_byte_update");
+
+  // 17-bit zero: tail_shift = 8 - (17 % 8) = 7, so bits [7, 24) are cleared.
+  unsigned x17 = 0xFFFFFFFFu;
+  __CPROVER_bitvector[17] *p17 = (__CPROVER_bitvector[17] *)&x17;
+  *p17 = 0;
+  __CPROVER_assert(
+    x17 == 0xFF00007Fu, "17-bit update matches lower_byte_update");
+
+  return 0;
+}

--- a/regression/cbmc/byte_update_sub_byte1/multibyte.desc
+++ b/regression/cbmc/byte_update_sub_byte1/multibyte.desc
@@ -1,0 +1,15 @@
+CORE
+multibyte.c
+--little-endian --no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Non-byte-aligned updates wider than one byte (9-bit and 17-bit). These
+exercise the regime where the whole value must be shifted up by
+byte_width - tail_bits to match lower_byte_update; placing only the
+trailing partial byte (the earlier behaviour) would yield 0xFFFF7F00 /
+0xFF7F0000 instead of 0xFFFF007F / 0xFF00007F. --no-simplify exercises
+the boolbv convert_byte_update path with a constant offset.

--- a/regression/cbmc/byte_update_sub_byte1/symbolic-offset.desc
+++ b/regression/cbmc/byte_update_sub_byte1/symbolic-offset.desc
@@ -1,0 +1,11 @@
+CORE
+symbolic.c
+--little-endian --no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Same as test.desc but with a symbolic (constrained-to-0) byte offset,
+exercising the variable-offset branch of convert_byte_update.

--- a/regression/cbmc/byte_update_sub_byte1/symbolic.c
+++ b/regression/cbmc/byte_update_sub_byte1/symbolic.c
@@ -1,0 +1,9 @@
+int main()
+{
+  unsigned x;
+  unsigned offset;
+  __CPROVER_assume(offset == 0);
+  __CPROVER_bitvector[1] *p = (__CPROVER_bitvector[1] *)((char *)&x + offset);
+  *p = 0;
+  __CPROVER_assert((x & 0x80u) == 0u, "MSB of byte 0 is cleared");
+}

--- a/regression/cbmc/byte_update_sub_byte1/test.desc
+++ b/regression/cbmc/byte_update_sub_byte1/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--little-endian --no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Writing a 1-bit zero through a __CPROVER_bitvector[1] pointer must
+clear the MSB of the first byte, not the LSB. The --no-simplify flag
+is needed to exercise the boolbv convert_byte_update path directly.
+This test uses a constant offset (byte 0).

--- a/src/solvers/flattening/boolbv_byte_update.cpp
+++ b/src/solvers/flattening/boolbv_byte_update.cpp
@@ -41,6 +41,25 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
   if(update_width>bv.size())
     update_width=bv.size();
 
+  // When the update value's width is not a multiple of the byte width,
+  // lower_byte_update places the value at the high end of the last partial
+  // byte (concatenating {value, remaining_low_bits}). For little-endian the
+  // high end is at higher bit indices, so the *whole* value is shifted up by
+  // byte_width - tail_bits (the low tail_shift bits of the target keep their
+  // original value). For big-endian the endianness map already places bit 0
+  // at the MSB, so no shift is needed.
+  //
+  // TODO: This MSB-first placement matches lower_byte_update, but
+  // simplify_byte_update's expr2bits/bits2expr path places a sub-byte value
+  // LSB-first, so the two disagree for non-byte-aligned updates (e.g. writing
+  // a 1-bit 0 over 0xFFFFFFFF yields 0xFFFFFF7F here but 0xFFFFFFFE via the
+  // simplifier). That is why the regression tests run with --no-simplify and
+  // assert the concrete bit pattern. The canonical convention should be picked
+  // and both paths aligned in a follow-up.
+  const std::size_t tail_bits = update_width % byte_width;
+  const std::size_t tail_shift =
+    little_endian && tail_bits != 0 ? byte_width - tail_bits : 0;
+
   // see if the byte number is constant
 
   const auto index = numeric_cast<mp_integer>(offset_expr);
@@ -59,10 +78,11 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
       endianness_mapt map_value = endianness_map(value.type(), little_endian);
 
       const std::size_t offset_i = numeric_cast_v<std::size_t>(offset);
+      const std::size_t shifted_offset_i = offset_i + tail_shift;
 
       for(std::size_t i = 0; i < update_width; i++)
       {
-        size_t index_op = map_op.map_bit(offset_i + i);
+        size_t index_op = map_op.map_bit(shifted_offset_i + i);
         size_t index_value = map_value.map_bit(i);
 
         INVARIANT(
@@ -89,10 +109,11 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
     endianness_mapt map_op = endianness_map(op.type(), little_endian);
     endianness_mapt map_value = endianness_map(value.type(), little_endian);
 
+    const std::size_t shifted_offset = offset + tail_shift;
     for(std::size_t bit=0; bit<update_width; bit++)
-      if(offset+bit<bv.size())
+      if(shifted_offset + bit < bv.size())
       {
-        std::size_t bv_o=map_op.map_bit(offset+bit);
+        std::size_t bv_o = map_op.map_bit(shifted_offset + bit);
         std::size_t value_bv_o=map_value.map_bit(bit);
 
         bv[bv_o]=prop.lselect(equal, value_bv[value_bv_o], bv[bv_o]);


### PR DESCRIPTION
When byte_update writes a sub-byte value (e.g., a 1-bit bitvector) at a byte-aligned offset, the value must be placed at the high end of the affected byte, matching the semantics of lower_byte_update which concatenates {value, remaining_low_bits}.

The boolbv convert_byte_update was placing the value at bit 0 (the low end) instead. For little-endian, this means the value was written to the LSB instead of the MSB of the byte. For big-endian, the endianness map already reverses bits so that bit 0 maps to the MSB, making the existing code accidentally correct.

Generalise the fix to handle any non-byte-aligned update width: the trailing partial byte's bits are shifted to the high end for little-endian, matching lower_byte_update's padding semantics.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
