### PR TITLE
move `range_typet` to `mathematical_types.h`

### DIFF
--- a/jbmc/src/java_bytecode/nondet.h
+++ b/jbmc/src/java_bytecode/nondet.h
@@ -9,6 +9,7 @@ Author: Diffblue Ltd.
 #ifndef CPROVER_JAVA_BYTECODE_NONDET_H
 #define CPROVER_JAVA_BYTECODE_NONDET_H
 
+#include <util/mp_arith.h>
 #include <util/std_code.h>
 
 class allocate_objectst;

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -12,13 +12,15 @@ Date: April 2010
 #ifndef CPROVER_ANALYSES_GOTO_RW_H
 #define CPROVER_ANALYSES_GOTO_RW_H
 
-#include <iosfwd>
-#include <map>
-#include <memory> // unique_ptr
+#include <util/mp_arith.h>
+
+#include <goto-programs/goto_program.h>
 
 #include "guard.h"
 
-#include <goto-programs/goto_program.h>
+#include <iosfwd>
+#include <map>
+#include <memory> // unique_ptr
 
 class goto_functionst;
 class message_handlert;

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.h
@@ -12,9 +12,11 @@
 #ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_FULL_ARRAY_ABSTRACT_OBJECT_H
 #define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_FULL_ARRAY_ABSTRACT_OBJECT_H
 
-#include <iosfwd>
+#include <util/mp_arith.h>
 
 #include <analyses/variable-sensitivity/abstract_aggregate_object.h>
+
+#include <iosfwd>
 
 class ai_baset;
 

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_C_TYPECHECK_BASE_H
 #define CPROVER_ANSI_C_C_TYPECHECK_BASE_H
 
+#include <util/mp_arith.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
 #include <util/symbol.h>

--- a/src/goto-synthesizer/cegis_verifier.h
+++ b/src/goto-synthesizer/cegis_verifier.h
@@ -12,6 +12,8 @@ Author: Qinheping Hu
 #ifndef CPROVER_GOTO_SYNTHESIZER_CEGIS_VERIFIER_H
 #define CPROVER_GOTO_SYNTHESIZER_CEGIS_VERIFIER_H
 
+#include <util/mp_arith.h>
+
 #include <goto-programs/goto_model.h>
 #include <goto-programs/loop_ids.h>
 

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -12,6 +12,7 @@ Author: Jesse Sigal, jesse.sigal@diffblue.com
 #ifndef CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H
 #define CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H
 
+#include <util/mp_arith.h>
 #include <util/std_expr.h> // IWYU pragma: keep
 
 #include <set>

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "fixedbv.h"
 #include "ieee_float.h"
 #include "invariant.h"
+#include "mathematical_types.h"
 #include "std_expr.h"
 
 #include <algorithm>

--- a/src/util/mathematical_types.cpp
+++ b/src/util/mathematical_types.cpp
@@ -63,3 +63,40 @@ constant_exprt real_typet::one_expr() const
 {
   return constant_exprt{ID_1, *this};
 }
+
+bool range_typet::includes(const mp_integer &singleton) const
+{
+  return get_from() <= singleton && singleton <= get_to();
+}
+
+constant_exprt range_typet::one_expr() const
+{
+  PRECONDITION(includes(1));
+  return constant_exprt{ID_1, *this};
+}
+
+constant_exprt range_typet::zero_expr() const
+{
+  PRECONDITION(includes(0));
+  return constant_exprt{ID_0, *this};
+}
+
+void range_typet::set_from(const mp_integer &from)
+{
+  set(ID_from, integer2string(from));
+}
+
+void range_typet::set_to(const mp_integer &to)
+{
+  set(ID_to, integer2string(to));
+}
+
+mp_integer range_typet::get_from() const
+{
+  return string2integer(get_string(ID_from));
+}
+
+mp_integer range_typet::get_to() const
+{
+  return string2integer(get_string(ID_to));
+}

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -144,7 +144,8 @@ inline mathematical_function_typet &to_mathematical_function_type(typet &type)
   return static_cast<mathematical_function_typet &>(type);
 }
 
-/// A type for subranges of integers
+/// A type for closed integer intervals `[from, to]`. Both endpoints are
+/// inclusive. The interval may be empty (if `from > to`).
 class range_typet : public typet
 {
 public:
@@ -154,10 +155,24 @@ public:
     set_to(to);
   }
 
+  /// \return The lower bound of the interval (inclusive).
   mp_integer get_from() const;
+
+  /// \return The upper bound of the interval (inclusive).
   mp_integer get_to() const;
+
+  /// \return True iff the given value lies within the closed interval
+  ///   `[get_from(), get_to()]`.
   bool includes(const mp_integer &) const;
+
+  /// \return A constant expression of this type representing the value 0.
+  /// \remark Precondition: the interval must include 0, i.e.
+  ///   `includes(0)` must hold.
   constant_exprt zero_expr() const;
+
+  /// \return A constant expression of this type representing the value 1.
+  /// \remark Precondition: the interval must include 1, i.e.
+  ///   `includes(1)` must hold.
   constant_exprt one_expr() const;
 
   void set_from(const mp_integer &from);

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -148,10 +148,10 @@ inline mathematical_function_typet &to_mathematical_function_type(typet &type)
 class range_typet : public typet
 {
 public:
-  range_typet(const mp_integer &_from, const mp_integer &_to) : typet(ID_range)
+  range_typet(const mp_integer &from, const mp_integer &to) : typet(ID_range)
   {
-    set_from(_from);
-    set_to(_to);
+    set_from(from);
+    set_to(to);
   }
 
   mp_integer get_from() const;
@@ -160,7 +160,7 @@ public:
   constant_exprt zero_expr() const;
   constant_exprt one_expr() const;
 
-  void set_from(const mp_integer &_from);
+  void set_from(const mp_integer &from);
   void set_to(const mp_integer &to);
 };
 

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "expr_cast.h" // IWYU pragma: keep
 #include "invariant.h"
+#include "mp_arith.h"
 #include "type.h"
 
 class constant_exprt;
@@ -141,6 +142,56 @@ inline mathematical_function_typet &to_mathematical_function_type(typet &type)
 {
   PRECONDITION(can_cast_type<mathematical_function_typet>(type));
   return static_cast<mathematical_function_typet &>(type);
+}
+
+/// A type for subranges of integers
+class range_typet : public typet
+{
+public:
+  range_typet(const mp_integer &_from, const mp_integer &_to) : typet(ID_range)
+  {
+    set_from(_from);
+    set_to(_to);
+  }
+
+  mp_integer get_from() const;
+  mp_integer get_to() const;
+  bool includes(const mp_integer &) const;
+  constant_exprt zero_expr() const;
+  constant_exprt one_expr() const;
+
+  void set_from(const mp_integer &_from);
+  void set_to(const mp_integer &to);
+};
+
+/// Check whether a reference to a typet is a \ref range_typet.
+/// \param type: Source type.
+/// \return True if \p type is a \ref range_typet.
+template <>
+inline bool can_cast_type<range_typet>(const typet &type)
+{
+  return type.id() == ID_range;
+}
+
+/// \brief Cast a typet to a \ref range_typet
+///
+/// This is an unchecked conversion. \a type must be known to be \ref
+/// range_typet. Will fail with a precondition violation if type
+/// doesn't match.
+///
+/// \param type: Source type.
+/// \return Object of type \ref range_typet.
+inline const range_typet &to_range_type(const typet &type)
+{
+  PRECONDITION(can_cast_type<range_typet>(type));
+  return static_cast<const range_typet &>(type);
+}
+
+/// \copydoc to_range_type(const typet &)
+inline range_typet &to_range_type(typet &type)
+{
+  PRECONDITION(can_cast_type<range_typet>(type));
+  return static_cast<range_typet &>(type);
 }
 
 bool is_number(const typet &type);

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -165,43 +165,6 @@ void bitvector_typet::width(const mp_integer &width)
   set_width(numeric_cast_v<std::size_t>(width));
 }
 
-bool range_typet::includes(const mp_integer &singleton) const
-{
-  return get_from() <= singleton && singleton <= get_to();
-}
-
-constant_exprt range_typet::one_expr() const
-{
-  PRECONDITION(includes(1));
-  return constant_exprt{ID_1, *this};
-}
-
-constant_exprt range_typet::zero_expr() const
-{
-  PRECONDITION(includes(0));
-  return constant_exprt{ID_0, *this};
-}
-
-void range_typet::set_from(const mp_integer &from)
-{
-  set(ID_from, integer2string(from));
-}
-
-void range_typet::set_to(const mp_integer &to)
-{
-  set(ID_to, integer2string(to));
-}
-
-mp_integer range_typet::get_from() const
-{
-  return string2integer(get_string(ID_from));
-}
-
-mp_integer range_typet::get_to() const
-{
-  return string2integer(get_string(ID_to));
-}
-
 /// Identify whether a given type is constant itself or contains constant
 /// components.
 /// Examples include:

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "expr_cast.h" // IWYU pragma: keep
 #include "invariant.h"
-#include "mp_arith.h"
 #include "validate.h"
 
 #include <unordered_map>
@@ -939,56 +938,6 @@ inline string_typet &to_string_type(typet &type)
 {
   PRECONDITION(can_cast_type<string_typet>(type));
   return static_cast<string_typet &>(type);
-}
-
-/// A type for subranges of integers
-class range_typet:public typet
-{
-public:
-  range_typet(const mp_integer &_from, const mp_integer &_to) : typet(ID_range)
-  {
-    set_from(_from);
-    set_to(_to);
-  }
-
-  mp_integer get_from() const;
-  mp_integer get_to() const;
-  bool includes(const mp_integer &) const;
-  constant_exprt zero_expr() const;
-  constant_exprt one_expr() const;
-
-  void set_from(const mp_integer &_from);
-  void set_to(const mp_integer &to);
-};
-
-/// Check whether a reference to a typet is a \ref range_typet.
-/// \param type: Source type.
-/// \return True if \p type is a \ref range_typet.
-template <>
-inline bool can_cast_type<range_typet>(const typet &type)
-{
-  return type.id() == ID_range;
-}
-
-/// \brief Cast a typet to a \ref range_typet
-///
-/// This is an unchecked conversion. \a type must be known to be \ref
-/// range_typet. Will fail with a precondition violation if type
-/// doesn't match.
-///
-/// \param type: Source type.
-/// \return Object of type \ref range_typet.
-inline const range_typet &to_range_type(const typet &type)
-{
-  PRECONDITION(can_cast_type<range_typet>(type));
-  return static_cast<const range_typet &>(type);
-}
-
-/// \copydoc to_range_type(const typet &)
-inline range_typet &to_range_type(typet &type)
-{
-  PRECONDITION(can_cast_type<range_typet>(type));
-  return static_cast<range_typet &>(type);
 }
 
 /// The vector type

--- a/unit/util/format_type.cpp
+++ b/unit/util/format_type.cpp
@@ -8,6 +8,7 @@
 
 #include <util/format.h>
 #include <util/format_type.h>
+#include <util/mathematical_types.h>
 #include <util/std_expr.h>
 
 #include <testing-utils/use_catch.h>


### PR DESCRIPTION
The header file `mathematical_types.h` is a better fit for `range_typet`, the type for subranges of integers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
