### PR TITLE
rename `range_typet` to `integer_range_typet`

### DIFF
--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -128,7 +128,7 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
     {
       // add: lhs + from + rhs + from - from = lhs + rhs + from
       // sub: lhs + from - (rhs + from) - from = lhs - rhs - from
-      mp_integer from = to_range_type(type).get_from();
+      mp_integer from = to_integer_range_type(type).from();
       bv = bv_utils.add_sub(bv, op, subtract);
       bv = bv_utils.add_sub(
         bv, bv_utils.build_constant(from, op.size()), subtract);

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -27,7 +27,7 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
   }
   else if(expr_type.id()==ID_range)
   {
-    mp_integer from=to_range_type(expr_type).get_from();
+    mp_integer from = to_integer_range_type(expr_type).from();
     mp_integer value=string2integer(id2string(expr.get_value()));
     mp_integer v=value-from;
 

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -128,7 +128,7 @@ bool boolbvt::type_conversion(
       src_bvtype == bvtypet::IS_C_BOOL) // unsigned to range
     {
       // need to do arithmetic: add -dest_from
-      mp_integer offset = -to_range_type(dest_type).get_from();
+      mp_integer offset = -to_integer_range_type(dest_type).from();
       dest = bv_utils.add(
         bv_utils.zero_extension(src, dest_width),
         bv_utils.build_constant(offset, dest_width));
@@ -138,7 +138,7 @@ bool boolbvt::type_conversion(
     else if(src_bvtype == bvtypet::IS_SIGNED) // signed to range
     {
       // need to do arithmetic: add -dest_from
-      mp_integer offset = -to_range_type(dest_type).get_from();
+      mp_integer offset = -to_integer_range_type(dest_type).from();
       dest = bv_utils.add(
         bv_utils.sign_extension(src, dest_width),
         bv_utils.build_constant(offset, dest_width));
@@ -147,8 +147,8 @@ bool boolbvt::type_conversion(
     }
     else if(src_bvtype == bvtypet::IS_RANGE) // range to range
     {
-      mp_integer src_from = to_range_type(src_type).get_from();
-      mp_integer dest_from = to_range_type(dest_type).get_from();
+      mp_integer src_from = to_integer_range_type(src_type).from();
+      mp_integer dest_from = to_integer_range_type(dest_type).from();
 
       // need to do arithmetic: add src_from-dest_from
       mp_integer offset = src_from - dest_from;
@@ -161,7 +161,7 @@ bool boolbvt::type_conversion(
     else if(src_type.id() == ID_bool) // bool to range
     {
       // need to do arithmetic: add -dest_from
-      mp_integer offset = -to_range_type(dest_type).get_from();
+      mp_integer offset = -to_integer_range_type(dest_type).from();
       dest = bv_utils.add(
         bv_utils.zero_extension(src, dest_width),
         bv_utils.build_constant(offset, dest_width));

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -597,7 +597,7 @@ constant_exprt smt2_convt::parse_literal(
   }
   else if(type.id() == ID_range)
   {
-    return from_integer(value + to_range_type(type).get_from(), type);
+    return from_integer(value + to_integer_range_type(type).from(), type);
   }
   else
     UNREACHABLE_BECAUSE(
@@ -1440,7 +1440,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     }
     else if(type.id() == ID_range)
     {
-      auto &range_type = to_range_type(type);
+      auto &range_type = to_integer_range_type(type);
       PRECONDITION(type == unary_minus_expr.op().type());
       // turn -x into 0-x
       auto minus_expr =
@@ -3246,16 +3246,12 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
   }
   else if(dest_type.id()==ID_range)
   {
-    auto &dest_range_type = to_range_type(dest_type);
-    const auto dest_size =
-      dest_range_type.get_to() - dest_range_type.get_from() + 1;
-    const auto dest_width = address_bits(dest_size);
+    auto &dest_range_type = to_integer_range_type(dest_type);
+    const auto dest_width = address_bits(dest_range_type.size());
     if(src_type.id() == ID_range)
     {
-      auto &src_range_type = to_range_type(src_type);
-      const auto src_size =
-        src_range_type.get_to() - src_range_type.get_from() + 1;
-      const auto src_width = address_bits(src_size);
+      auto &src_range_type = to_integer_range_type(src_type);
+      const auto src_width = address_bits(src_range_type.size());
       if(src_width < dest_width)
       {
         out << "((_ zero_extend " << dest_width - src_width << ") ";
@@ -3821,12 +3817,10 @@ void smt2_convt::convert_constant(const constant_exprt &expr)
   }
   else if(expr_type.id() == ID_range)
   {
-    auto &range_type = to_range_type(expr_type);
-    const auto size = range_type.get_to() - range_type.get_from() + 1;
-    const auto width = address_bits(size);
+    auto &range_type = to_integer_range_type(expr_type);
+    const auto width = address_bits(range_type.size());
     const auto value_int = numeric_cast_v<mp_integer>(expr);
-    out << "(_ bv" << (value_int - range_type.get_from()) << " " << width
-        << ")";
+    out << "(_ bv" << (value_int - range_type.from()) << " " << width << ")";
   }
   else
     UNEXPECTEDCASE("unknown constant: "+expr_type.id_string());
@@ -4051,22 +4045,20 @@ void smt2_convt::convert_plus(const plus_exprt &expr)
   }
   else if(expr.type().id() == ID_range)
   {
-    auto &range_type = to_range_type(expr.type());
+    auto &range_type = to_integer_range_type(expr.type());
 
     // These could be chained, i.e., need not be binary,
     // but at least MathSat doesn't like that.
     if(expr.operands().size() == 2)
     {
       // add: lhs + from + rhs + from - from = lhs + rhs + from
-      mp_integer from = range_type.get_from();
-      const auto size = range_type.get_to() - range_type.get_from() + 1;
-      const auto width = address_bits(size);
+      const auto width = address_bits(range_type.size());
 
       out << "(bvadd ";
       convert_expr(expr.op0());
       out << " (bvadd ";
       convert_expr(expr.op1());
-      out << " (_ bv" << range_type.get_from() << ' ' << width
+      out << " (_ bv" << range_type.from() << ' ' << width
           << ")))"; // bv, bvadd, bvadd
     }
     else
@@ -4321,19 +4313,16 @@ void smt2_convt::convert_minus(const minus_exprt &expr)
   }
   else if(expr.type().id() == ID_range)
   {
-    auto &range_type = to_range_type(expr.type());
+    auto &range_type = to_integer_range_type(expr.type());
 
     // sub: lhs + from - (rhs + from) - from = lhs - rhs - from
-    mp_integer from = range_type.get_from();
-    const auto size = range_type.get_to() - range_type.get_from() + 1;
-    const auto width = address_bits(size);
+    const auto width = address_bits(range_type.size());
 
     out << "(bvsub (bvsub ";
     convert_expr(expr.op0());
     out << ' ';
     convert_expr(expr.op1());
-    out << ") (_ bv" << range_type.get_from() << ' ' << width
-        << "))"; // bv, bvsub
+    out << ") (_ bv" << range_type.from() << ' ' << width << "))"; // bv, bvsub
   }
   else
     UNEXPECTEDCASE("unsupported type for -: "+expr.type().id_string());
@@ -6082,11 +6071,10 @@ void smt2_convt::convert_type(const typet &type)
   }
   else if(type.id() == ID_range)
   {
-    auto &range_type = to_range_type(type);
-    mp_integer size = range_type.get_to() - range_type.get_from() + 1;
-    if(size <= 0)
-      UNEXPECTEDCASE("unsuppored range type");
-    out << "(_ BitVec " << address_bits(size) << ")";
+    auto &range_type = to_integer_range_type(type);
+    if(range_type.empty())
+      UNEXPECTEDCASE("unsupported range type");
+    out << "(_ BitVec " << address_bits(range_type.size()) << ")";
   }
   else
   {

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -114,9 +114,9 @@ constant_exprt from_integer(
   }
   else if(type_id == ID_range)
   {
-    auto &range_type = to_range_type(type);
-    PRECONDITION(int_value >= range_type.get_from());
-    PRECONDITION(int_value <= range_type.get_to());
+    auto &range_type = to_integer_range_type(type);
+    PRECONDITION(int_value >= range_type.from());
+    PRECONDITION(int_value <= range_type.to());
     return constant_exprt{integer2string(int_value), type};
   }
   else if(type_id==ID_unsignedbv)

--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -100,9 +100,9 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
     return os << "\xe2\x84\x95"; // u+2115, 'N'
   else if(id == ID_range)
   {
-    auto &range_type = to_range_type(type);
-    return os << "{ " << range_type.get_from() << ", ..., "
-              << range_type.get_to() << " }";
+    auto &range_type = to_integer_range_type(type);
+    return os << "{ " << range_type.from() << ", ..., " << range_type.to()
+              << " }";
   }
   else if(id == ID_rational)
     return os << "\xe2\x84\x9a"; // u+211A, 'Q'

--- a/src/util/mathematical_types.cpp
+++ b/src/util/mathematical_types.cpp
@@ -64,39 +64,50 @@ constant_exprt real_typet::one_expr() const
   return constant_exprt{ID_1, *this};
 }
 
-bool range_typet::includes(const mp_integer &singleton) const
+bool integer_range_typet::includes(const mp_integer &singleton) const
 {
-  return get_from() <= singleton && singleton <= get_to();
+  return from() <= singleton && singleton <= to();
 }
 
-constant_exprt range_typet::one_expr() const
+constant_exprt integer_range_typet::one_expr() const
 {
   PRECONDITION(includes(1));
   return constant_exprt{ID_1, *this};
 }
 
-constant_exprt range_typet::zero_expr() const
+constant_exprt integer_range_typet::zero_expr() const
 {
   PRECONDITION(includes(0));
   return constant_exprt{ID_0, *this};
 }
 
-void range_typet::set_from(const mp_integer &from)
+void integer_range_typet::from(const mp_integer &from)
 {
   set(ID_from, integer2string(from));
 }
 
-void range_typet::set_to(const mp_integer &to)
+void integer_range_typet::to(const mp_integer &to)
 {
   set(ID_to, integer2string(to));
 }
 
-mp_integer range_typet::get_from() const
+mp_integer integer_range_typet::from() const
 {
   return string2integer(get_string(ID_from));
 }
 
-mp_integer range_typet::get_to() const
+mp_integer integer_range_typet::to() const
 {
   return string2integer(get_string(ID_to));
+}
+
+mp_integer integer_range_typet::size() const
+{
+  auto difference = to() - from();
+  return difference >= 0 ? difference + 1 : 0;
+}
+
+bool integer_range_typet::empty() const
+{
+  return to() < from();
 }

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -146,23 +146,24 @@ inline mathematical_function_typet &to_mathematical_function_type(typet &type)
 
 /// A type for closed integer intervals `[from, to]`. Both endpoints are
 /// inclusive. The interval may be empty (if `from > to`).
-class range_typet : public typet
+class integer_range_typet : public typet
 {
 public:
-  range_typet(const mp_integer &from, const mp_integer &to) : typet(ID_range)
+  integer_range_typet(const mp_integer &_from, const mp_integer &_to)
+    : typet(ID_range)
   {
-    set_from(from);
-    set_to(to);
+    from(_from);
+    to(_to);
   }
 
   /// \return The lower bound of the interval (inclusive).
-  mp_integer get_from() const;
+  mp_integer from() const;
 
   /// \return The upper bound of the interval (inclusive).
-  mp_integer get_to() const;
+  mp_integer to() const;
 
   /// \return True iff the given value lies within the closed interval
-  ///   `[get_from(), get_to()]`.
+  ///   `[from(), to()]`.
   bool includes(const mp_integer &) const;
 
   /// \return A constant expression of this type representing the value 0.
@@ -175,38 +176,46 @@ public:
   ///   `includes(1)` must hold.
   constant_exprt one_expr() const;
 
-  void set_from(const mp_integer &from);
-  void set_to(const mp_integer &to);
+  /// \return The number of integers in the closed interval `[from(), to()]`,
+  ///   or `0` if the range is empty (i.e. `from() > to()`).
+  mp_integer size() const;
+
+  /// \return True iff the range contains no elements, i.e. `from() > to()`
+  ///   (equivalently, `size() == 0`).
+  bool empty() const;
+
+  void from(const mp_integer &);
+  void to(const mp_integer &);
 };
 
-/// Check whether a reference to a typet is a \ref range_typet.
+/// Check whether a reference to a typet is a \ref integer_range_typet.
 /// \param type: Source type.
-/// \return True if \p type is a \ref range_typet.
+/// \return True if \p type is a \ref integer_range_typet.
 template <>
-inline bool can_cast_type<range_typet>(const typet &type)
+inline bool can_cast_type<integer_range_typet>(const typet &type)
 {
   return type.id() == ID_range;
 }
 
-/// \brief Cast a typet to a \ref range_typet
+/// \brief Cast a typet to a \ref integer_range_typet
 ///
 /// This is an unchecked conversion. \a type must be known to be \ref
-/// range_typet. Will fail with a precondition violation if type
+/// integer_range_typet. Will fail with a precondition violation if type
 /// doesn't match.
 ///
 /// \param type: Source type.
-/// \return Object of type \ref range_typet.
-inline const range_typet &to_range_type(const typet &type)
+/// \return Object of type \ref integer_range_typet.
+inline const integer_range_typet &to_integer_range_type(const typet &type)
 {
-  PRECONDITION(can_cast_type<range_typet>(type));
-  return static_cast<const range_typet &>(type);
+  PRECONDITION(can_cast_type<integer_range_typet>(type));
+  return static_cast<const integer_range_typet &>(type);
 }
 
-/// \copydoc to_range_type(const typet &)
-inline range_typet &to_range_type(typet &type)
+/// \copydoc to_integer_range_type(const typet &)
+inline integer_range_typet &to_integer_range_type(typet &type)
 {
-  PRECONDITION(can_cast_type<range_typet>(type));
-  return static_cast<range_typet &>(type);
+  PRECONDITION(can_cast_type<integer_range_typet>(type));
+  return static_cast<integer_range_typet &>(type);
 }
 
 bool is_number(const typet &type);

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -181,6 +181,7 @@ SRC += analyses/ai/ai.cpp \
        util/lazy.cpp \
        util/lower_byte_operators.cpp \
        util/max_malloc_size.cpp \
+       util/mathematical_types.cpp \
        util/memory_info.cpp \
        util/message.cpp \
        util/optional_utils.cpp \

--- a/unit/util/format_type.cpp
+++ b/unit/util/format_type.cpp
@@ -15,6 +15,6 @@
 
 TEST_CASE("Format a range type", "[core][util][format_type]")
 {
-  auto type = range_typet(1, 10);
+  auto type = integer_range_typet{1, 10};
   REQUIRE(format_to_string(type) == "{ 1, ..., 10 }");
 }

--- a/unit/util/mathematical_types.cpp
+++ b/unit/util/mathematical_types.cpp
@@ -1,0 +1,122 @@
+/*******************************************************************\
+
+Module: Unit test for util/mathematical_types.h
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <util/mathematical_types.h>
+#include <util/std_expr.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("for an integer range", "[unit][util][mathematical_types]")
+{
+  SECTION("empty() returns true iff the range is empty")
+  {
+    // non-empty: from <= to
+    REQUIRE(!integer_range_typet{1, 1}.empty());
+    REQUIRE(!integer_range_typet{-5, 5}.empty());
+    REQUIRE(!integer_range_typet{-10, -1}.empty());
+
+    // empty: from > to
+    REQUIRE(integer_range_typet{1, 0}.empty());
+    REQUIRE(integer_range_typet{0, -1}.empty());
+  }
+
+  SECTION("size() returns the number of elements")
+  {
+    // singletons
+    REQUIRE(integer_range_typet{1, 1}.size() == 1);
+    REQUIRE(integer_range_typet{0, 0}.size() == 1);
+    REQUIRE(integer_range_typet{-3, -3}.size() == 1);
+
+    // standard ranges
+    REQUIRE(integer_range_typet{0, 9}.size() == 10);
+    REQUIRE(integer_range_typet{-5, 5}.size() == 11);
+    REQUIRE(integer_range_typet{-10, -1}.size() == 10);
+
+    // empty ranges clamp to 0
+    REQUIRE(integer_range_typet{1, 0}.size() == 0);
+    REQUIRE(integer_range_typet{5, -5}.size() == 0);
+
+    // large values that exceed std::size_t
+    const mp_integer large{"100000000000000000000"};
+    REQUIRE(integer_range_typet{0, large}.size() == large + 1);
+  }
+
+  SECTION("from() / to() round-trip through the setters and getters")
+  {
+    integer_range_typet range{0, 0};
+    range.from(-42);
+    range.to(1000);
+    REQUIRE(range.from() == -42);
+    REQUIRE(range.to() == 1000);
+
+    // large values are preserved
+    const mp_integer large{"100000000000000000000"};
+    range.from(-large);
+    range.to(large);
+    REQUIRE(range.from() == -large);
+    REQUIRE(range.to() == large);
+  }
+
+  SECTION("includes() covers the closed interval and rejects outside values")
+  {
+    const integer_range_typet range{-3, 3};
+
+    // interior
+    REQUIRE(range.includes(0));
+    REQUIRE(range.includes(1));
+    REQUIRE(range.includes(-1));
+
+    // boundaries are inclusive
+    REQUIRE(range.includes(-3));
+    REQUIRE(range.includes(3));
+
+    // just outside
+    REQUIRE(!range.includes(-4));
+    REQUIRE(!range.includes(4));
+
+    // empty range: nothing is included
+    const integer_range_typet empty_range{1, 0};
+    REQUIRE(!empty_range.includes(0));
+    REQUIRE(!empty_range.includes(1));
+    REQUIRE(!empty_range.includes(-1));
+  }
+
+  SECTION("zero_expr() / one_expr() succeed when 0 / 1 are in range")
+  {
+    const integer_range_typet range{-5, 5};
+    const constant_exprt zero = range.zero_expr();
+    REQUIRE(zero.type() == range);
+    REQUIRE(zero.get_value() == ID_0);
+
+    const constant_exprt one = range.one_expr();
+    REQUIRE(one.type() == range);
+    REQUIRE(one.get_value() == ID_1);
+  }
+
+  SECTION("zero_expr() / one_expr() fail PRECONDITIONs when out of range")
+  {
+    const cbmc_invariants_should_throwt invariants_throw_in_this_scope;
+
+    // zero not included
+    const integer_range_typet positive_range{1, 10};
+    REQUIRE_THROWS_AS(positive_range.zero_expr(), invariant_failedt);
+    // one is still included
+    REQUIRE_NOTHROW(positive_range.one_expr());
+
+    // one not included
+    const integer_range_typet non_positive_range{-10, 0};
+    REQUIRE_THROWS_AS(non_positive_range.one_expr(), invariant_failedt);
+    // zero is still included
+    REQUIRE_NOTHROW(non_positive_range.zero_expr());
+
+    // empty range includes neither
+    const integer_range_typet empty_range{1, 0};
+    REQUIRE_THROWS_AS(empty_range.zero_expr(), invariant_failedt);
+    REQUIRE_THROWS_AS(empty_range.one_expr(), invariant_failedt);
+  }
+}


### PR DESCRIPTION
1.  This renames the type class `range_typet` to `integer_range_typet` to clarify that it denotes a subrange of the integers.
    
2.  This renames the existing getters/setters to use C++ naming, as opposed to Java naming.
    
3.  This adds the `size()` method, the number of integers in the range.
    
4.  This adds the `empty()` method, which returns true when the range has no elements.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
