### PR TITLE
Fix ROUND_TO_AWAY rounding decision in float_bvt

### DIFF
--- a/regression/cbmc/Float-round-to-away/main.c
+++ b/regression/cbmc/Float-round-to-away/main.c
@@ -1,0 +1,52 @@
+// Test that ROUND_TO_AWAY (rounding mode 4) correctly rounds to the
+// nearest representable value, only rounding away from zero on exact ties.
+//
+// Bug: float_bvt was rounding away from zero even for non-tie cases.
+//
+// The test uses non-deterministic inputs constrained to specific values
+// to force the solver to exercise the float encoding.
+
+#include <assert.h>
+
+int main()
+{
+  // --- Test 1: non-tie addition under ROUND_TO_AWAY ---
+  // a + b is very close to -1.0 but not a tie.
+  // The nearest float is 0xBF7FFFFF (-0x1.fffffep-1), not -1.0 (0xBF800000).
+  // ROUND_TO_AWAY must still pick the nearest value.
+  float a, b;
+  __CPROVER_assume(a == -0.9961287975311279f);    // 0xBF7F024C
+  __CPROVER_assume(b == -0.0038711430970579386f); // 0xBB7DB301
+
+  __CPROVER_rounding_mode = 4;
+  float sum = a + b;
+  // The exact sum is ~-0.999999940628..., closer to -0x1.fffffep-1 than -1.0;
+  // the buggy formula would round away to -1.0f.
+  assert(sum == -0x1.fffffep-1f);
+
+  // --- Test 2: tie addition under ROUND_TO_AWAY ---
+  // 1.0f + 2^-24 = 0x1.000001p+0 (exact tie).
+  // ROUND_TO_AWAY rounds away from zero -> 0x1.000002p+0f.
+  float c, d;
+  __CPROVER_assume(c == 1.0f);
+  __CPROVER_assume(d == 0x1.0p-24f);
+
+  __CPROVER_rounding_mode = 4;
+  float tie_sum = c + d;
+  assert(tie_sum == 0x1.000002p+0f);
+
+  // --- Test 3: non-tie multiplication under ROUND_TO_AWAY ---
+  // In real arithmetic 1.5 * 1.1 = 1.65, but 1.1f is not exactly representable
+  // in binary32, so the operands are already rounded. The product is not a
+  // tie, so ROUND_TO_AWAY rounds to nearest, the same as ROUND_TO_EVEN:
+  // 1.5f * 1.1f = 0x1.a66668p+0f (1.65000009...).
+  float e, f;
+  __CPROVER_assume(e == 1.5f);
+  __CPROVER_assume(f == 1.1f);
+
+  __CPROVER_rounding_mode = 4;
+  float prod = e * f;
+  assert(prod == 0x1.a66668p+0f);
+
+  return 0;
+}

--- a/regression/cbmc/Float-round-to-away/test.desc
+++ b/regression/cbmc/Float-round-to-away/test.desc
@@ -1,0 +1,12 @@
+CORE no-new-smt
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests IEEE 754 ROUND_TO_AWAY (mode 4) for non-tie and tie cases.
+The non-tie test catches a bug in float_bvt where non-tie results
+were incorrectly rounded away from zero instead of to nearest.

--- a/regression/cbmc/Float-round-to-away/test_smt.desc
+++ b/regression/cbmc/Float-round-to-away/test_smt.desc
@@ -1,0 +1,10 @@
+CORE no-new-smt
+main.c
+--smt2 --z3
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests ROUND_TO_AWAY via the SMT path (float_bvt encoding).

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -1299,8 +1299,8 @@ exprt float_bvt::fraction_rounding_decision(
   // round to zero
   false_exprt round_to_zero;
 
-  // round to away
-  const auto round_to_away = or_exprt(rounding_bit, sticky_bit);
+  // round-to-nearest (ties to away)
+  const auto round_to_away = rounding_bit;
 
   // now select appropriate one
   // clang-format off


### PR DESCRIPTION
float_bvt::fraction_rounding_decision used
  or_exprt(rounding_bit, sticky_bit)
for ROUND_TO_AWAY, which incorrectly rounds away from zero whenever any extra bits are non-zero. The correct formula is just rounding_bit, matching float_utilst.

ROUND_TO_AWAY means 'round to nearest, ties away from zero':
- rounding_bit=0: closer to truncated value, don't increment
- rounding_bit=1, sticky=0: exact tie, round away (increment)
- rounding_bit=1, sticky=1: closer to incremented value, increment

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
