### PR TITLE
float_utils: normalization shift for very short fractions

### DIFF
--- a/regression/smt2_solver/fp/bit-to-fp1.desc
+++ b/regression/smt2_solver/fp/bit-to-fp1.desc
@@ -1,0 +1,7 @@
+CORE
+bit-to-fp1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--

--- a/regression/smt2_solver/fp/bit-to-fp1.smt2
+++ b/regression/smt2_solver/fp/bit-to-fp1.smt2
@@ -1,0 +1,14 @@
+;
+; convert (_ bv1 1) to double precision FP,
+; and check whether that is equal to 1.0.
+;
+(define-fun B0 () Bool (=
+  ((_ to_fp_unsigned 11 53) roundNearestTiesToAway (_ bv1 1))
+  (fp #b0 #b01111111111 #b0000000000000000000000000000000000000000000000000000)))
+
+(assert (not B0))
+
+; expected to be UNSAT, i.e., they are equal
+(check-sat)
+
+(exit)

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -917,7 +917,7 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
     literalt shift=prop.land(equal);
 
     // build shifted value
-    bvt shifted_fraction=bv_utils.shift(fraction, bv_utilst::LEFT, i);
+    bvt shifted_fraction=bv_utils.shift(fraction, bv_utilst::shiftt::SHIFT_LEFT, i);
     bv_utils.cond_implies_equal(shift, shifted_fraction, new_fraction);
 
     // build new exponent
@@ -950,11 +950,18 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
 
   bvt exponent_delta=bv_utils.zeros(exponent.size());
 
+  // Fraction smaller than the max distance? Pad up with zeros.
+  std::size_t max_distance = 1 << (depth - 1);
+
+  if(fraction.size() < max_distance)
+    fraction = bv_utils.zero_extension(fraction, max_distance);
+
   for(int d=depth-1; d>=0; d--)
   {
     std::size_t distance=(1<<d);
+
     INVARIANT(
-      fraction.size() > distance, "fraction must be larger than distance");
+      fraction.size() >= distance, "fraction must be larger or equal distance");
 
     // check if first 'distance'-many bits are zeros
     const bvt prefix=bv_utils.extract_msb(fraction, distance);


### PR DESCRIPTION
Instead of erroring, this uses zero extension when the fraction given to the normalization shift is shorter than the distances considered.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
