### PR TITLE
Fix division exponent overflow and overflow-to-inf ROUND_TO_AWAY

### DIFF
--- a/regression/cbmc/Float-div-overflow/main.c
+++ b/regression/cbmc/Float-div-overflow/main.c
@@ -1,0 +1,135 @@
+// Test that division overflow is handled correctly under all rounding
+// modes, in both the bitvector and SMT encodings.
+//
+// Bug 1 (float_bvt::div): the exponent was extended by only 1 bit
+// instead of 2, leaving the post-`+spec.f` adjustment vulnerable to
+// silent wraparound on large quotients. The FLT_MAX / FLT_MIN
+// (single) and DBL_MAX / DBL_MIN (double) cases below exercise the
+// extended exponent path. (Empirically these inputs already saturate
+// to the correct ±inf via downstream denormalization handling on
+// both pre-fix and post-fix encoders, so they don't fail on develop;
+// they are still kept here as exercise of the corrected path.)
+//
+// Bug 2 (round_exponent in both encoders): overflow_to_inf did not
+// include ROUND_TO_AWAY. Since ROUND_TO_AWAY is a round-to-nearest
+// mode, overflow must produce ±inf. The ROUND_TO_AWAY cases below
+// pin that fix down — reverting the round_to_away disjunct in either
+// encoder leaves the test green if those cases are absent.
+
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+
+// Rounding-mode encoding mirrors src/util/ieee_float.h
+// (and matches the x86 control-word values).
+#define ROUND_TO_EVEN 0
+#define ROUND_TO_MINUS_INF 1
+#define ROUND_TO_PLUS_INF 2
+#define ROUND_TO_ZERO 3
+#define ROUND_TO_AWAY 4
+
+extern int __CPROVER_rounding_mode;
+
+int main()
+{
+  float a, b;
+  __CPROVER_assume(a == FLT_MAX);
+  __CPROVER_assume(b == 0.5f);
+
+  // ---- bug 2 coverage (overflow under each rounding mode) ----
+
+  // ROUND_TO_EVEN: positive overflow -> +inf
+  __CPROVER_rounding_mode = ROUND_TO_EVEN;
+  float r0 = a / b;
+  assert(isinf(r0) && r0 > 0);
+
+  // ROUND_TO_ZERO: directed toward zero -> FLT_MAX
+  __CPROVER_rounding_mode = ROUND_TO_ZERO;
+  float r3 = a / b;
+  assert(r3 == FLT_MAX);
+
+  // ROUND_TO_PLUS_INF: directed toward +inf -> +inf
+  __CPROVER_rounding_mode = ROUND_TO_PLUS_INF;
+  float r2 = a / b;
+  assert(isinf(r2) && r2 > 0);
+
+  // ROUND_TO_MINUS_INF: directed toward -inf -> FLT_MAX
+  __CPROVER_rounding_mode = ROUND_TO_MINUS_INF;
+  float r1 = a / b;
+  assert(r1 == FLT_MAX);
+
+  // ROUND_TO_AWAY: round-to-nearest, ties away from zero -> +inf.
+  // This case directly exercises the round_to_away disjunct in
+  // round_exponent's overflow_to_inf.
+  __CPROVER_rounding_mode = ROUND_TO_AWAY;
+  float r4 = a / b;
+  assert(isinf(r4) && r4 > 0);
+
+  // Negative overflow: -FLT_MAX / 0.5f
+  float c;
+  __CPROVER_assume(c == -FLT_MAX);
+
+  // ROUND_TO_EVEN: -inf
+  __CPROVER_rounding_mode = ROUND_TO_EVEN;
+  float rn0 = c / b;
+  assert(isinf(rn0) && rn0 < 0);
+
+  // ROUND_TO_MINUS_INF: directed toward -inf -> -inf
+  __CPROVER_rounding_mode = ROUND_TO_MINUS_INF;
+  float rn1 = c / b;
+  assert(isinf(rn1) && rn1 < 0);
+
+  // ROUND_TO_PLUS_INF: directed toward +inf -> -FLT_MAX
+  __CPROVER_rounding_mode = ROUND_TO_PLUS_INF;
+  float rn2 = c / b;
+  assert(rn2 == -FLT_MAX);
+
+  // ROUND_TO_AWAY: round-to-nearest -> -inf (negative overflow).
+  __CPROVER_rounding_mode = ROUND_TO_AWAY;
+  float rn4 = c / b;
+  assert(isinf(rn4) && rn4 < 0);
+
+  // ---- bug 1 coverage (exponent wraparound on large quotient) ----
+
+  // FLT_MAX / FLT_MIN: unbiased exponent of the quotient is
+  // 127 - (-126) + 23 = 276, which would overflow the signed 9-bit
+  // (spec.e + 1) intermediate in the buggy float_bvt::div; after the fix
+  // it is 10-bit signed.
+  //
+  // These cases exercise the widened-exponent path but cannot *pin* bug 1:
+  // the result is identical on the pre-fix and post-fix encoders, so they
+  // pass on develop too. The reason is structural, not luck. The largest
+  // intermediate that float_bvt::div can produce is FLT_MAX / FLT_TRUE_MIN,
+  // i.e. 127 - (-149) + 23 = 299; wrapping that in the buggy 9-bit signed
+  // type always lands deeply negative (<= -213), i.e. in the underflow
+  // range, never on a spurious in-range finite exponent (which would need a
+  // value in [386, 639]). The downstream normalization/denormalization path
+  // then recovers the correct saturation, so no C-level input can
+  // distinguish the two encoders. The real safeguard for fix 1 is therefore
+  // parity with float_utilst::div (which has used spec.e + 2 since 2017) and
+  // with float_bvt::mul, not this test.
+  __CPROVER_rounding_mode = ROUND_TO_ZERO;
+  float fmm_max = FLT_MAX / FLT_MIN;
+  assert(fmm_max == FLT_MAX);
+
+  __CPROVER_rounding_mode = ROUND_TO_EVEN;
+  float fmm_inf = FLT_MAX / FLT_MIN;
+  assert(isinf(fmm_inf) && fmm_inf > 0);
+
+  // DBL_MAX / DBL_MIN: unbiased exponent of the quotient is
+  // 1023 - (-1022) + 52 = 2097, which would overflow signed 12-bit
+  // (spec.e + 1 = 12 for double). Same caveat as the float case: the
+  // largest intermediate (DBL_MAX / DBL_TRUE_MIN = 1023 - (-1074) + 52 =
+  // 2149) wraps to <= -1947 in the buggy 12-bit type -- deep underflow, not
+  // a spurious in-range finite (which would need [3074, 5119]) -- so the
+  // result is again indistinguishable from the fixed encoder.
+  __CPROVER_rounding_mode = ROUND_TO_ZERO;
+  double dmm_max = DBL_MAX / DBL_MIN;
+  assert(dmm_max == DBL_MAX);
+
+  __CPROVER_rounding_mode = ROUND_TO_EVEN;
+  double dmm_inf = DBL_MAX / DBL_MIN;
+  assert(isinf(dmm_inf) && dmm_inf > 0);
+
+  return 0;
+}

--- a/regression/cbmc/Float-div-overflow/test.desc
+++ b/regression/cbmc/Float-div-overflow/test.desc
@@ -1,0 +1,10 @@
+CORE no-new-smt
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Division overflow under directed rounding modes.

--- a/regression/cbmc/Float-div-overflow/test_smt.desc
+++ b/regression/cbmc/Float-div-overflow/test_smt.desc
@@ -1,0 +1,10 @@
+CORE smt-backend no-new-smt
+main.c
+--z3
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Division overflow under directed rounding modes (SMT path).

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -723,7 +723,7 @@ exprt float_bvt::mul(
 
   const plus_exprt added_exponent(exponent1, exponent2);
 
-  // Adjust exponent; we are thowing in an extra fraction bit,
+  // Adjust exponent; we are throwing in an extra fraction bit,
   // it has been extended above.
   result.exponent=
     plus_exprt(added_exponent, from_integer(1, new_exponent_type));
@@ -785,17 +785,19 @@ exprt float_bvt::div(
     concatenation_exprt(
       result.fraction, have_remainder, unsignedbv_typet(div_width+1));
 
-  // We will subtract the exponents;
-  // to account for overflow, we add a bit.
+  // We will subtract the exponents; the result needs to be wider than
+  // spec.e by two bits: one bit to absorb subtraction overflow, and one
+  // more bit to absorb the subsequent +spec.f adjustment for the extra
+  // fraction bits we padded in above.
   const typecast_exprt exponent1(
-    unpacked1.exponent, signedbv_typet(spec.e + 1));
+    unpacked1.exponent, signedbv_typet(spec.e + 2));
   const typecast_exprt exponent2(
-    unpacked2.exponent, signedbv_typet(spec.e + 1));
+    unpacked2.exponent, signedbv_typet(spec.e + 2));
 
   // subtract exponents
   const minus_exprt added_exponent(exponent1, exponent2);
 
-  // adjust, as we have thown in extra fraction bits
+  // adjust, as we have thrown in extra fraction bits
   result.exponent=plus_exprt(
     added_exponent,
     from_integer(spec.f, added_exponent.type()));
@@ -1453,13 +1455,19 @@ void float_bvt::round_exponent(
       notequal_exprt(result.fraction, from_integer(0, result.fraction.type())));
 
 #if 1
-    // Directed rounding modes round overflow to the maximum normal
-    // depending on the particular mode and the sign
+    // Round-to-nearest modes (round_to_even, round_to_away) overflow to
+    // infinity. Directed modes (round_to_zero, round_to_plus_inf,
+    // round_to_minus_inf) overflow to infinity only when the rounding
+    // direction matches the sign; otherwise the result is saturated to
+    // the largest finite representable value (set_to_max below).
     const or_exprt overflow_to_inf(
       rounding_mode_bits.round_to_even,
       or_exprt(
-        and_exprt(rounding_mode_bits.round_to_plus_inf, not_exprt(result.sign)),
-        and_exprt(rounding_mode_bits.round_to_minus_inf, result.sign)));
+        rounding_mode_bits.round_to_away,
+        or_exprt(
+          and_exprt(
+            rounding_mode_bits.round_to_plus_inf, not_exprt(result.sign)),
+          and_exprt(rounding_mode_bits.round_to_minus_inf, result.sign))));
 
     const and_exprt set_to_max(exponent_too_large, not_exprt(overflow_to_inf));
 

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -467,7 +467,7 @@ bvt float_utilst::mul(const bvt &src1, const bvt &src2)
 
   bvt added_exponent=bv_utils.add(exponent1, exponent2);
 
-  // adjust, we are thowing in an extra fraction bit
+  // adjust, we are throwing in an extra fraction bit
   // it has been extended above
   result.exponent=bv_utils.inc(added_exponent);
 
@@ -640,9 +640,10 @@ bvt float_utilst::div(const bvt &src1, const bvt &src2)
   result.fraction.insert(
     result.fraction.begin(), have_remainder);
 
-  // We will subtract the exponents;
-  // to account for overflow, we add a bit.
-  // we add a second bit for the adjust by extra fraction bits
+  // We will subtract the exponents; the result needs to be wider than
+  // spec.e by two bits: one bit to absorb subtraction overflow, and one
+  // more bit to absorb the subsequent +spec.f adjustment for the extra
+  // fraction bits we padded in above.
   const bvt exponent1=
     bv_utils.sign_extension(unpacked1.exponent, unpacked1.exponent.size()+2);
   const bvt exponent2=
@@ -651,7 +652,7 @@ bvt float_utilst::div(const bvt &src1, const bvt &src2)
   // subtract exponents
   bvt added_exponent=bv_utils.sub(exponent1, exponent2);
 
-  // adjust, as we have thown in extra fraction bits
+  // adjust, as we have thrown in extra fraction bits
   result.exponent=bv_utils.add(
     added_exponent,
     bv_utils.build_constant(spec.f, added_exponent.size()));
@@ -1291,14 +1292,18 @@ void float_utilst::round_exponent(unbiased_floatt &result)
         !bv_utils.is_zero(result.fraction));
 
 #if 1
-    // Directed rounding modes round overflow to the maximum normal
-    // depending on the particular mode and the sign
-    literalt overflow_to_inf=
-      prop.lor(rounding_mode_bits.round_to_even,
-      prop.lor(prop.land(rounding_mode_bits.round_to_plus_inf,
-                         !result.sign),
-               prop.land(rounding_mode_bits.round_to_minus_inf,
-                         result.sign)));
+    // Round-to-nearest modes (round_to_even, round_to_away) overflow to
+    // infinity. Directed modes (round_to_zero, round_to_plus_inf,
+    // round_to_minus_inf) overflow to infinity only when the rounding
+    // direction matches the sign; otherwise the result is saturated to
+    // the largest finite representable value (set_to_max below).
+    literalt overflow_to_inf = prop.lor(
+      rounding_mode_bits.round_to_even,
+      prop.lor(
+        rounding_mode_bits.round_to_away,
+        prop.lor(
+          prop.land(rounding_mode_bits.round_to_plus_inf, !result.sign),
+          prop.land(rounding_mode_bits.round_to_minus_inf, result.sign))));
 
     literalt set_to_max=
       prop.land(exponent_too_large, !overflow_to_inf);


### PR DESCRIPTION
Two fixes:

1. float_bvt::div: exponent extended by only 1 bit (spec.e+1) instead of 2 (spec.e+2), causing wraparound for large quotients.

2. round_exponent in both float_utilst and float_bvt: overflow_to_inf did not include ROUND_TO_AWAY. Since ROUND_TO_AWAY is a round-to-nearest mode, overflow should produce infinity.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
