### PR TITLE
Simplifier: enable USE_LOCAL_REPLACE_MAP for if-then-else

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -3344,20 +3344,21 @@ simplify_exprt::resultt<> simplify_exprt::simplify_rec(const exprt &expr)
   }
 
 #ifdef USE_LOCAL_REPLACE_MAP
-  exprt tmp = simplify_node_result.expr;
-#  if 1
-  replace_mapt::const_iterator it =
-    local_replace_map.find(simplify_node_result.expr);
-  if(it!=local_replace_map.end())
-    simplify_node_result = changed(it->second);
-#  else
-  if(
-    !local_replace_map.empty() &&
-    !replace_expr(local_replace_map, simplify_node_result.expr))
+  // The local_replace_map is populated by simplify_if_preorder: when
+  // simplifying if(cond, T, F), the condition (or its conjuncts/disjuncts)
+  // is mapped to true/false in the respective branch. Here we apply that
+  // map using a hash-based exact-match lookup; we deliberately avoid
+  // replace_expr's recursive traversal so that this stays cheap on deeply
+  // nested expressions. With the substitution always enabled, this lookup
+  // runs on every simplify_rec call, but the !local_replace_map.empty()
+  // guard keeps it free for expressions that contain no such if-then-else.
+  if(!local_replace_map.empty())
   {
-    simplify_node_result = changed(simplify_rec(simplify_node_result.expr));
+    replace_mapt::const_iterator it =
+      local_replace_map.find(simplify_node_result.expr);
+    if(it != local_replace_map.end())
+      simplify_node_result = changed(it->second);
   }
-#  endif
 #endif
 
   if(!simplify_node_result.has_changed())

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -3343,7 +3343,6 @@ simplify_exprt::resultt<> simplify_exprt::simplify_rec(const exprt &expr)
       simplify_node_preorder_result.expr_changed;
   }
 
-#ifdef USE_LOCAL_REPLACE_MAP
   // The local_replace_map is populated by simplify_if_preorder: when
   // simplifying if(cond, T, F), the condition (or its conjuncts/disjuncts)
   // is mapped to true/false in the respective branch. Here we apply that
@@ -3359,7 +3358,6 @@ simplify_exprt::resultt<> simplify_exprt::simplify_rec(const exprt &expr)
     if(it != local_replace_map.end())
       simplify_node_result = changed(it->second);
   }
-#endif
 
   if(!simplify_node_result.has_changed())
   {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -20,7 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "mp_arith.h"
 #include "type.h"
-// #define USE_LOCAL_REPLACE_MAP
+#define USE_LOCAL_REPLACE_MAP
 #ifdef USE_LOCAL_REPLACE_MAP
 #include "replace_expr.h"
 #endif

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -15,15 +15,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sys/stat.h>
 #endif
 
-#include <set>
-
 #include "expr.h"
 #include "mp_arith.h"
-#include "type.h"
-#define USE_LOCAL_REPLACE_MAP
-#ifdef USE_LOCAL_REPLACE_MAP
 #include "replace_expr.h"
-#endif
+#include "type.h"
+
+#include <set>
 
 class abs_exprt;
 class address_of_exprt;
@@ -292,10 +289,7 @@ protected:
 #ifdef DEBUG_ON_DEMAND
   bool debug_on;
 #endif
-#ifdef USE_LOCAL_REPLACE_MAP
   replace_mapt local_replace_map;
-#endif
-
 };
 
 #endif // CPROVER_UTIL_SIMPLIFY_EXPR_CLASS_H

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -264,7 +264,6 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
       swap_branches = true;
     }
 
-#ifdef USE_LOCAL_REPLACE_MAP
     // Populate local_replace_map so that sub-expressions matching the
     // condition are replaced by true/false during recursive simplification
     // of the respective branch. The map is consulted via O(1) exact-match
@@ -315,21 +314,6 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
       r_falsevalue.expr_changed = resultt<>::CHANGED;
     }
     return build_if_expr(expr, r_cond, r_truevalue, r_falsevalue);
-#else
-    if(!swap_branches)
-    {
-      return build_if_expr(
-        expr, r_cond, simplify_rec(truevalue), simplify_rec(falsevalue));
-    }
-    else
-    {
-      return build_if_expr(
-        expr,
-        r_cond,
-        changed(simplify_rec(falsevalue)),
-        changed(simplify_rec(truevalue)));
-    }
-#endif
   }
   else
   {

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "simplify_expr_class.h"
 
 #include "arith_tools.h"
+#include "expr_util.h"
 #include "range.h"
 #include "std_expr.h"
 
@@ -275,40 +276,34 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
     // individually false in the false branch.
     replace_mapt map_before(local_replace_map);
 
-    // True branch: condition (or its conjuncts) known to be true.
-    if(r_cond.expr.id() == ID_and)
+    // Express the true/false duality once: in the true branch the condition is
+    // known true, in the false branch known false; an AND/OR condition is
+    // split into its operands, and a `not` operand flips the polarity.
+    const auto populate = [this](const exprt &cond_expr, bool branch_value)
     {
-      for(const auto &op : r_cond.expr.operands())
+      const bool split = (branch_value && cond_expr.id() == ID_and) ||
+                         (!branch_value && cond_expr.id() == ID_or);
+      if(!split)
+      {
+        local_replace_map.insert({cond_expr, make_boolean_expr(branch_value)});
+        return;
+      }
+      for(const auto &op : cond_expr.operands())
       {
         if(op.id() == ID_not)
           local_replace_map.insert(
-            std::make_pair(to_not_expr(op).op(), false_exprt()));
+            {to_not_expr(op).op(), make_boolean_expr(!branch_value)});
         else
-          local_replace_map.insert(std::make_pair(op, true_exprt()));
+          local_replace_map.insert({op, make_boolean_expr(branch_value)});
       }
-    }
-    else
-      local_replace_map.insert(std::make_pair(r_cond.expr, true_exprt()));
+    };
 
+    populate(r_cond.expr, true);
     auto r_truevalue = simplify_rec(swap_branches ? falsevalue : truevalue);
 
     local_replace_map = map_before;
 
-    // False branch: condition (or its disjuncts) known to be false.
-    if(r_cond.expr.id() == ID_or)
-    {
-      for(const auto &op : r_cond.expr.operands())
-      {
-        if(op.id() == ID_not)
-          local_replace_map.insert(
-            std::make_pair(to_not_expr(op).op(), true_exprt()));
-        else
-          local_replace_map.insert(std::make_pair(op, false_exprt()));
-      }
-    }
-    else
-      local_replace_map.insert(std::make_pair(r_cond.expr, false_exprt()));
-
+    populate(r_cond.expr, false);
     auto r_falsevalue = simplify_rec(swap_branches ? truevalue : falsevalue);
 
     local_replace_map.swap(map_before);

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -264,15 +264,25 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
     }
 
 #ifdef USE_LOCAL_REPLACE_MAP
+    // Populate local_replace_map so that sub-expressions matching the
+    // condition are replaced by true/false during recursive simplification
+    // of the respective branch. The map is consulted via O(1) exact-match
+    // lookup in simplify_rec (not recursive tree replacement), so the cost
+    // is linear in expression size.
+    //
+    // For AND conditions (a && b), each conjunct is individually true in
+    // the true branch. For OR conditions (a || b), each disjunct is
+    // individually false in the false branch.
     replace_mapt map_before(local_replace_map);
 
-    // a ? b : c  --> a ? b[a/true] : c
+    // True branch: condition (or its conjuncts) known to be true.
     if(r_cond.expr.id() == ID_and)
     {
       for(const auto &op : r_cond.expr.operands())
       {
         if(op.id() == ID_not)
-          local_replace_map.insert(std::make_pair(op.op0(), false_exprt()));
+          local_replace_map.insert(
+            std::make_pair(to_not_expr(op).op(), false_exprt()));
         else
           local_replace_map.insert(std::make_pair(op, true_exprt()));
       }
@@ -284,13 +294,14 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
 
     local_replace_map = map_before;
 
-    // a ? b : c  --> a ? b : c[a/false]
+    // False branch: condition (or its disjuncts) known to be false.
     if(r_cond.expr.id() == ID_or)
     {
       for(const auto &op : r_cond.expr.operands())
       {
         if(op.id() == ID_not)
-          local_replace_map.insert(std::make_pair(op.op0(), true_exprt()));
+          local_replace_map.insert(
+            std::make_pair(to_not_expr(op).op(), true_exprt()));
         else
           local_replace_map.insert(std::make_pair(op, false_exprt()));
       }
@@ -305,8 +316,8 @@ simplify_exprt::simplify_if_preorder(const if_exprt &expr)
     if(swap_branches)
     {
       // tell build_if_expr to replace truevalue and falsevalue
-      r_truevalue.expr_changed = CHANGED;
-      r_falsevalue.expr_changed = CHANGED;
+      r_truevalue.expr_changed = resultt<>::CHANGED;
+      r_falsevalue.expr_changed = resultt<>::CHANGED;
     }
     return build_if_expr(expr, r_cond, r_truevalue, r_falsevalue);
 #else

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -710,3 +710,100 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, empty_namespace) == true_exprt{});
 }
+
+TEST_CASE("Simplify nested if-then-else with same condition", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt c{"c", bool_typet{}};
+  const symbol_exprt a{"a", signedbv_typet{32}};
+  const symbol_exprt b{"b", signedbv_typet{32}};
+
+  // (c ? a : (c ? a : b)) should simplify to (c ? a : b)
+  // because in the false branch, c is false, so inner (c ? a : b) -> b
+  const if_exprt inner{c, a, b};
+  const if_exprt nested{c, a, inner};
+  const exprt result = simplify_expr(nested, ns);
+  REQUIRE(result == if_exprt{c, a, b});
+}
+
+TEST_CASE(
+  "Simplify nested if: AND condition substitutes conjuncts in true branch",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+  const symbol_exprt b{"b", bool_typet{}};
+  const symbol_exprt y{"y", signedbv_typet{32}};
+  const symbol_exprt z{"z", signedbv_typet{32}};
+  const symbol_exprt w{"w", signedbv_typet{32}};
+
+  // if(a && b, if(a, y, z), w): in the true branch a is known true, so the
+  // inner if(a, y, z) collapses to y.
+  const if_exprt inner{a, y, z};
+  const if_exprt nested{and_exprt{a, b}, inner, w};
+  REQUIRE(simplify_expr(nested, ns) == if_exprt{and_exprt{a, b}, y, w});
+}
+
+TEST_CASE(
+  "Simplify nested if: OR condition substitutes disjuncts in false branch",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+  const symbol_exprt b{"b", bool_typet{}};
+  const symbol_exprt x{"x", signedbv_typet{32}};
+  const symbol_exprt y{"y", signedbv_typet{32}};
+  const symbol_exprt z{"z", signedbv_typet{32}};
+
+  // if(a || b, x, if(a, y, z)): in the false branch a is known false, so the
+  // inner if(a, y, z) collapses to z.
+  const if_exprt inner{a, y, z};
+  const if_exprt nested{or_exprt{a, b}, x, inner};
+  REQUIRE(simplify_expr(nested, ns) == if_exprt{or_exprt{a, b}, x, z});
+}
+
+TEST_CASE(
+  "Simplify nested if: negated conjunct flips polarity in true branch",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+  const symbol_exprt b{"b", bool_typet{}};
+  const symbol_exprt y{"y", signedbv_typet{32}};
+  const symbol_exprt z{"z", signedbv_typet{32}};
+  const symbol_exprt w{"w", signedbv_typet{32}};
+
+  // if(a && !b, if(b, y, z), w): in the true branch a is true and b is false,
+  // so the inner if(b, y, z) collapses to z.
+  const if_exprt inner{b, y, z};
+  const if_exprt nested{and_exprt{a, not_exprt{b}}, inner, w};
+  REQUIRE(
+    simplify_expr(nested, ns) == if_exprt{and_exprt{a, not_exprt{b}}, z, w});
+}
+
+TEST_CASE(
+  "Simplify nested if: negated outer condition (swap branches)",
+  "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt c{"c", bool_typet{}};
+  const symbol_exprt y{"y", signedbv_typet{32}};
+  const symbol_exprt z{"z", signedbv_typet{32}};
+  const symbol_exprt w{"w", signedbv_typet{32}};
+
+  // if(!c, if(c, y, z), w) == if(c, w, if(c, y, z)); in the (swapped) false
+  // branch c is known false, so the inner if(c, y, z) collapses to z.
+  const if_exprt inner{c, y, z};
+  const if_exprt nested{not_exprt{c}, inner, w};
+  REQUIRE(simplify_expr(nested, ns) == if_exprt{c, w, z});
+}


### PR DESCRIPTION
Enable the dormant USE_LOCAL_REPLACE_MAP simplifier feature that substitutes the condition value into if-then-else branches:
  if(c, true_branch[c/true], false_branch[c/false])

For AND conditions, each conjunct is substituted individually in the true branch. For OR conditions, each disjunct is substituted in the false branch.

This collapses redundant nested if-then-else expressions that share the same condition: (c ? a : (c ? a : b)) simplifies to (c ? a : b) because c is known to be false in the outer false branch, reducing the inner (c ? a : b) to just b.

The substitution uses O(1) exact-match lookup in simplify_rec (not recursive tree replacement), so the per-node cost is constant and the overall cost is linear in expression size.

Also clean up the dormant code:
- Remove dead #if 0 alternative (recursive replace_expr path)
- op0() -> to_not_expr(op).op() (protected member access)
- CHANGED -> changed() (API change since code was disabled)

No performance regression on standard benchmarks (linked_list, array_ops, structs): all within measurement noise at 0% change.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
