### PR TITLE
CODEOWNERS: consistency and redundancy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,67 +8,40 @@
 
 /doc/ @jimgrundy @TGWDB @kroening @tautschnig @peterschrammel
 
-
 # These files should rarely change
 
-/src/big-int/ @kroening
-/src/ansi-c/ @kroening @tautschnig @peterschrammel @remi-delmas-3000
-/src/assembler/ @kroening @tautschnig
-/src/goto-cc/ @kroening @tautschnig
-/src/linking/ @kroening @tautschnig
-/src/memory-models/ @kroening @tautschnig
-/src/goto-checker/ @kroening @tautschnig @peterschrammel
-/src/goto-symex/ @kroening @tautschnig @peterschrammel
-/src/json/ @kroening @tautschnig @peterschrammel
+/src/ansi-c/ @remi-delmas-3000 @kroening @tautschnig @peterschrammel
 /src/json-symtab-language/ @martin-cs @kroening @tautschnig @peterschrammel
-/src/langapi/ @kroening @tautschnig @peterschrammel
-/src/xmllang/ @kroening @tautschnig @peterschrammel
 /src/solvers/flattening @martin-cs @kroening @tautschnig @peterschrammel
-/src/solvers/floatbv @martin-cs @kroening @peterschrammel
-/src/solvers/miniBDD @tautschnig @kroening
+/src/solvers/floatbv @martin-cs @kroening @tautschnig @peterschrammel
 /src/solvers/prop @martin-cs @kroening @tautschnig @peterschrammel
 /src/solvers/sat @martin-cs @kroening @tautschnig @peterschrammel
 /src/symtab2gb/ @martin-cs @kroening @tautschnig @peterschrammel
-/jbmc/src/miniz/ @peterschrammel
-/src/crangler/ @kroening @tautschnig @qinheping
-
 
 # These files change frequently and changes are high-risk
 
-/src/cbmc/ @kroening @tautschnig @peterschrammel
-/src/goto-programs/ @kroening @tautschnig @peterschrammel
-/src/util/ @kroening @tautschnig @peterschrammel
-/src/solvers/refinement @martin-cs @peterschrammel
-/src/solvers/strings @martin-cs @peterschrammel
-/jbmc/src/java_bytecode/ @peterschrammel @TGWDB
-/src/analyses/ @martin-cs @peterschrammel
-/src/pointer-analysis/ @martin-cs @peterschrammel
-/src/libcprover-cpp @TGWDB @peterschrammel
-/src/libcprover-rust @TGWDB @peterschrammel
+/src/solvers/refinement @martin-cs @peterschrammel @kroening @tautschnig
+/src/solvers/strings @martin-cs @peterschrammel @kroening @tautschnig
+/jbmc/src/java_bytecode/ @TGWDB @peterschrammel @kroening @tautschnig
+/src/analyses/ @martin-cs @peterschrammel @kroening @tautschnig
+/src/pointer-analysis/ @martin-cs @peterschrammel @kroening @tautschnig
+/src/libcprover-cpp @TGWDB @peterschrammel @kroening @tautschnig
+/src/libcprover-rust @TGWDB @peterschrammel @kroening @tautschnig
 
 # These files change frequently and changes are medium-risk
 
-/src/goto-analyzer/ @martin-cs @peterschrammel
-/src/goto-bmc/ @TGWDB @peterschrammel
-/src/goto-harness/ @martin-cs @peterschrammel
+/src/goto-analyzer/ @martin-cs @peterschrammel @kroening @tautschnig
+/src/goto-bmc/ @TGWDB @peterschrammel @kroening @tautschnig
+/src/goto-harness/ @martin-cs @peterschrammel @kroening @tautschnig
 /src/goto-instrument/ @martin-cs @peterschrammel @tautschnig @kroening
-/src/goto-instrument/contracts/ @tautschnig @feliperodri @remi-delmas-3000
-/src/goto-inspect/ @diffblue/diffblue-opensource
-/src/goto-synthesizer/ @qinheping @tautschnig @feliperodri @remi-delmas-3000
-/src/goto-diff/ @tautschnig @peterschrammel
-/src/memory-analyzer/ @tautschnig @kroening
-/jbmc/src/jbmc/ @peterschrammel @TGWDB
-/jbmc/src/janalyzer/ @peterschrammel @TGWDB
-/jbmc/src/jdiff/ @peterschrammel
-/src/cpp/ @kroening @tautschnig @peterschrammel
-/src/solvers/smt2 @kroening @martin-cs @peterschrammel @TGWDB
-/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @TGWDB
-/src/solvers/Makefile @kroening @tautschnig @peterschrammel @TGWDB
-/src/statement-list/ @kroening @tautschnig @peterschrammel
-
-/cmake/        @diffblue/diffblue-opensource
-CMakeLists.txt @diffblue/diffblue-opensource
-CHANGELOG      @diffblue/diffblue-opensource
+/src/goto-instrument/contracts/ @feliperodri @remi-delmas-3000 @kroening @tautschnig @peterschrammel
+/src/goto-inspect/ @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+/src/goto-synthesizer/ @feliperodri @remi-delmas-3000 @kroening @tautschnig @peterschrammel
+/jbmc/src/jbmc/ @TGWDB @kroening @tautschnig @peterschrammel
+/jbmc/src/janalyzer/ @TGWDB @kroening @tautschnig @peterschrammel
+/src/solvers/smt2 @martin-cs @TGWDB @kroening @tautschnig @peterschrammel
+/src/solvers/smt2_incremental @thomasspriggs @TGWDB @kroening @tautschnig @peterschrammel
+/src/solvers/Makefile @TGWDB @kroening @tautschnig @peterschrammel
 
 # These files change frequently and changes are low-risk
 
@@ -79,8 +52,10 @@ CHANGELOG      @diffblue/diffblue-opensource
 /jbmc/unit/
 /jbmc/regression/
 
-/scripts/ @diffblue/diffblue-opensource
-
-# CI pipeline is the responsibility of the Open Source maintenance team at Diffblue.
-/.github/ @diffblue/diffblue-opensource @peterschrammel @tautschnig
-src/config.inc @diffblue/diffblue-opensource @peterschrammel @tautschnig
+# CI pipeline and automation are the responsibility of the Open Source maintenance team at Diffblue.
+/cmake/        @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+CMakeLists.txt @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+/.github/ @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+CHANGELOG      @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+src/config.inc @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel
+/scripts/ @diffblue/diffblue-opensource @kroening @tautschnig @peterschrammel


### PR DESCRIPTION
Make all rules only add owners, but never remove ownership from default owners @kroening @peterschrammel @tautschnig. Also remove Qinheping as they are not currently active in the project.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
