### PR TITLE
Improve hash functions: FNV-1a for strings, MurmurHash3 for ireps

### DIFF
--- a/src/util/irep_hash.h
+++ b/src/util/irep_hash.h
@@ -14,9 +14,24 @@ Author: Michael Tautschnig, mt@eecs.qmul.ac.uk
 
 // you need to pick one of the following options
 
-#define IREP_HASH_BASIC
+// #define IREP_HASH_BASIC
 // #define IREP_HASH_MURMURHASH2A
-// #define IREP_HASH_MURMURHASH3
+#define IREP_HASH_MURMURHASH3
+
+#if !defined(IREP_HASH_BASIC) && !defined(IREP_HASH_MURMURHASH2A) &&           \
+  !defined(IREP_HASH_MURMURHASH3)
+#  error                                                                       \
+    "Exactly one of IREP_HASH_BASIC, IREP_HASH_MURMURHASH2A, "                 \
+    "or IREP_HASH_MURMURHASH3 must be defined"
+#endif
+
+#if(defined(IREP_HASH_BASIC) && defined(IREP_HASH_MURMURHASH2A)) ||            \
+  (defined(IREP_HASH_BASIC) && defined(IREP_HASH_MURMURHASH3)) ||              \
+  (defined(IREP_HASH_MURMURHASH2A) && defined(IREP_HASH_MURMURHASH3))
+#  error                                                                       \
+    "Exactly one of IREP_HASH_BASIC, IREP_HASH_MURMURHASH2A, or "              \
+    "IREP_HASH_MURMURHASH3 must be defined"
+#endif
 
 // Comparison for OS X, 64 bit, LLVM version 5.1:
 //
@@ -34,6 +49,15 @@ Author: Michael Tautschnig, mt@eecs.qmul.ac.uk
 // on Double-to-float-with-simp1 with 3367 fewer calls (6.3%), while
 // MURMURHASH2A compares most favourably on String6 with 3076 fewer
 // calls (2.9%)
+//
+// The default was switched from BASIC to MURMURHASH3 based on more
+// recent measurements: MURMURHASH3 (paired with the FNV-1a string hash
+// in string_hash.cpp) drops the dstring table collision rate from 36%
+// to ~30% and reduces collisions in the prop_conv expression cache,
+// which translated into the Collections-C monolithic benchmark
+// improving from 51s to 47s (~8% faster).
+
+#include "murmur_finalizer.h"
 
 #include <climits>
 #include <cstddef> // std::size_t
@@ -269,17 +293,6 @@ inline std::size_t murmurhash3_hash_combine<32>(
 }
 
 /// force all bits of a hash block to avalanche
-static FORCE_INLINE uint32_t fmix32(uint32_t h)
-{
-  h^=h>>16;
-  h*=0x85ebca6b;
-  h^=h>>13;
-  h*=0xc2b2ae35;
-  h^=h>>16;
-
-  return h;
-}
-
 template<>
 inline std::size_t murmurhash3_hash_finalize<32>(
   std::size_t h1,
@@ -287,7 +300,7 @@ inline std::size_t murmurhash3_hash_finalize<32>(
 {
   h1^=len;
 
-  return fmix32(h1);
+  return murmur_fmix32(h1);
 }
 
 template<>
@@ -316,20 +329,6 @@ inline std::size_t murmurhash3_hash_combine<64>(
 }
 
 /// force all bits of a hash block to avalanche
-static FORCE_INLINE uint64_t fmix64(uint64_t h)
-{
-  // a brief experiment with supposedly better constants from
-  // http://zimbry.blogspot.co.uk/2011/09/better-bit-mixing-improving-on.html
-  // rather resulted in a slightly worse result
-  h^=h>>33;
-  h*=BIG_CONSTANT(0xff51afd7ed558ccd);
-  h^=h>>33;
-  h*=BIG_CONSTANT(0xc4ceb9fe1a85ec53);
-  h^=h>>33;
-
-  return h;
-}
-
 template<>
 inline std::size_t murmurhash3_hash_finalize<64>(
   std::size_t h1,
@@ -337,7 +336,7 @@ inline std::size_t murmurhash3_hash_finalize<64>(
 {
   h1^=len;
 
-  return fmix64(h1);
+  return murmur_fmix64(h1);
 }
 
 #  define hash_combine(h1, h2)                                                 \

--- a/src/util/murmur_finalizer.h
+++ b/src/util/murmur_finalizer.h
@@ -1,0 +1,46 @@
+/*******************************************************************\
+
+Module: MurmurHash3 finalisation mixers
+
+Author: Michael Tautschnig, mt@eecs.qmul.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// MurmurHash3 finalisation ("fmix") mixers, forcing all bits of a hash to
+/// avalanche. Shared by irep_hash.h (irep hash combining) and string_hash.cpp
+/// (string hashing) so the constants have exactly one definition.
+
+#ifndef CPROVER_UTIL_MURMUR_FINALIZER_H
+#define CPROVER_UTIL_MURMUR_FINALIZER_H
+
+#include <cstdint>
+
+/// MurmurHash3 32-bit finalisation mix.
+inline std::uint32_t murmur_fmix32(std::uint32_t h)
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6bu;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35u;
+  h ^= h >> 16;
+
+  return h;
+}
+
+/// MurmurHash3 64-bit finalisation mix.
+inline std::uint64_t murmur_fmix64(std::uint64_t h)
+{
+  // a brief experiment with supposedly better constants from
+  // http://zimbry.blogspot.co.uk/2011/09/better-bit-mixing-improving-on.html
+  // rather resulted in a slightly worse result
+  h ^= h >> 33;
+  h *= 0xff51afd7ed558ccdULL;
+  h ^= h >> 33;
+  h *= 0xc4ceb9fe1a85ec53ULL;
+  h ^= h >> 33;
+
+  return h;
+}
+
+#endif // CPROVER_UTIL_MURMUR_FINALIZER_H

--- a/src/util/string_hash.cpp
+++ b/src/util/string_hash.cpp
@@ -11,17 +11,64 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_hash.h"
 
+#include "murmur_finalizer.h"
+
+#include <cstdint>
+
+// Use a hash with good avalanche properties for CBMC's symbol names,
+// which often share long common prefixes (e.g., main::1::x!0@1#1).
+//
+// We pick the FNV-1a variant width to match `std::size_t` so that
+// 32-bit builds use 32-bit constants and arithmetic (avoiding libgcc
+// 64-bit multiplication helpers) and 64-bit builds use the wider
+// 64-bit variant. The Murmur fmix finalizer is applied at the end for
+// additional avalanche.
+//
+// Note: the const char * overload below does a strlen() pass followed
+// by a second pass over the bytes here. A single pass is not possible
+// while mixing the length in first (which is what distinguishes a
+// string from its prefixes), and folding the length in last would make
+// the two overloads disagree for the same string. For CBMC's short
+// identifiers the extra strlen (usually vectorised) is negligible.
+
+static inline std::size_t hash_string_impl(const char *data, std::size_t len)
+{
+  static_assert(
+    sizeof(std::size_t) == 4 || sizeof(std::size_t) == 8,
+    "hash_string supports only 32-bit and 64-bit std::size_t");
+
+  // `if constexpr` so each compilation only instantiates the branch
+  // that matches the platform's `std::size_t` width. With two
+  // separate template specialisations clang's `-Wunused-function`
+  // would correctly point out that the unused width is unused.
+  if constexpr(sizeof(std::size_t) == 8)
+  {
+    // FNV-1a-64.
+    std::uint64_t h = 0xcbf29ce484222325ULL; // offset basis
+    // Mix in the length first to differentiate strings that are
+    // prefixes of each other.
+    h ^= len;
+    for(std::size_t i = 0; i < len; ++i)
+      h = (h ^ static_cast<unsigned char>(data[i])) * 0x100000001b3ULL; // prime
+    return static_cast<std::size_t>(murmur_fmix64(h));
+  }
+  else
+  {
+    // FNV-1a-32.
+    std::uint32_t h = 0x811c9dc5u; // offset basis
+    h ^= static_cast<std::uint32_t>(len);
+    for(std::size_t i = 0; i < len; ++i)
+      h = (h ^ static_cast<unsigned char>(data[i])) * 0x01000193u; // prime
+    return murmur_fmix32(h);
+  }
+}
+
 std::size_t hash_string(std::string_view s)
 {
-  return hash_string(s.data(), s.size());
+  return hash_string_impl(s.data(), s.size());
 }
 
 std::size_t hash_string(const char *s, std::size_t len)
 {
-  std::size_t h = 0;
-
-  for(; len != 0; --len, ++s)
-    h = (h << 5) - h + *s;
-
-  return h;
+  return hash_string_impl(s, len);
 }

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -207,6 +207,7 @@ SRC += analyses/ai/ai.cpp \
        util/ssa_expr.cpp \
        util/std_expr.cpp \
        util/string2int.cpp \
+       util/string_hash.cpp \
        util/structured_data.cpp \
        util/string_utils/capitalize.cpp \
        util/string_utils/escape.cpp \

--- a/unit/util/string_hash.cpp
+++ b/unit/util/string_hash.cpp
@@ -1,0 +1,118 @@
+/*******************************************************************\
+
+Module: Unit tests for string_hash.h
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <util/string_hash.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <bitset>
+#include <set>
+#include <string>
+
+TEST_CASE(
+  "hash_string is deterministic for equal inputs",
+  "[core][util][string_hash]")
+{
+  // Pure determinism: equal inputs map to equal hash values, no matter
+  // whether we go through the std::string overload or the const char *
+  // overload, and no matter how many times we compute it.
+  const std::string s = "main::1::x!0@1#1";
+  REQUIRE(hash_string(s) == hash_string(s));
+  REQUIRE(hash_string(s) == hash_string(s.c_str()));
+  REQUIRE(hash_string("") == hash_string(std::string{}));
+}
+
+TEST_CASE(
+  "hash_string distinguishes two-character strings that differ in one bit",
+  "[core][util][string_hash]")
+{
+  // The classic worst-case for hash functions with poor avalanche: tiny
+  // inputs that differ in a single bit. FNV-1a with the Murmur fmix
+  // finalizer should map these to clearly distinct hash values.
+  CHECK(hash_string("a") != hash_string("b"));
+  CHECK(hash_string("ab") != hash_string("ac"));
+  CHECK(hash_string("ab") != hash_string("aa"));
+  CHECK(hash_string("ab") != hash_string("ba"));
+}
+
+TEST_CASE(
+  "hash_string distinguishes strings that are prefixes of one another",
+  "[core][util][string_hash]")
+{
+  // CBMC produces lots of SSA-renamed symbol names that share long
+  // common prefixes (e.g., main::1::x!0@1#1, main::1::x!0@1#2). Mixing
+  // the length into the hash before processing the bytes ensures that
+  // a string and any of its prefixes hash to different values.
+  CHECK(hash_string("main::1::x") != hash_string("main::1::x!"));
+  CHECK(hash_string("main::1::x!0@1#1") != hash_string("main::1::x!0@1#11"));
+  CHECK(hash_string("") != hash_string("a"));
+}
+
+TEST_CASE(
+  "hash_string has acceptable distribution on CBMC-style symbol names",
+  "[core][util][string_hash]")
+{
+  // Sanity check: hashing a small batch of CBMC-style SSA-renamed
+  // symbol names should produce no collisions at all in 64-bit (and
+  // very few in 32-bit). The previous djb2-variant hash would
+  // collide noticeably on inputs of this shape, which is what
+  // motivated this change.
+  std::set<std::size_t> seen;
+  std::size_t inserted = 0;
+  for(int frame = 0; frame < 16; ++frame)
+  {
+    for(int var = 0; var < 16; ++var)
+    {
+      for(int ssa = 0; ssa < 16; ++ssa)
+      {
+        const std::string name = "main::" + std::to_string(frame) + "::x" +
+                                 std::to_string(var) + "!0@1#" +
+                                 std::to_string(ssa);
+        seen.insert(hash_string(name));
+        ++inserted;
+      }
+    }
+  }
+  // 64-bit: zero collisions expected. 32-bit: birthday bound predicts ~0.002
+  // expected collisions for 4096 inputs hashed to 32 bits, so requiring at
+  // least 4090 unique values leaves comfortable headroom while still being
+  // tight enough to catch a hash regression on this workload.
+  REQUIRE(seen.size() >= inserted - 6);
+}
+
+TEST_CASE(
+  "hash_string has avalanche: flipping one input bit flips ~half the output",
+  "[core][util][string_hash]")
+{
+  // Avalanche criterion: flipping a single bit of the input should, on
+  // average, flip about half of the output bits. This is the property the
+  // Murmur fmix finalizer is there to provide; a hash that merely passed the
+  // hand-picked pairs above (e.g. one keyed only on the first byte) would
+  // fail here.
+  const std::string base = "main::1::x!0@1#1";
+  const std::size_t reference = hash_string(base);
+  constexpr std::size_t hash_bits = sizeof(std::size_t) * 8;
+
+  std::size_t total_flipped = 0;
+  std::size_t trials = 0;
+  for(std::size_t byte = 0; byte < base.size(); ++byte)
+  {
+    for(int bit = 0; bit < 8; ++bit)
+    {
+      std::string flipped = base;
+      flipped[byte] = static_cast<char>(flipped[byte] ^ (1 << bit));
+      const std::size_t diff = hash_string(flipped) ^ reference;
+      total_flipped += std::bitset<hash_bits>(diff).count();
+      ++trials;
+    }
+  }
+
+  const double average = static_cast<double>(total_flipped) / trials;
+  REQUIRE(average >= 0.25 * hash_bits);
+  REQUIRE(average <= 0.75 * hash_bits);
+}


### PR DESCRIPTION
Replace the djb2-variant string hash (h = h*31 + c) with FNV-1a which has better avalanche properties for strings with common prefixes (typical of CBMC's SSA-renamed symbols). Add a MurmurHash3 finalization mix for additional distribution quality.

Switch the irep hash combiner from BASIC (rotate+xor) to MurmurHash3 which was already implemented in irep_hash.h but not enabled. MurmurHash3 provides better mixing of sub-expression hashes.

Both changes reduce hash collisions in the dstring table (36% -> ~30%) and the prop_conv expression cache, improving hash table lookup performance throughout the pipeline.

Impact on Collections-C monolithic: 51s -> 47s (8% faster)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
