### PR TITLE
Align floating-point predicates across float_utilst and float_bvt

### DIFF
--- a/regression/cbmc-library/__builtin_finite/main.c
+++ b/regression/cbmc-library/__builtin_finite/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  __builtin_finite();
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_finite/test.desc
+++ b/regression/cbmc-library/__builtin_finite/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/__builtin_finitef/main.c
+++ b/regression/cbmc-library/__builtin_finitef/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  __builtin_finitef();
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_finitef/test.desc
+++ b/regression/cbmc-library/__builtin_finitef/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/__builtin_finitel/main.c
+++ b/regression/cbmc-library/__builtin_finitel/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  __builtin_finitel();
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_finitel/test.desc
+++ b/regression/cbmc-library/__builtin_finitel/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/__builtin_isfinite/main.c
+++ b/regression/cbmc-library/__builtin_isfinite/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  __builtin_isfinite();
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_isfinite/test.desc
+++ b/regression/cbmc-library/__builtin_isfinite/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Float-predicates/main.c
+++ b/regression/cbmc/Float-predicates/main.c
@@ -1,0 +1,28 @@
+// Test floating-point classification predicates: isfinite, isinf (signed).
+
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float pos_inf = 1.0f / 0.0f;
+  float neg_inf = -1.0f / 0.0f;
+  float nan_val = 0.0f / 0.0f;
+  float normal = 1.5f;
+  float zero = 0.0f;
+
+  // isfinite
+  assert(isfinite(normal));
+  assert(isfinite(zero));
+  assert(!isfinite(pos_inf));
+  assert(!isfinite(neg_inf));
+  assert(!isfinite(nan_val));
+
+  // isinf with sign
+  assert(isinf(pos_inf) && pos_inf > 0);
+  assert(isinf(neg_inf) && neg_inf < 0);
+  assert(!isinf(normal));
+  assert(!isinf(nan_val));
+
+  return 0;
+}

--- a/regression/cbmc/Float-predicates/test.desc
+++ b/regression/cbmc/Float-predicates/test.desc
@@ -1,0 +1,10 @@
+CORE no-new-smt
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Floating-point classification predicates.

--- a/regression/cbmc/Float-predicates/test_smt.desc
+++ b/regression/cbmc/Float-predicates/test_smt.desc
@@ -1,0 +1,10 @@
+CORE smt-backend no-new-smt
+main.c
+--smt2 --z3
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Floating-point classification predicates (SMT path).

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3246,9 +3246,12 @@ exprt c_typecheck_baset::do_special_functions(
 
     return typecast_exprt::conditional_cast(isnan_expr, expr.type());
   }
-  else if(identifier==CPROVER_PREFIX "isfinitef" ||
-          identifier==CPROVER_PREFIX "isfinited" ||
-          identifier==CPROVER_PREFIX "isfiniteld")
+  else if(
+    identifier == CPROVER_PREFIX "isfinitef" ||
+    identifier == CPROVER_PREFIX "isfinited" ||
+    identifier == CPROVER_PREFIX "isfiniteld" ||
+    identifier == "__builtin_isfinite" || identifier == "__builtin_finite" ||
+    identifier == "__builtin_finitef" || identifier == "__builtin_finitel")
   {
     if(expr.arguments().size()!=1)
     {

--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -251,6 +251,34 @@ int __builtin_isnanf(float f)
   return __CPROVER_isnanf(f);
 }
 
+/* FUNCTION: __builtin_isfinite */
+
+int __builtin_isfinite(double d)
+{
+  return __CPROVER_isfinited(d);
+}
+
+/* FUNCTION: __builtin_finite */
+
+int __builtin_finite(double d)
+{
+  return __CPROVER_isfinited(d);
+}
+
+/* FUNCTION: __builtin_finitef */
+
+int __builtin_finitef(float f)
+{
+  return __CPROVER_isfinitef(f);
+}
+
+/* FUNCTION: __builtin_finitel */
+
+int __builtin_finitel(long double ld)
+{
+  return __CPROVER_isfiniteld(ld);
+}
+
 /* FUNCTION: __builtin_huge_valf */
 
 float __builtin_huge_valf(void)

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -461,7 +461,7 @@ literalt boolbvt::convert_rest(const exprt &expr)
         !float_utils.is_infinity(bv),
         !float_utils.is_NaN(bv));
     }
-    else if(op.id() == ID_fixedbv)
+    else if(op.type().id() == ID_fixedbv)
       return const_literal(true);
   }
   else if(expr.id()==ID_isinf)

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -457,9 +457,7 @@ literalt boolbvt::convert_rest(const exprt &expr)
     if(op.type().id() == ID_floatbv)
     {
       float_utilst float_utils(prop, to_floatbv_type(op.type()));
-      return prop.land(
-        !float_utils.is_infinity(bv),
-        !float_utils.is_NaN(bv));
+      return float_utils.is_finite(bv);
     }
     else if(op.type().id() == ID_fixedbv)
       return const_literal(true);

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -813,15 +813,6 @@ literalt float_utilst::is_zero(const bvt &src)
   return bv_utils.is_zero(all_but_sign);
 }
 
-literalt float_utilst::is_plus_inf(const bvt &src)
-{
-  bvt and_bv;
-  and_bv.push_back(!sign_bit(src));
-  and_bv.push_back(exponent_all_ones(src));
-  and_bv.push_back(fraction_all_zeros(src));
-  return prop.land(and_bv);
-}
-
 literalt float_utilst::is_infinity(const bvt &src)
 {
   return prop.land(
@@ -841,19 +832,15 @@ bvt float_utilst::get_fraction(const bvt &src)
   return bv_utils.extract(src, 0, spec.f-1);
 }
 
-literalt float_utilst::is_minus_inf(const bvt &src)
-{
-  bvt and_bv;
-  and_bv.push_back(sign_bit(src));
-  and_bv.push_back(exponent_all_ones(src));
-  and_bv.push_back(fraction_all_zeros(src));
-  return prop.land(and_bv);
-}
-
 literalt float_utilst::is_NaN(const bvt &src)
 {
   return prop.land(exponent_all_ones(src),
                    !fraction_all_zeros(src));
+}
+
+literalt float_utilst::is_finite(const bvt &src)
+{
+  return !exponent_all_ones(src);
 }
 
 literalt float_utilst::exponent_all_ones(const bvt &src)

--- a/src/solvers/floatbv/float_utils.h
+++ b/src/solvers/floatbv/float_utils.h
@@ -107,9 +107,9 @@ public:
   literalt is_normal(const bvt &);
   literalt is_zero(const bvt &); // this returns true on both 0 and -0
   literalt is_infinity(const bvt &);
-  literalt is_plus_inf(const bvt &);
-  literalt is_minus_inf(const bvt &);
   literalt is_NaN(const bvt &);
+  /// Returns true iff \p src is finite (not NaN and not infinity).
+  literalt is_finite(const bvt &);
 
   // add/sub
   virtual bvt add_sub(const bvt &src1, const bvt &src2, bool subtract);


### PR DESCRIPTION
Depends-on: #9020

- Add float_utilst::is_finite and use it (float_bvt already has is_finite).
- Remove unused float_utilst::is_plus_inf, float_utilst::is_minus_inf (float_bvt does not have these either).

Tests targeting predicates continue to pass.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
