### PR TITLE
Drop unused functions before property instrumentation

### DIFF
--- a/regression/cbmc/drop-unused-functions-error-label/main.c
+++ b/regression/cbmc/drop-unused-functions-error-label/main.c
@@ -1,0 +1,14 @@
+// The ERROR label lives in unreachable(), which is never called from main().
+// --error-label turns such labels into assertions inside goto_check_c, but
+// that runs after --drop-unused-functions has removed the function, so the
+// error-label assertion is elided together with the dropped function.
+void unreachable(void)
+{
+ERROR:
+  return;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/cbmc/drop-unused-functions-error-label/test.desc
+++ b/regression/cbmc/drop-unused-functions-error-label/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--error-label ERROR --drop-unused-functions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\[unreachable\.
+--
+The ERROR label is inside an unreachable function that --drop-unused-functions
+removes before goto_check_c turns error labels into assertions. The
+error-label-derived assertion is therefore elided together with the dropped
+function, demonstrating that moving the removal ahead of goto_check_c does not
+change observable behaviour.

--- a/regression/cbmc/drop-unused-functions-pointer-check/main.c
+++ b/regression/cbmc/drop-unused-functions-pointer-check/main.c
@@ -1,0 +1,13 @@
+// unreachable() is never called from main(), so --drop-unused-functions
+// removes it before property instrumentation. Its null dereference must
+// therefore never be turned into a property.
+void unreachable(void)
+{
+  int *p = 0;
+  *p = 0;
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/cbmc/drop-unused-functions-pointer-check/test.desc
+++ b/regression/cbmc/drop-unused-functions-pointer-check/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--pointer-check --drop-unused-functions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\[unreachable\.
+--
+Dropping unused functions happens before property instrumentation, so the
+unreachable null dereference is never turned into a property. If the removal
+ever stopped happening before goto_check_c, a [unreachable.pointer_dereference.*]
+property would reappear and fail this test.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -23,7 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/remove_skip.h>
-#include <goto-programs/remove_unused_functions.h>
 #include <goto-programs/set_properties.h>
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_properties.h>
@@ -918,13 +917,6 @@ bool cbmc_parse_optionst::process_goto_program(
   // add failed symbols
   // needs to be done before pointer analysis
   add_failed_symbols(goto_model.symbol_table);
-
-  if(options.get_bool_option("drop-unused-functions"))
-  {
-    // Entry point will have been set before and function pointers removed
-    log.status() << "Removing unused functions" << messaget::eom;
-    remove_unused_functions(goto_model, log.get_message_handler());
-  }
 
   // remove skips such that trivial GOTOs are deleted and not considered
   // for coverage annotation:

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -22,6 +22,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #include <goto-programs/remove_complex.h>
 #include <goto-programs/remove_function_pointers.h>
 #include <goto-programs/remove_returns.h>
+#include <goto-programs/remove_unused_functions.h>
 #include <goto-programs/remove_vector.h>
 #include <goto-programs/rewrite_rw_ok.h>
 #include <goto-programs/rewrite_union.h>
@@ -73,6 +74,16 @@ bool process_goto_program(
 
   if(options.get_bool_option("rewrite-rw-ok"))
     rewrite_rw_ok(goto_model);
+
+  // Drop unused functions before property instrumentation to avoid
+  // instrumenting functions that will never be reached. The entry point
+  // has been set, and function pointers have already been removed above,
+  // so the static call graph is now an accurate reachability oracle.
+  if(options.get_bool_option("drop-unused-functions"))
+  {
+    log.status() << "Removing unused functions" << messaget::eom;
+    remove_unused_functions(goto_model, log.get_message_handler());
+  }
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;


### PR DESCRIPTION
Move remove_unused_functions() into process_goto_program(), before goto_check_c(). For an example from Collections-C, all ~370 functions in the goto model were instrumented with pointer/bounds/overflow checks, then most were dropped. Now we drop first, instrumenting only the ~20 reachable functions.

This is safe because function pointers have already been resolved and partial inlining has been performed at this point. The option guard (drop-unused-functions) ensures other tools that don't set this option are unaffected.

Remove the now-redundant remove_unused_functions() call from cbmc_parse_options.cpp.

Impact on Collections-C:
  Monolithic: 93s -> 62s
  Paths:      92s -> 60s

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
