### PR TITLE
move `bitvector_typet` into bitvector_type.h

### DIFF
--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <map>
 
 class ansi_c_declarationt;
+class bitvector_typet;
 class c_bit_field_typet;
 class shift_exprt;
 

--- a/src/ansi-c/literals/convert_integer_literal.cpp
+++ b/src/ansi-c/literals/convert_integer_literal.cpp
@@ -11,12 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "convert_integer_literal.h"
 
-#include <cctype>
-
 #include <util/arith_tools.h>
+#include <util/c_types.h> // IWYU pragma: keep
 #include <util/config.h>
 #include <util/std_expr.h>
 #include <util/string2int.h>
+
+#include <cctype>
 
 exprt convert_integer_literal(const std::string &src)
 {

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening
 #include "xml_goto_trace.h"
 
 #include <util/arith_tools.h>
+#include <util/bitvector_types.h>
 #include <util/namespace.h>
 #include <util/string_constant.h>
 #include <util/symbol.h>

--- a/src/statement-list/converters/statement_list_types.cpp
+++ b/src/statement-list/converters/statement_list_types.cpp
@@ -13,6 +13,7 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 
 #include <util/bitvector_types.h>
 #include <util/ieee_float.h>
+#include <util/std_types.h>
 
 signedbv_typet get_int_type()
 {

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file util/bitvector_expr.h
 /// API to expression classes for bitvectors
 
+#include "bitvector_types.h"
 #include "std_expr.h"
 
 /// \brief The byte swap expression

--- a/src/util/bitvector_types.h
+++ b/src/util/bitvector_types.h
@@ -12,7 +12,70 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_BITVECTOR_TYPES_H
 #define CPROVER_UTIL_BITVECTOR_TYPES_H
 
-#include "std_types.h"
+#include "expr_cast.h" // IWYU pragma: keep
+#include "mp_arith.h"
+#include "type.h"
+
+class constant_exprt;
+
+/// Base class of fixed-width bit-vector types
+///
+/// Superclass of anything represented by bits, for example integers (in 32
+/// or 64-bit representation), floating point numbers etc. In contrast, \ref
+/// integer_typet is a direct integer representation.
+class bitvector_typet : public typet
+{
+public:
+  explicit bitvector_typet(const irep_idt &_id) : typet(_id)
+  {
+  }
+
+  bitvector_typet(const irep_idt &_id, std::size_t width) : typet(_id)
+  {
+    set_width(width);
+  }
+
+  bitvector_typet(const irep_idt &_id, mp_integer _width) : typet(_id)
+  {
+    width(_width);
+  }
+
+  std::size_t get_width() const
+  {
+    return get_size_t(ID_width);
+  }
+
+  std::size_t width() const;
+
+  void set_width(std::size_t width)
+  {
+    set_size_t(ID_width, width);
+  }
+
+  void width(const mp_integer &);
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      vm, !type.get(ID_width).empty(), "bitvector type must have width");
+  }
+};
+
+/// Check whether a reference to a typet is a \ref bitvector_typet.
+/// \param type: Source type.
+/// \return True if \p type is a \ref bitvector_typet.
+template <>
+inline bool can_cast_type<bitvector_typet>(const typet &type)
+{
+  return type.id() == ID_signedbv || type.id() == ID_unsignedbv ||
+         type.id() == ID_fixedbv || type.id() == ID_floatbv ||
+         type.id() == ID_verilog_signedbv ||
+         type.id() == ID_verilog_unsignedbv || type.id() == ID_bv ||
+         type.id() == ID_pointer || type.id() == ID_c_bit_field ||
+         type.id() == ID_c_bool;
+}
 
 /// This method tests,
 /// if the given typet is a signed or unsigned bitvector.

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -900,65 +900,6 @@ inline array_typet &to_array_type(typet &type)
   return static_cast<array_typet &>(type);
 }
 
-/// Base class of fixed-width bit-vector types
-///
-/// Superclass of anything represented by bits, for example integers (in 32
-/// or 64-bit representation), floating point numbers etc. In contrast, \ref
-/// integer_typet is a direct integer representation.
-class bitvector_typet : public typet
-{
-public:
-  explicit bitvector_typet(const irep_idt &_id) : typet(_id)
-  {
-  }
-
-  bitvector_typet(const irep_idt &_id, std::size_t width) : typet(_id)
-  {
-    set_width(width);
-  }
-
-  bitvector_typet(const irep_idt &_id, mp_integer _width) : typet(_id)
-  {
-    width(_width);
-  }
-
-  std::size_t get_width() const
-  {
-    return get_size_t(ID_width);
-  }
-
-  std::size_t width() const;
-
-  void set_width(std::size_t width)
-  {
-    set_size_t(ID_width, width);
-  }
-
-  void width(const mp_integer &);
-
-  static void check(
-    const typet &type,
-    const validation_modet vm = validation_modet::INVARIANT)
-  {
-    DATA_CHECK(
-      vm, !type.get(ID_width).empty(), "bitvector type must have width");
-  }
-};
-
-/// Check whether a reference to a typet is a \ref bitvector_typet.
-/// \param type: Source type.
-/// \return True if \p type is a \ref bitvector_typet.
-template <>
-inline bool can_cast_type<bitvector_typet>(const typet &type)
-{
-  return type.id() == ID_signedbv || type.id() == ID_unsignedbv ||
-         type.id() == ID_fixedbv || type.id() == ID_floatbv ||
-         type.id() == ID_verilog_signedbv ||
-         type.id() == ID_verilog_unsignedbv || type.id() == ID_bv ||
-         type.id() == ID_pointer || type.id() == ID_c_bit_field ||
-         type.id() == ID_c_bool;
-}
-
 /// String type
 ///
 /// Represents string constants, such as `@class_identifier`.

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/extremes-go-top.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/extremes-go-top.cpp
@@ -7,6 +7,7 @@
 \*******************************************************************/
 
 #include <util/arith_tools.h>
+#include <util/bitvector_types.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 


### PR DESCRIPTION
This moves the class `bitvector_typet` from `std_types.h` into `bitvector_types.h`, which is more intuitive.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
