### PR TITLE
Optimize replace_symbolt: skip have_to_replace pre-check for symbols

### DIFF
--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -71,47 +71,25 @@ bool replace_symbolt::replace(exprt &dest) const
     if(!replace(dest.type()))
       result=false;
 
-  // now do expression itself
-
-  if(!have_to_replace(dest))
-    return result;
-
-  if(dest.id()==ID_member)
+  // Handle expression replacement directly (no have_to_replace pre-check)
+  if(dest.id() == ID_symbol)
   {
-    member_exprt &me=to_member_expr(dest);
-
-    if(!replace(me.struct_op()))
-      result=false;
-  }
-  else if(dest.id()==ID_index)
-  {
-    index_exprt &ie=to_index_expr(dest);
-
-    if(!replace(ie.array()))
-      result=false;
-
-    if(!replace(ie.index()))
-      result=false;
-  }
-  else if(dest.id()==ID_address_of)
-  {
-    address_of_exprt &aoe=to_address_of_expr(dest);
-
-    if(!replace(aoe.object()))
-      result=false;
-  }
-  else if(dest.id()==ID_symbol)
-  {
-    if(!replace_symbol_expr(to_symbol_expr(dest)))
+    if(
+      bindings.find(to_symbol_expr(dest).get_identifier()) == bindings.end() &&
+      !replace_symbol_expr(to_symbol_expr(dest)))
+    {
       return false;
+    }
   }
   else if(dest.id() == ID_let)
   {
+    if(!have_to_replace(dest))
+      return result;
     auto &let_expr = to_let_expr(dest);
 
     // first replace the assigned value expressions
     for(auto &op : let_expr.values())
-      if(replace(op))
+      if(!replace(op))
         result = false;
 
     // now set up the binding
@@ -129,6 +107,8 @@ bool replace_symbolt::replace(exprt &dest) const
     dest.id() == ID_array_comprehension || dest.id() == ID_exists ||
     dest.id() == ID_forall || dest.id() == ID_lambda)
   {
+    if(!have_to_replace(dest))
+      return result;
     auto &binding_expr = to_binding_expr(dest);
 
     auto old_bindings = bindings;
@@ -140,7 +120,7 @@ bool replace_symbolt::replace(exprt &dest) const
 
     bindings = std::move(old_bindings);
   }
-  else
+  else if(have_to_replace(dest))
   {
     Forall_operands(it, dest)
       if(!replace(*it))
@@ -363,8 +343,6 @@ bool address_of_aware_replace_symbolt::replace(exprt &dest) const
     if(!unchecked_replace_symbolt::replace(dest.type()))
       result = false;
   }
-
-  // now do expression itself
 
   if(!have_to_replace(dest))
     return result;

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -6,11 +6,12 @@ Author: Michael Tautschnig
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
-
+#include <util/mathematical_expr.h>
 #include <util/pointer_expr.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
+
+#include <testing-utils/use_catch.h>
 
 TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
 {
@@ -104,4 +105,81 @@ TEST_CASE("Replace always", "[core][util][replace_symbol]")
     to_index_expr(to_address_of_expr(binary.op1()).object());
   REQUIRE(to_array_type(index_expr.array().type()).size() == c);
   REQUIRE(index_expr.index() == c);
+}
+
+TEST_CASE("Let expression hides bound variable", "[core][util][replace_symbol]")
+{
+  const typet t{"some_type"};
+  const symbol_exprt x{"x", t};
+  const symbol_exprt y{"y", t};
+  const constant_exprt replacement{"val", t};
+
+  // let x = y in x + y
+  const binary_exprt body{x, "plus", y, t};
+  const let_exprt let{x, y, body};
+
+  replace_symbolt r;
+  r.insert(x, replacement);
+  r.insert(y, replacement);
+
+  exprt result = let;
+  // replacements happen, so return value is false
+  REQUIRE(!r.replace(result));
+
+  const auto &result_let = to_let_expr(result);
+  // the value expression (y) is replaced
+  REQUIRE(result_let.value() == replacement);
+  // in the body, x is bound and must NOT be replaced
+  const auto &result_body = result_let.where();
+  REQUIRE(result_body.operands().size() == 2);
+  REQUIRE(result_body.operands()[0] == x);
+  // y is not bound, so it IS replaced in the body
+  REQUIRE(result_body.operands()[1] == replacement);
+}
+
+TEST_CASE(
+  "Forall expression hides bound variable",
+  "[core][util][replace_symbol]")
+{
+  const typet t{"some_type"};
+  const symbol_exprt x{"x", t};
+  const symbol_exprt y{"y", t};
+  const constant_exprt replacement{"val", t};
+
+  // forall x. x == y
+  const equal_exprt body{x, y};
+  const forall_exprt forall{x, body};
+
+  replace_symbolt r;
+  r.insert(x, replacement);
+  r.insert(y, replacement);
+
+  exprt result = forall;
+  REQUIRE(!r.replace(result));
+
+  const auto &result_forall = to_quantifier_expr(result);
+  // x is bound and must NOT be replaced in the body
+  REQUIRE(result_forall.where().operands()[0] == x);
+  // y is free and IS replaced
+  REQUIRE(result_forall.where().operands()[1] == replacement);
+}
+
+TEST_CASE(
+  "Let expression returns true when nothing replaced",
+  "[core][util][replace_symbol]")
+{
+  const typet t{"some_type"};
+  const symbol_exprt x{"x", t};
+  const symbol_exprt y{"y", t};
+  const constant_exprt replacement{"val", t};
+
+  // let x = x in x  -- only bound variable, no free occurrences of y
+  const let_exprt let{x, x, x};
+
+  replace_symbolt r;
+  r.insert(y, replacement);
+
+  exprt result = let;
+  // nothing to replace, so return value is true
+  REQUIRE(r.replace(result));
 }


### PR DESCRIPTION
Move the have_to_replace(dest) pre-check from the top of replace_symbolt::replace(exprt&) to guard only the code paths that would break expression sharing: Forall_operands (which detaches shared operand vectors) and to_let_expr/to_binding_expr (which detach shared let/binding nodes).

The symbol check (dest.id() == ID_symbol) is O(1) and does not detach, so it needs no guard. This avoids the O(n²) behavior where have_to_replace traversed the entire subtree at every non-symbol node, while still preserving sharing for subtrees that contain no replaceable symbols.

Apply the same pattern to address_of_aware_replace_symbolt::replace.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
