### PR TITLE
Fix subnormal division precision loss in float_utilst and float_bvt

### DIFF
--- a/regression/cbmc/Float-div-subnormal/main.c
+++ b/regression/cbmc/Float-div-subnormal/main.c
@@ -1,0 +1,47 @@
+// Test division with a subnormal dividend.
+//
+// Bug: float_utilst and float_bvt used an insufficient division width,
+// causing 1-ULP errors when the unpacked dividend had many leading zeros
+// (which happens for subnormal operands).  After the rounder's
+// normalization shift left-shifts the quotient to place the leading 1 at
+// the top of the buffer, the bits below the round position were all zero,
+// so the `have_remainder` sticky bit was effectively lost: a true
+// round-up (round=1, sticky=1) was mistaken for a tie (round=1, sticky=0)
+// and broken to even.  The error only surfaces when the quotient lands
+// back in the normal range and needs rounding, i.e. for subnormal/subnormal
+// division; a subnormal divided by a normal yields an (exact) subnormal or
+// zero and does not trigger it.
+
+#include <assert.h>
+#include <float.h>
+
+int main()
+{
+  // Smallest positive subnormal divided by three times the smallest
+  // subnormal: mathematically 1/3, whose IEEE-754 round-to-nearest-even
+  // value is 0x1.555556p-2.  The buggy build returned 0x1.555554p-2
+  // (1 ULP low) because the sticky bit was lost.
+  float a, b;
+  __CPROVER_assume(a == 0x1p-149f);
+  __CPROVER_assume(b == 0x3p-149f);
+  float r = a / b;
+  assert(r == 0x1.555556p-2f);
+
+  // A second subnormal/subnormal case, 7/4 = 1.75 exactly.
+  float c, d;
+  __CPROVER_assume(c == 0x7p-149f);
+  __CPROVER_assume(d == 0x4p-149f);
+  float r2 = c / d;
+  assert(r2 == 0x1.cp+0f);
+
+  // Exact subnormal/normal sanity check: FLT_MIN is the smallest positive
+  // normal float; FLT_MIN * 0.5f is subnormal, and dividing it by 2 stays
+  // exactly representable.
+  float e, f;
+  __CPROVER_assume(e == FLT_MIN * 0.5f);
+  __CPROVER_assume(f == 2.0f);
+  float r3 = e / f;
+  assert(r3 == FLT_MIN * 0.25f);
+
+  return 0;
+}

--- a/regression/cbmc/Float-div-subnormal/test.desc
+++ b/regression/cbmc/Float-div-subnormal/test.desc
@@ -1,0 +1,10 @@
+CORE no-new-smt
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Division with subnormal dividend.

--- a/regression/cbmc/Float-div-subnormal/test_smt.desc
+++ b/regression/cbmc/Float-div-subnormal/test_smt.desc
@@ -1,0 +1,10 @@
+CORE no-new-smt
+main.c
+--smt2 --z3
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Division with subnormal dividend (SMT path).

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -757,7 +757,17 @@ exprt float_bvt::div(
 
   std::size_t fraction_width=
     to_unsignedbv_type(unpacked1.fraction.type()).get_width();
-  std::size_t div_width=fraction_width*2+1;
+  // Division width: we need enough bits below the round position so that
+  // `have_remainder` (used as a single sticky bit) survives the left-shift
+  // performed by the rounder's normalization step.  When the unpacked
+  // dividend is subnormal it has up to spec.f leading zeros, so the
+  // normalization shift is correspondingly larger and would otherwise move
+  // the sticky into the round position with all-zero bits below it; the
+  // extra bits give the sticky room to survive.  fraction_width == spec.f + 1
+  // by construction (unpack concatenates the hidden bit onto the fraction),
+  // so derive the extra width from it as a single source of truth.
+  const std::size_t extra_div_bits = fraction_width - 1; // == spec.f
+  std::size_t div_width = fraction_width * 2 + 1 + extra_div_bits;
 
   // pad fraction1 with zeros
   const concatenation_exprt fraction1(

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -757,21 +757,24 @@ exprt float_bvt::div(
 
   std::size_t fraction_width=
     to_unsignedbv_type(unpacked1.fraction.type()).get_width();
-  // Division width: we need enough bits below the round position so that
-  // `have_remainder` (used as a single sticky bit) survives the left-shift
-  // performed by the rounder's normalization step.  When the unpacked
-  // dividend is subnormal it has up to spec.f leading zeros, so the
-  // normalization shift is correspondingly larger and would otherwise move
-  // the sticky into the round position with all-zero bits below it; the
-  // extra bits give the sticky room to survive.  fraction_width == spec.f + 1
-  // by construction (unpack concatenates the hidden bit onto the fraction),
-  // so derive the extra width from it as a single source of truth.
-  const std::size_t extra_div_bits = fraction_width - 1; // == spec.f
-  std::size_t div_width = fraction_width * 2 + 1 + extra_div_bits;
+
+  // Pre-normalize the dividend.  A subnormal dividend has leading zeros in
+  // its fraction (the hidden bit is 0); dividing it directly would give a
+  // quotient with too few significant bits, so the `have_remainder` sticky
+  // bit is lost during the rounder's normalization shift and ties round the
+  // wrong way (a 1-ULP error).  Left-aligning the fraction and decreasing the
+  // exponent by the same amount preserves the value but guarantees a
+  // normalized dividend, so the minimal division width suffices and
+  // normal/normal division pays no extra cost.
+  exprt dividend_fraction = unpacked1.fraction;
+  exprt dividend_exponent = unpacked1.exponent;
+  normalization_shift(dividend_fraction, dividend_exponent);
+
+  std::size_t div_width = fraction_width * 2 + 1;
 
   // pad fraction1 with zeros
   const concatenation_exprt fraction1(
-    unpacked1.fraction,
+    dividend_fraction,
     from_integer(0, unsignedbv_typet(div_width - fraction_width)),
     unsignedbv_typet(div_width));
 
@@ -795,12 +798,12 @@ exprt float_bvt::div(
     concatenation_exprt(
       result.fraction, have_remainder, unsignedbv_typet(div_width+1));
 
-  // We will subtract the exponents;
-  // to account for overflow, we add a bit.
-  const typecast_exprt exponent1(
-    unpacked1.exponent, signedbv_typet(spec.e + 1));
+  // We will subtract the exponents; allow two extra bits so the more
+  // negative exponent of a freshly normalized (formerly subnormal) dividend
+  // cannot overflow the subtraction.
+  const typecast_exprt exponent1(dividend_exponent, signedbv_typet(spec.e + 2));
   const typecast_exprt exponent2(
-    unpacked2.exponent, signedbv_typet(spec.e + 1));
+    unpacked2.exponent, signedbv_typet(spec.e + 2));
 
   // subtract exponents
   const minus_exprt added_exponent(exponent1, exponent2);

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -615,7 +615,14 @@ bvt float_utilst::div(const bvt &src1, const bvt &src2)
   const unbiased_floatt unpacked1=unpack(src1);
   const unbiased_floatt unpacked2=unpack(src2);
 
-  std::size_t div_width=unpacked1.fraction.size()*2+1;
+  // Division width: we need enough bits below the round position so that
+  // `have_remainder` (used as a single sticky bit) survives the left-shift
+  // performed by the rounder's normalization step.  When the unpacked
+  // dividend is subnormal it has up to spec.f leading zeros, so the
+  // normalization shift is correspondingly larger and would otherwise move
+  // the sticky into the round position with all-zero bits below it; the
+  // extra spec.f bits give the sticky room to survive.
+  std::size_t div_width = unpacked1.fraction.size() * 2 + 1 + spec.f;
 
   // pad fraction1 with zeros
   bvt fraction1=unpacked1.fraction;

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -615,17 +615,22 @@ bvt float_utilst::div(const bvt &src1, const bvt &src2)
   const unbiased_floatt unpacked1=unpack(src1);
   const unbiased_floatt unpacked2=unpack(src2);
 
-  // Division width: we need enough bits below the round position so that
-  // `have_remainder` (used as a single sticky bit) survives the left-shift
-  // performed by the rounder's normalization step.  When the unpacked
-  // dividend is subnormal it has up to spec.f leading zeros, so the
-  // normalization shift is correspondingly larger and would otherwise move
-  // the sticky into the round position with all-zero bits below it; the
-  // extra spec.f bits give the sticky room to survive.
-  std::size_t div_width = unpacked1.fraction.size() * 2 + 1 + spec.f;
+  // Pre-normalize the dividend.  A subnormal dividend has leading zeros in
+  // its fraction (the hidden bit is 0); dividing it directly would give a
+  // quotient with too few significant bits, so the `have_remainder` sticky
+  // bit is lost during the rounder's normalization shift and ties round the
+  // wrong way (a 1-ULP error).  Left-aligning the fraction and decreasing the
+  // exponent by the same amount preserves the value but guarantees a
+  // normalized dividend, so the minimal division width suffices and
+  // normal/normal division pays no extra cost.
+  bvt dividend_fraction = unpacked1.fraction;
+  bvt dividend_exponent = unpacked1.exponent;
+  normalization_shift(dividend_fraction, dividend_exponent);
+
+  std::size_t div_width = dividend_fraction.size() * 2 + 1;
 
   // pad fraction1 with zeros
-  bvt fraction1=unpacked1.fraction;
+  bvt fraction1 = dividend_fraction;
   fraction1.reserve(div_width);
   while(fraction1.size()<div_width)
     fraction1.insert(fraction1.begin(), const_literal(false));
@@ -650,10 +655,12 @@ bvt float_utilst::div(const bvt &src1, const bvt &src2)
   // We will subtract the exponents;
   // to account for overflow, we add a bit.
   // we add a second bit for the adjust by extra fraction bits
-  const bvt exponent1=
-    bv_utils.sign_extension(unpacked1.exponent, unpacked1.exponent.size()+2);
-  const bvt exponent2=
-    bv_utils.sign_extension(unpacked2.exponent, unpacked2.exponent.size()+2);
+  // The dividend exponent may have grown during normalization; extend both
+  // exponents to a common width.
+  const std::size_t exp_width =
+    std::max(dividend_exponent.size(), unpacked2.exponent.size()) + 2;
+  const bvt exponent1 = bv_utils.sign_extension(dividend_exponent, exp_width);
+  const bvt exponent2 = bv_utils.sign_extension(unpacked2.exponent, exp_width);
 
   // subtract exponents
   bvt added_exponent=bv_utils.sub(exponent1, exponent2);


### PR DESCRIPTION
When the dividend of a floating-point division is subnormal, its unpacked fraction has leading zeros (the hidden bit is 0). The rounder's normalization step then left-shifts the quotient to bring the leading 1 to the top of the buffer, which moves the `have_remainder` sticky bit into the round position with all-zero bits below it. A genuine round-up (round=1, sticky=1) is thereby mistaken for a tie (round=1, sticky=0) and broken to even, giving a 1-ULP error.

This only surfaces when the quotient lands back in the normal range and so needs rounding — in practice **subnormal/subnormal** division. For example `0x1p-149f / 0x3p-149f` (mathematically 1/3) returned `0x1.555554p-2f` instead of the correct round-to-nearest-even `0x1.555556p-2f`. (A subnormal divided by a *normal* yields an exact subnormal or zero and does not trigger it; the original "subnormal by a normal" framing has been corrected.)

The fix is applied to both `float_utilst::div` (bit-flattening back end) and `float_bvt::div` (used by the non-FPA SMT back end, e.g. Z3).

## Commits

**1. Fix subnormal division precision loss** — widen `div_width` by `spec.f` extra bits so the sticky bit has room below the round position and survives the normalization shift. Includes the regression test. This widening is paid by *every* float division.

**2. Pre-normalize the dividend instead of widening the divider** — normalize the dividend before dividing (left-align its fraction, decrease the exponent by the same amount; value-preserving) via the existing `normalization_shift`. A normalized dividend has no leading zeros, so the minimal `div_width` suffices, avoiding the unconditional widening.

The two commits are kept separate on purpose: commit 1 is the minimal, self-contained fix; commit 2 is an optional optimization that explains and justifies the extra machinery. Reverting to commit 1 alone remains a valid, simpler option.

## Regression test

`regression/cbmc/Float-div-subnormal` exercises the subnormal/subnormal case (and an exact subnormal/normal sanity check) on **both** back ends (`test.desc` → flattening; `test_smt.desc` → `--smt2 --z3`). Verified to **fail on an unpatched `cbmc`** and pass with either fix. The full `regression/cbmc/Float*` suite (CORE and THOROUGH) passes unchanged.

## Performance

Measured end-to-end with the default flattening back end (base = unpatched develop):

| workload | base | commit 1 (widen) | commit 2 (pre-normalize) |
| --- | --- | --- | --- |
| single double division | ~0.10s | ~0.13s | ~0.10s |
| four chained double divisions | ~0.39s | ~6.5s | ~3.2s |

Commit 1's unconditional widening grows `div_width` from 49→72 bits (float) and 105→157 (double); the bit-blasted divider's cost grows roughly with the square of its width. Commit 2 removes the regression for isolated divisions and roughly halves it for chained divisions; the residual cost is the per-division normalization shifter, which is far cheaper than the wider divider.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
