### PR TITLE
Remove support for CVC 3 and CVC 4

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -495,12 +495,6 @@ use Boolector
 \fB\-\-cprover\-smt2\fR
 use CPROVER SMT2 solver
 .TP
-\fB\-\-cvc3\fR
-use CVC3
-.TP
-\fB\-\-cvc4\fR
-use CVC4
-.TP
 \fB\-\-cvc5\fR
 use CVC5
 .TP

--- a/doc/man/goto-synthesizer.1
+++ b/doc/man/goto-synthesizer.1
@@ -61,12 +61,6 @@ use Boolector
 \fB\-\-cprover\-smt2\fR
 use CPROVER SMT2 solver
 .TP
-\fB\-\-cvc3\fR
-use CVC3
-.TP
-\fB\-\-cvc4\fR
-use CVC4
-.TP
 \fB\-\-cvc5\fR
 use CVC5
 .TP

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -413,12 +413,6 @@ use Boolector
 \fB\-\-cprover\-smt2\fR
 use CPROVER SMT2 solver
 .TP
-\fB\-\-cvc3\fR
-use CVC3
-.TP
-\fB\-\-cvc4\fR
-use CVC4
-.TP
 \fB\-\-cvc5\fR
 use CVC5
 .TP

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -149,10 +149,6 @@ smt2_dect::solvert solver_factoryt::get_smt2_solver_type() const
     s = smt2_dect::solvert::CPROVER_SMT2;
   else if(options.get_bool_option("mathsat"))
     s = smt2_dect::solvert::MATHSAT;
-  else if(options.get_bool_option("cvc3"))
-    s = smt2_dect::solvert::CVC3;
-  else if(options.get_bool_option("cvc4"))
-    s = smt2_dect::solvert::CVC4;
   else if(options.get_bool_option("cvc5"))
     s = smt2_dect::solvert::CVC5;
   else if(options.get_bool_option("yices"))
@@ -663,12 +659,6 @@ static void parse_smt2_options(const cmdlinet &cmdline, optionst &options)
     options.set_option("smt2", true);
   }
 
-  if(cmdline.isset("cvc4"))
-  {
-    options.set_option("cvc4", true), solver_set = true;
-    options.set_option("smt2", true);
-  }
-
   if(cmdline.isset("cvc5"))
   {
     options.set_option("cvc5", true), solver_set = true;
@@ -742,8 +732,6 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options)
        "boolector",
        "cprover-smt2",
        "mathsat",
-       "cvc3",
-       "cvc4",
        "cvc5",
        "yices",
        "z3",

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -103,8 +103,7 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   "(smt1)" /* rejected, will eventually disappear */                           \
   "(smt2)"                                                                     \
   "(fpa)"                                                                      \
-  "(cvc3)"                                                                     \
-  "(cvc4)(cvc5)(bitwuzla)(boolector)(yices)(z3)"                               \
+  "(cvc5)(bitwuzla)(boolector)(yices)(z3)"                                     \
   "(mathsat)"                                                                  \
   "(cprover-smt2)"                                                             \
   "(incremental-smt2-solver):"                                                 \
@@ -133,8 +132,6 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   " {y--bitwuzla} \t use Bitwuzla\n"                                           \
   " {y--boolector} \t use Boolector\n"                                         \
   " {y--cprover-smt2} \t use CPROVER SMT2 solver\n"                            \
-  " {y--cvc3} \t use CVC3\n"                                                   \
-  " {y--cvc4} \t use CVC4\n"                                                   \
   " {y--cvc5} \t use CVC5\n"                                                   \
   " {y--mathsat} \t use MathSAT\n"                                             \
   " {y--yices} \t use Yices\n"                                                 \

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -101,15 +101,6 @@ smt2_convt::smt2_convt(
     emit_set_logic = false;
     break;
 
-  case solvert::CVC3:
-    break;
-
-  case solvert::CVC4:
-    logic = "ALL";
-    use_array_of_bool = true;
-    use_as_const = true;
-    break;
-
   case solvert::CVC5:
     logic = "ALL";
     use_FPA_theory = true;
@@ -178,8 +169,6 @@ void smt2_convt::write_header()
   case solvert::BOOLECTOR: out << "; Generated for Boolector\n"; break;
   case solvert::CPROVER_SMT2:
     out << "; Generated for the CPROVER SMT2 solver\n"; break;
-  case solvert::CVC3: out << "; Generated for CVC 3\n"; break;
-  case solvert::CVC4: out << "; Generated for CVC 4\n"; break;
   case solvert::CVC5: out << "; Generated for CVC 5\n"; break;
   case solvert::MATHSAT: out << "; Generated for MathSAT\n"; break;
   case solvert::YICES: out << "; Generated for Yices\n"; break;

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -47,8 +47,6 @@ public:
     BITWUZLA,
     BOOLECTOR,
     CPROVER_SMT2,
-    CVC3,
-    CVC4,
     CVC5,
     MATHSAT,
     YICES,

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -25,8 +25,6 @@ std::string smt2_dect::decision_procedure_text() const
      solver==solvert::BITWUZLA?"Bitwuzla":
      solver==solvert::BOOLECTOR?"Boolector":
      solver==solvert::CPROVER_SMT2?"CPROVER SMT2":
-     solver==solvert::CVC3?"CVC3":
-     solver==solvert::CVC4?"CVC4":
      solver==solvert::CVC5?"CVC5":
      solver==solvert::MATHSAT?"MathSAT":
      solver==solvert::YICES?"Yices":
@@ -87,23 +85,6 @@ decision_proceduret::resultt smt2_dect::dec_solve(const exprt &assumption)
   case solvert::CPROVER_SMT2:
     argv = {solver_binary_name("smt2_solver")};
     stdin_filename = temp_file_problem();
-    break;
-
-  case solvert::CVC3:
-    argv = {
-      solver_binary_name("cvc3"),
-      "+model",
-      "-lang",
-      "smtlib",
-      "-output-lang",
-      "smtlib",
-      temp_file_problem()};
-    break;
-
-  case solvert::CVC4:
-    // The flags --bitblast=eager --bv-div-zero-const help but only
-    // work for pure bit-vector formulas.
-    argv = {solver_binary_name("cvc4"), "-L", "smt2", temp_file_problem()};
     break;
 
   case solvert::CVC5:


### PR DESCRIPTION
This removes the support for CVC 3 and CVC 4.

CVC 3 and 4 have been superseded by CVC 5.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
