### PR TITLE
SMT2 backend: reduction operators

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2724,6 +2724,67 @@ void smt2_convt::convert_expr(const exprt &expr)
     // use the lowering
     convert_expr(to_cond_expr(expr).lower());
   }
+  else if(expr.id() == ID_reduction_and)
+  {
+    // This is true iff all bits in the operand are true
+    auto &op = to_unary_expr(expr).op();
+    auto all_ones = to_bitvector_type(op.type()).all_ones_expr();
+    convert_expr(equal_exprt{op, all_ones});
+  }
+  else if(expr.id() == ID_reduction_nand)
+  {
+    // This is the negation of "reduction and"
+    auto &op = to_unary_expr(expr).op();
+    convert_expr(not_exprt{unary_predicate_exprt{ID_reduction_and, op}});
+  }
+  else if(expr.id() == ID_reduction_or)
+  {
+    // This is true iff the operand is not zero
+    auto &op = to_unary_expr(expr).op();
+    auto all_zeros = to_bitvector_type(op.type()).all_zeros_expr();
+    convert_expr(notequal_exprt{op, all_zeros});
+  }
+  else if(expr.id() == ID_reduction_nor)
+  {
+    // This is the negation of "reduction or"
+    auto &op = to_unary_expr(expr).op();
+    convert_expr(not_exprt{unary_predicate_exprt{ID_reduction_or, op}});
+  }
+  else if(expr.id() == ID_reduction_xor)
+  {
+    // This is the parity of the operand. No SMT-LIB 2 equivalent.
+    // Do bit-wise. SMT-LIB 3.0 could do this with "fold bvxor".
+    auto &op = to_unary_expr(expr).op();
+    auto width = to_bitvector_type(op.type()).get_width();
+    PRECONDITION(width >= 1);
+
+    if(width == 1)
+    {
+      out << "(= ";
+      flatten2bv(op);
+      out << " #b1)";
+    }
+    else
+    {
+      out << "(let ((?rop ";
+      flatten2bv(op);
+      out << ")) ";
+
+      // XOR all bits: extract each bit and use multi-ary bvxor
+      out << "(= (bvxor";
+      for(std::size_t i = 0; i < width; i++)
+        out << " ((_ extract " << i << " " << i << ") ?rop)";
+      out << ") #b1)";
+
+      out << ')'; // let
+    }
+  }
+  else if(expr.id() == ID_reduction_xnor)
+  {
+    // This is the negation of "reduction xor"
+    auto &op = to_unary_expr(expr).op();
+    convert_expr(not_exprt{unary_predicate_exprt{ID_reduction_xor, op}});
+  }
   else
     INVARIANT_WITH_DIAGNOSTICS(
       false,

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -1,8 +1,15 @@
 // Author: Diffblue Ltd.
 
-#include <testing-utils/use_catch.h>
+/// \file
+/// Unit tests for smt2_convt
+
+#include <util/bitvector_types.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 #include <solvers/smt2/smt2_conv.h>
+#include <testing-utils/use_catch.h>
 
 TEST_CASE(
   "smt2_convt::convert_identifier character escaping.",
@@ -16,4 +23,94 @@ TEST_CASE(
   CHECK(smt2_convt::convert_identifier("\\") == "|&92;|");
   CHECK(smt2_convt::convert_identifier("|") == "|&124;|");
   CHECK(smt2_convt::convert_identifier("&") == "&");
+}
+
+/// Helper: extract the "(assert ...)" line from SMT2 output of set_to
+static std::string get_assert(const exprt &red_expr)
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+  std::ostringstream out;
+  smt2_convt conv(ns, "test", "", "QF_BV", smt2_convt::solvert::GENERIC, out);
+  conv.set_to(red_expr, true);
+  std::string result = out.str();
+  auto pos = result.find("(assert ");
+  REQUIRE(pos != std::string::npos);
+  // strip trailing newline
+  auto end = result.find_last_not_of('\n');
+  return result.substr(pos, end - pos + 1);
+}
+
+TEST_CASE("smt2_convt reduction operators", "[core][solvers][smt2]")
+{
+  unsignedbv_typet u2(2);
+  symbol_exprt sym("x", u2);
+
+  SECTION("reduction_and")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_and, sym}) ==
+      "(assert (= x (_ bv3 2)))");
+  }
+
+  SECTION("reduction_nand")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_nand, sym}) ==
+      "(assert (not (= x (_ bv3 2))))");
+  }
+
+  SECTION("reduction_or")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_or, sym}) ==
+      "(assert (not (= x (_ bv0 2))))");
+  }
+
+  SECTION("reduction_nor")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_nor, sym}) ==
+      "(assert (not (not (= x (_ bv0 2)))))");
+  }
+
+  SECTION("reduction_xor")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_xor, sym}) ==
+      "(assert (let ((?rop x)) "
+      "(= (bvxor ((_ extract 0 0) ?rop) ((_ extract 1 1) ?rop)) #b1)))");
+  }
+
+  SECTION("reduction_xnor")
+  {
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_xnor, sym}) ==
+      "(assert (not (let ((?rop x)) "
+      "(= (bvxor ((_ extract 0 0) ?rop) ((_ extract 1 1) ?rop)) #b1))))");
+  }
+
+  SECTION("reduction_xor 1-bit")
+  {
+    symbol_exprt sym1("y", unsignedbv_typet(1));
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_xor, sym1}) ==
+      "(assert (= y #b1))");
+  }
+
+  SECTION("reduction_and 1-bit")
+  {
+    symbol_exprt sym1("y", unsignedbv_typet(1));
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_and, sym1}) ==
+      "(assert (= y (_ bv1 1)))");
+  }
+
+  SECTION("reduction_or 1-bit")
+  {
+    symbol_exprt sym1("y", unsignedbv_typet(1));
+    REQUIRE(
+      get_assert(unary_predicate_exprt{ID_reduction_or, sym1}) ==
+      "(assert (not (= y (_ bv0 1))))");
+  }
 }


### PR DESCRIPTION
This adds the reduction operators to the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
