### PR TITLE
Unit tests: verify complementary pair detection in AND/OR

### DIFF
--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -731,3 +731,41 @@ TEST_CASE("Simplify flatten nested AND", "[core][util]")
   const and_exprt nested{a, inner};
   REQUIRE(simplify_expr(nested, ns) == and_exprt{a, b, c});
 }
+
+TEST_CASE("Simplify complementary pair in OR", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+
+  // (a || !a) should simplify to true
+  const or_exprt expr{a, not_exprt{a}};
+  REQUIRE(simplify_expr(expr, ns) == true_exprt{});
+}
+
+TEST_CASE("Simplify complementary pair in AND", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+
+  // (a && !a) should simplify to false
+  const and_exprt expr{a, not_exprt{a}};
+  REQUIRE(simplify_expr(expr, ns) == false_exprt{});
+}
+
+TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const symbol_exprt a{"a", bool_typet{}};
+  const symbol_exprt b{"b", bool_typet{}};
+
+  // (a || (b || !a)) should simplify to true (after flattening)
+  const or_exprt inner{b, not_exprt{a}};
+  const or_exprt expr{a, inner};
+  REQUIRE(simplify_expr(expr, ns) == true_exprt{});
+}


### PR DESCRIPTION
Add unit tests confirming that the simplifier detects complementary pairs in boolean AND/OR expressions:
  A || !A -> true
  A && !A -> false
  A || (B || !A) -> true  (after flattening by join_operands)

This is already handled by the existing 'search for a and !a' loop in simplify_boolean(). The tests document and protect this behavior.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
