### PR TITLE
Skip rename_symbolt::rename when maps are empty

### DIFF
--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -28,6 +28,9 @@ void rename_symbolt::insert(
 
 bool rename_symbolt::rename(exprt &dest) const
 {
+  if(empty())
+    return true;
+
   bool result=true;
 
   for(auto it = dest.depth_begin(), end = dest.depth_end(); it != end; ++it)
@@ -82,7 +85,7 @@ bool rename_symbolt::rename(exprt &dest) const
 
 bool rename_symbolt::have_to_rename(const exprt &dest) const
 {
-  if(expr_map.empty() && type_map.empty())
+  if(empty())
     return false;
 
   // first look at type
@@ -222,7 +225,7 @@ bool rename_symbolt::rename(typet &dest) const
 
 bool rename_symbolt::have_to_rename(const typet &dest) const
 {
-  if(expr_map.empty() && type_map.empty())
+  if(empty())
     return false;
 
   if(dest.has_subtype())

--- a/src/util/rename_symbol.h
+++ b/src/util/rename_symbol.h
@@ -43,6 +43,12 @@ public:
     type_map.insert(std::pair<irep_idt, irep_idt>(old_id, new_id));
   }
 
+  /// \return True if, and only if, there is nothing to rename.
+  bool empty() const
+  {
+    return expr_map.empty() && type_map.empty();
+  }
+
   /// Rename symbols in \p dest.
   /// \return True if, and only if, the expression was not modified.
   bool operator()(exprt &dest) const

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -196,6 +196,7 @@ SRC += analyses/ai/ai.cpp \
        util/pointer_offset_size.cpp \
        util/prefix_filter.cpp \
        util/range.cpp \
+       util/rename_symbol.cpp \
        util/replace_symbol.cpp \
        util/run.cpp \
        util/sharing_map.cpp \

--- a/unit/util/rename_symbol.cpp
+++ b/unit/util/rename_symbol.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************\
+
+Module: Unit tests for rename_symbolt
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// rename_symbolt unit tests
+
+#include <util/bitvector_types.h>
+#include <util/rename_symbol.h>
+#include <util/std_expr.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "rename_symbolt is a no-op when its maps are empty",
+  "[core][util][rename_symbol]")
+{
+  const rename_symbolt rename;
+  REQUIRE(rename.empty());
+
+  // Contract (see rename_symbol.h): the call returns true ("did nothing") and
+  // leaves the expression untouched.
+  symbol_exprt e{"foo", signedbv_typet{32}};
+  const exprt before = e;
+  REQUIRE(rename(e));
+  REQUIRE(e == before);
+}
+
+TEST_CASE(
+  "rename_symbolt renames a symbol present in the expr_map",
+  "[core][util][rename_symbol]")
+{
+  rename_symbolt rename;
+  rename.insert_expr("foo", "bar");
+  REQUIRE_FALSE(rename.empty());
+
+  // A populated map renames the matching symbol and returns false ("renamed
+  // something").
+  symbol_exprt e{"foo", signedbv_typet{32}};
+  REQUIRE_FALSE(rename(e));
+  REQUIRE(e.get_identifier() == "bar");
+}


### PR DESCRIPTION
rename_symbolt::rename(exprt) creates a depth_iterator and walks the entire expression tree even when both expr_map and type_map are empty. This happens during library linking when no symbols need renaming. Add an early return to avoid the wasted traversal.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
