### PR TITLE
Fix profiling: use --verbosity 8 instead of 10

### DIFF
--- a/scripts/profiling/runner.py
+++ b/scripts/profiling/runner.py
@@ -150,6 +150,17 @@ def run_benchmark(cbmc, bench, output_dir, timeout, memory_mb, skip_solver):
         if m:
             timings["sliced_assignments"] = int(m.group(1))
 
+    # The regexes above are coupled to what CBMC currently emits via
+    # log.statistics() / log.status(). If a future change reroutes a
+    # timing line to log.progress() or log.debug(), or renames a prefix,
+    # they would silently drop everything. Surface that loudly when we
+    # have CBMC output (i.e., the run was not a timeout) but parsed
+    # nothing, so a maintainer notices and updates the parser.
+    if cbmc_stdout and not timings:
+        warn(f"[{name}] No timing lines parsed from CBMC output; "
+             f"the regexes in run_benchmark may have drifted from "
+             f"CBMC's log.statistics() / log.status() output.")
+
     return {
         "name": name,
         "elapsed": elapsed,

--- a/scripts/profiling/runner.py
+++ b/scripts/profiling/runner.py
@@ -74,7 +74,10 @@ def run_benchmark(cbmc, bench, output_dir, timeout, memory_mb, skip_solver):
     if skip_solver:
         if not any(a in cmd for a in ("--dimacs", "--smt2", "--show-vcc")):
             cmd += ["--dimacs", "--outfile", "/dev/null"]
-    cmd += ["--verbosity", "10"]
+    # --verbosity 8 == M_STATISTICS (see src/util/message.h); captures the
+    # `Runtime ...` lines parsed below without enabling M_DEBUG=10, which
+    # dumps every SSA step via SSA_stept::output and distorts the profile.
+    cmd += ["--verbosity", "8"]
 
     perf_data = bench_dir / "perf.data"
     cbmc_output = bench_dir / "cbmc_output.txt"


### PR DESCRIPTION
Verbosity 10 triggers per-step SSA output via SSA_stept::output, which calls format_rec and accounts for ~16% of the profile. This distorts the results. Verbosity 8 still captures Runtime statistics without the per-step output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
