### PR TITLE
SMT2: fix for encoding of range-typed symbols

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5458,7 +5458,22 @@ void smt2_convt::find_symbols(const exprt &expr)
         convert_type(expr.type());
       }
 
-      out << ")" << "\n";
+      out << ')' << '\n';
+
+      // We need an additional constraint for range-typed symbols,
+      // or otherwise we get satisfying assignments with values
+      // outside of the range when the size of the range isn't
+      // a power of two.
+      if(expr.type().id() == ID_range)
+      {
+        auto &range_type = to_integer_range_type(expr.type());
+        if(!is_power_of_two(range_type.size()))
+        {
+          out << "(assert (bvule " << smt2_identifier << ' ';
+          convert_expr(from_integer(range_type.to(), range_type));
+          out << "))\n"; // bvule, assert
+        }
+      }
     }
   }
   else if(expr.id() == ID_array_of)

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -202,6 +202,17 @@ std::size_t address_bits(const mp_integer &size)
   return result;
 }
 
+bool is_power_of_two(const mp_integer &n)
+{
+  mp_integer x;
+
+  for(x = 1; n > x; x *= 2)
+  {
+  }
+
+  return x == n;
+}
+
 /// A multi-precision implementation of the power operator.
 /// \par parameters: Two mp_integers, base and exponent
 /// \return One mp_integer with the value base^{exponent}

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -163,6 +163,8 @@ std::size_t address_bits(const mp_integer &size);
 
 mp_integer power(const mp_integer &base, const mp_integer &exponent);
 
+bool is_power_of_two(const mp_integer &);
+
 void mp_min(mp_integer &a, const mp_integer &b);
 void mp_max(mp_integer &a, const mp_integer &b);
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -142,6 +142,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/strings/string_refinement/string_refinement.cpp \
        solvers/strings/string_refinement/substitute_array_list.cpp \
        solvers/strings/string_refinement/union_find_replace.cpp \
+       util/arith_tools.cpp \
        util/bitvector_expr.cpp \
        util/case_expr.cpp \
        util/cmdline.cpp \

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -3,13 +3,17 @@
 /// \file
 /// Unit tests for smt2_convt
 
+#include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
+#include <util/mathematical_types.h>
+#include <util/message.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
 #include <solvers/smt2/smt2_conv.h>
+#include <solvers/smt2/smt2_dec.h>
 #include <testing-utils/use_catch.h>
 
 TEST_CASE(
@@ -129,4 +133,33 @@ TEST_CASE(
   // the non-zero-width operand directly, not (concat x)
   concatenation_exprt concat{{z, x}, u8};
   REQUIRE(get_assert(equal_exprt{concat, x}) == "(assert (= x x))");
+}
+
+TEST_CASE("smt2_convt range encoding", "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  null_message_handlert message_handler;
+  smt2_dect smt2_dec(
+    ns,
+    "unit test",
+    "",
+    "QF_AUFBV",
+    smt2_dect::solvert::Z3,
+    "",
+    message_handler);
+
+  GIVEN("An unsatisfiable formula over range-typed variables")
+  {
+    integer_range_typet range_type{0, 2}; // {0,...,2}
+    symbol_exprt a{"a", range_type};
+    smt2_dec << notequal_exprt{a, from_integer(0, range_type)};
+    smt2_dec << notequal_exprt{a, from_integer(1, range_type)};
+    smt2_dec << notequal_exprt{a, from_integer(2, range_type)};
+
+    THEN("the SMT2 solver says it's UNSAT")
+    {
+      REQUIRE(smt2_dec() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
 }

--- a/unit/util/arith_tools.cpp
+++ b/unit/util/arith_tools.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: Unit test for util/arith_tools.h
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("is_power_of_two", "[unit][util][arith_tools]")
+{
+  REQUIRE(!is_power_of_two(0));
+  REQUIRE(is_power_of_two(1));
+  REQUIRE(is_power_of_two(2));
+  REQUIRE(!is_power_of_two(3));
+  REQUIRE(is_power_of_two(4));
+}


### PR DESCRIPTION
The SMT2 backend now adds a constraint to ranged-typed symbols that prevent out-of-range values.

The SMT2 backend uses a bit-vector encoding for finite integer ranges, which uses a logarithmic number of bits in the width of the interval.  If the width of the interval is not a power of two, values above the upper end of the range are possible.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
