### PR TITLE
Make namespacet references const where possible

### DIFF
--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -30,7 +30,7 @@ class instrumentert
 {
 public:
   /* reference to goto-functions and symbol_table */
-  namespacet ns;
+  const namespacet ns;
 
 protected:
   goto_functionst &goto_functions;
@@ -86,7 +86,7 @@ protected:
   class cfg_visitort
   {
   protected:
-    namespacet &ns;
+    const namespacet ns;
     instrumentert &instrumenter;
 
     /* pointer to the egraph(s) that we construct */
@@ -227,10 +227,12 @@ protected:
     /* set of functions visited so far -- we don't handle recursive functions */
     std::set<irep_idt> functions_met;
 
-    cfg_visitort(namespacet &_ns, instrumentert &_instrumenter)
-    :ns(_ns), instrumenter(_instrumenter), egraph(_instrumenter.egraph),
-      egraph_SCCs(_instrumenter.egraph_SCCs),
-      egraph_alt(_instrumenter.egraph_alt)
+    cfg_visitort(const namespacet &_ns, instrumentert &_instrumenter)
+      : ns(_ns),
+        instrumenter(_instrumenter),
+        egraph(_instrumenter.egraph),
+        egraph_SCCs(_instrumenter.egraph_SCCs),
+        egraph_alt(_instrumenter.egraph_alt)
     {
       write_counter = 0;
       read_counter = 0;

--- a/src/linking/linking_diagnostics.h
+++ b/src/linking/linking_diagnostics.h
@@ -12,16 +12,16 @@ Author: Michael Tautschnig
 #ifndef CPROVER_LINKING_LINKING_DIAGNOSTICS_H
 #define CPROVER_LINKING_LINKING_DIAGNOSTICS_H
 
+#include <util/namespace.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
 
 class message_handlert;
-class namespacet;
 
 class linking_diagnosticst
 {
 public:
-  linking_diagnosticst(message_handlert &message_handler, namespacet &ns)
+  linking_diagnosticst(message_handlert &message_handler, const namespacet &ns)
     : message_handler(message_handler), ns(ns)
   {
   }
@@ -54,7 +54,7 @@ public:
 
 protected:
   message_handlert &message_handler;
-  const namespacet &ns;
+  const namespacet ns;
 
   std::string
   type_to_string_verbose(const symbolt &symbol, const typet &type) const;

--- a/unit/analyses/variable-sensitivity/eval-member-access.cpp
+++ b/unit/analyses/variable-sensitivity/eval-member-access.cpp
@@ -20,7 +20,7 @@
 void test_array(
   std::vector<int> contents,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 const auto TOP = -99;
 
@@ -53,13 +53,13 @@ SCENARIO(
 exprt make_array(
   std::vector<int> contents,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 exprt fetch_element(
   int index,
   exprt &array,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 exprt integer_expression(int i);
 exprt top_expression();
@@ -67,7 +67,7 @@ exprt top_expression();
 void test_array(
   std::vector<int> values,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto array = make_array(values, environment, ns);
 
@@ -107,7 +107,7 @@ exprt fetch_element(
   int index,
   exprt &array,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto index_expression =
     index_exprt(array, from_integer(index, integer_typet()));
@@ -129,7 +129,7 @@ exprt fetch_element(
 exprt make_array(
   std::vector<int> contents,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   const array_typet array_type(
     integer_typet(), from_integer(contents.size(), integer_typet()));

--- a/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
+++ b/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
@@ -24,7 +24,7 @@ static abstract_object_ptrt write_array(
   int index,
   int new_value,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   const typet type = signedbv_typet(32);
 

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/extremes-go-top.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/extremes-go-top.cpp
@@ -19,8 +19,10 @@
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
 #include <testing-utils/use_catch.h>
 
-static void
-verify_extreme_interval(typet type, abstract_environmentt &env, namespacet &ns)
+static void verify_extreme_interval(
+  typet type,
+  abstract_environmentt &env,
+  const namespacet &ns)
 {
   auto interval =
     make_interval(min_value_exprt(type), max_value_exprt(type), env, ns);

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
@@ -28,7 +28,7 @@ exprt binary_expression(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto op1_sym = symbol_exprt("op1", op1->type());
   auto op2_sym = symbol_exprt("op2", op2->type());
@@ -105,7 +105,7 @@ public:
     }
   }
 
-  assume_testert(abstract_environmentt &env, namespacet &n)
+  assume_testert(abstract_environmentt &env, const namespacet &n)
     : environment(env), ns(n)
   {
   }
@@ -155,7 +155,7 @@ private:
   const typet type = signedbv_typet(32);
 
   abstract_environmentt &environment;
-  namespacet &ns;
+  const namespacet &ns;
 };
 
 SCENARIO(

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
@@ -28,7 +28,7 @@ static void ASSUME_TRUE(
   const irep_idt &id,
   symbol_exprt const &y,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto assumption = env.do_assume(binary_relation_exprt(x, id, y), ns);
 
@@ -43,7 +43,7 @@ static void EXPECT_RESULT(
   symbol_exprt const &y,
   const std::vector<exprt> &y_expected,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto x_result = as_value_set(env.eval(x, ns));
   auto y_result = as_value_set(env.eval(y, ns));
@@ -60,7 +60,7 @@ static void EXPECT_RESULT(
   exprt const &y_lower,
   exprt const &y_upper,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto x_result = as_interval(env.eval(x, ns));
   auto y_result = as_interval(env.eval(y, ns));

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -24,7 +24,7 @@
 #include <testing-utils/use_catch.h>
 
 std::shared_ptr<const constant_abstract_valuet>
-make_constant(exprt val, abstract_environmentt &env, namespacet &ns)
+make_constant(exprt val, abstract_environmentt &env, const namespacet &ns)
 {
   return std::make_shared<constant_abstract_valuet>(val, env, ns);
 }
@@ -45,7 +45,7 @@ std::shared_ptr<const interval_abstract_valuet> make_interval(
   const exprt &vall,
   const exprt &valh,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto interval = constant_interval_exprt(vall, valh);
   return make_interval(interval, env, ns);
@@ -54,14 +54,14 @@ std::shared_ptr<const interval_abstract_valuet> make_interval(
 std::shared_ptr<const interval_abstract_valuet> make_interval(
   const binary_relation_exprt &val,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   return std::make_shared<interval_abstract_valuet>(val, env, ns);
 }
 std::shared_ptr<const interval_abstract_valuet> make_interval(
   const constant_interval_exprt &val,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   return std::make_shared<interval_abstract_valuet>(val, env, ns);
 }
@@ -79,7 +79,7 @@ std::shared_ptr<const interval_abstract_valuet> make_bottom_interval()
 }
 
 std::shared_ptr<const value_set_abstract_objectt>
-make_value_set(exprt val, abstract_environmentt &env, namespacet &ns)
+make_value_set(exprt val, abstract_environmentt &env, const namespacet &ns)
 {
   auto vals = std::vector<exprt>{val};
   return make_value_set(vals, env, ns);
@@ -88,7 +88,7 @@ make_value_set(exprt val, abstract_environmentt &env, namespacet &ns)
 std::shared_ptr<const value_set_abstract_objectt> make_value_set(
   const std::vector<exprt> &vals,
   abstract_environmentt &env,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto initial_values = abstract_object_sett{};
   for(auto v : vals)
@@ -298,7 +298,7 @@ void EXPECT_INDEX(
   int index,
   int expected,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto type = signedbv_typet(32);
   auto index_expr = index_exprt(
@@ -319,7 +319,7 @@ void EXPECT_INDEX(
   int index,
   std::vector<int> expected,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto type = signedbv_typet(32);
   auto index_expr = index_exprt(
@@ -341,7 +341,7 @@ void EXPECT_INDEX_TOP(
   std::shared_ptr<const abstract_objectt> &result,
   int index,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto type = signedbv_typet(32);
   auto index_expr = index_exprt(
@@ -510,7 +510,7 @@ std::shared_ptr<const abstract_objectt> add(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto op1_sym = symbol_exprt("op1", op1->type());
   auto op2_sym = symbol_exprt("op2", op2->type());
@@ -526,7 +526,7 @@ std::shared_ptr<const constant_abstract_valuet> add_as_constant(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto result = add(op1, op2, environment, ns);
   auto cv = as_constant(result);
@@ -540,7 +540,7 @@ std::shared_ptr<const interval_abstract_valuet> add_as_interval(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto result = add(op1, op2, environment, ns);
   auto i = as_interval(result);
@@ -554,7 +554,7 @@ std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto result = add(op1, op2, environment, ns);
   auto vs = as_value_set(result);
@@ -569,7 +569,7 @@ std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
   const abstract_object_pointert &op2,
   const abstract_object_pointert &op3,
   abstract_environmentt &environment,
-  namespacet &ns)
+  const namespacet &ns)
 {
   auto op1_sym = symbol_exprt("op1", op1->type());
   auto op2_sym = symbol_exprt("op2", op2->type());

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
@@ -21,7 +21,7 @@ class value_set_abstract_objectt;
 class variable_sensitivity_domaint;
 
 std::shared_ptr<const constant_abstract_valuet>
-make_constant(exprt val, abstract_environmentt &env, namespacet &ns);
+make_constant(exprt val, abstract_environmentt &env, const namespacet &ns);
 
 std::shared_ptr<const constant_abstract_valuet> make_top_constant();
 std::shared_ptr<const constant_abstract_valuet> make_bottom_constant();
@@ -30,25 +30,25 @@ std::shared_ptr<const interval_abstract_valuet> make_interval(
   const exprt &vall,
   const exprt &valh,
   abstract_environmentt &env,
-  namespacet &ns);
+  const namespacet &ns);
 std::shared_ptr<const interval_abstract_valuet> make_interval(
   const binary_relation_exprt &val,
   abstract_environmentt &env,
-  namespacet &ns);
+  const namespacet &ns);
 std::shared_ptr<const interval_abstract_valuet> make_interval(
   const constant_interval_exprt &val,
   abstract_environmentt &env,
-  namespacet &ns);
+  const namespacet &ns);
 std::shared_ptr<const interval_abstract_valuet> make_top_interval();
 std::shared_ptr<const interval_abstract_valuet> make_bottom_interval();
 
 std::shared_ptr<const value_set_abstract_objectt>
-make_value_set(exprt val, abstract_environmentt &env, namespacet &ns);
+make_value_set(exprt val, abstract_environmentt &env, const namespacet &ns);
 
 std::shared_ptr<const value_set_abstract_objectt> make_value_set(
   const std::vector<exprt> &vals,
   abstract_environmentt &env,
-  namespacet &ns);
+  const namespacet &ns);
 
 std::shared_ptr<const value_set_abstract_objectt> make_bottom_value_set();
 std::shared_ptr<const value_set_abstract_objectt> make_top_value_set();
@@ -89,18 +89,18 @@ void EXPECT_INDEX(
   int index,
   int expected,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 void EXPECT_INDEX(
   std::shared_ptr<const abstract_objectt> &result,
   int index,
   std::vector<int> expected,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 void EXPECT_INDEX_TOP(
   std::shared_ptr<const abstract_objectt> &result,
   int index,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 void EXPECT_TOP(std::shared_ptr<const abstract_objectt> result);
 
@@ -241,31 +241,31 @@ std::shared_ptr<const abstract_objectt> add(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 std::shared_ptr<const constant_abstract_valuet> add_as_constant(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 std::shared_ptr<const interval_abstract_valuet> add_as_interval(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   const abstract_object_pointert &op3,
   abstract_environmentt &environment,
-  namespacet &ns);
+  const namespacet &ns);
 
 exprt to_expr(int v);
 std::string expr_to_str(const exprt &expr);


### PR DESCRIPTION
namespacet has no non-const member functions (other than constructors and assignment), so non-const references to it are misleading. The only legitimate non-const use is in goto_symext::symex_with_state where the namespacet object is reassigned via reset_namespacet.

Changes in src/:
- linking_diagnosticst constructor: namespacet& -> const namespacet& (the member was already const)
- cfg_visitort (wmm): namespacet& member and constructor parameter made const

Changes in unit/:
- variable_sensitivity_test_helpers: all namespacet& parameters -> const
- eval-member-access, assume, assume_prune, maximum_length, extremes-go-top: all namespacet& parameters and members -> const

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
