### PR TITLE
use `std::string_view` in dstring

### DIFF
--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -60,9 +60,21 @@ public:
   constexpr operator int() const { return no; }
   #endif
 
+  // The const char* and const std::string& constructors below are
+  // semantically equivalent to the std::string_view one (both implicitly
+  // convert to std::string_view); they are retained only so that overload
+  // resolution prefers them and avoids an extra conversion, not for any
+  // distinct behaviour.
+
   // this one is not safe for static objects
   // NOLINTNEXTLINE(runtime/explicit)
   dstringt(const char *s):no(get_string_container()[s])
+  {
+  }
+
+  // this one is not safe for static objects
+  // NOLINTNEXTLINE(runtime/explicit)
+  dstringt(std::string_view s) : no(get_string_container()[s])
   {
   }
 
@@ -102,7 +114,7 @@ public:
   }
 
   /// equivalent of as_string().starts_with(s)
-  bool starts_with(const std::string &prefix) const
+  bool starts_with(std::string_view prefix) const
   {
     return as_string().compare(0, prefix.size(), prefix) == 0;
   }

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -31,7 +31,7 @@ string_containert::~string_containert()
 {
 }
 
-unsigned string_containert::get(const char *s)
+unsigned string_containert::get(std::string_view s)
 {
   string_ptrt string_ptr(s);
 
@@ -44,29 +44,6 @@ unsigned string_containert::get(const char *s)
 
   // these are stable
   string_list.push_back(std::string(s));
-  string_ptrt result(string_list.back());
-
-  hash_table[result]=r;
-
-  // these are not
-  string_vector.push_back(&string_list.back());
-
-  return r;
-}
-
-unsigned string_containert::get(const std::string &s)
-{
-  string_ptrt string_ptr(s);
-
-  hash_tablet::iterator it=hash_table.find(string_ptr);
-
-  if(it!=hash_table.end())
-    return it->second;
-
-  size_t r=hash_table.size();
-
-  // these are stable
-  string_list.push_back(s);
   string_ptrt result(string_list.back());
 
   hash_table[result]=r;

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -19,8 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "memory_units.h"
 #include "string_hash.h"
 
-class string_ptr_hasht;
-
 class string_ptrt
 {
 public:
@@ -37,22 +35,25 @@ public:
   // this compares the contents of the string, not the address
   bool operator==(const string_ptrt &other) const;
 
-protected:
+  size_t hash() const
+  {
+    return hash_string(s, len);
+  }
+
+private:
   // s/len are a (pointer, length) pair into externally-owned storage; the
   // referenced string need not be zero terminated (there is no c_str()).
   const char *s;
   size_t len;
-
-  friend string_ptr_hasht;
 };
 
 // NOLINTNEXTLINE(readability/identifiers)
 class string_ptr_hasht
 {
 public:
-  size_t operator()(const string_ptrt s) const
+  size_t operator()(const string_ptrt &s) const
   {
-    return hash_string(s.s, s.len);
+    return s.hash();
   }
 };
 

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -19,30 +19,41 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "memory_units.h"
 #include "string_hash.h"
 
-struct string_ptrt
+class string_ptr_hasht;
+
+class string_ptrt
 {
+public:
+  explicit string_ptrt(const char *_s);
+
+  explicit string_ptrt(std::string_view _s) : s(_s.data()), len(_s.size())
+  {
+  }
+
+  explicit string_ptrt(const std::string &_s) : s(_s.data()), len(_s.size())
+  {
+  }
+
+  // this compares the contents of the string, not the address
+  bool operator==(const string_ptrt &other) const;
+
+protected:
+  // s/len are a (pointer, length) pair into externally-owned storage; the
+  // referenced string need not be zero terminated (there is no c_str()).
   const char *s;
   size_t len;
 
-  const char *c_str() const
-  {
-    return s;
-  }
-
-  explicit string_ptrt(const char *_s);
-
-  explicit string_ptrt(const std::string &_s):s(_s.c_str()), len(_s.size())
-  {
-  }
-
-  bool operator==(const string_ptrt &other) const;
+  friend string_ptr_hasht;
 };
 
 // NOLINTNEXTLINE(readability/identifiers)
-class string_ptr_hash
+class string_ptr_hasht
 {
 public:
-  size_t operator()(const string_ptrt s) const { return hash_string(s.s); }
+  size_t operator()(const string_ptrt s) const
+  {
+    return hash_string(s.s, s.len);
+  }
 };
 
 /// Has estimated statistics about string container
@@ -63,12 +74,7 @@ struct string_container_statisticst
 class string_containert
 {
 public:
-  unsigned operator[](const char *s)
-  {
-    return get(s);
-  }
-
-  unsigned operator[](const std::string &s)
+  unsigned operator[](std::string_view s)
   {
     return get(s);
   }
@@ -93,12 +99,11 @@ public:
 
 protected:
   // the 'unsigned' ought to be size_t
-  typedef std::unordered_map<string_ptrt, unsigned, string_ptr_hash>
+  typedef std::unordered_map<string_ptrt, unsigned, string_ptr_hasht>
     hash_tablet;
   hash_tablet hash_table;
 
-  unsigned get(const char *s);
-  unsigned get(const std::string &s);
+  unsigned get(std::string_view);
 
   typedef std::list<std::string> string_listt;
   string_listt string_list;

--- a/src/util/string_hash.cpp
+++ b/src/util/string_hash.cpp
@@ -11,23 +11,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_hash.h"
 
-size_t hash_string(const std::string &s)
+std::size_t hash_string(std::string_view s)
 {
-  size_t h=0;
-  size_t size=s.size();
-
-  for(unsigned i=0; i<size; i++)
-    h=(h<<5)-h+s[i];
-
-  return h;
+  return hash_string(s.data(), s.size());
 }
 
-size_t hash_string(const char *s)
+std::size_t hash_string(const char *s, std::size_t len)
 {
-  size_t h=0;
+  std::size_t h = 0;
 
-  for(; *s!=0; s++)
-    h=(h<<5)-h+*s;
+  for(; len != 0; --len, ++s)
+    h = (h << 5) - h + *s;
 
   return h;
 }

--- a/src/util/string_hash.h
+++ b/src/util/string_hash.h
@@ -13,14 +13,18 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_STRING_HASH_H
 
 #include <string>
+#include <string_view>
 
-size_t hash_string(const std::string &s);
-size_t hash_string(const char *s);
+std::size_t hash_string(std::string_view);
+std::size_t hash_string(const char *s, std::size_t len);
 
 // NOLINTNEXTLINE(readability/identifiers)
 struct string_hash
 {
-  size_t operator()(const std::string &s) const { return hash_string(s); }
+  std::size_t operator()(const std::string &s) const
+  {
+    return hash_string(s);
+  }
 };
 
 #endif // CPROVER_UTIL_STRING_HASH_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -149,6 +149,7 @@ SRC += analyses/ai/ai.cpp \
        util/case_expr.cpp \
        util/cmdline.cpp \
        util/dense_integer_map.cpp \
+       util/dstring.cpp \
        util/edit_distance.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr_initializer.cpp \

--- a/unit/util/dstring.cpp
+++ b/unit/util/dstring.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************\
+
+Module: Unit tests for dstringt
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for constructing dstringt via std::string_view, in particular
+/// the embedded-NUL and non-NUL-terminated content that the (ptr, len)
+/// string_container representation can express but the previous const char*
+/// path could not.
+
+#include <util/dstring.h>
+#include <util/string_hash.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <string>
+#include <string_view>
+
+TEST_CASE("dstringt string_view construction", "[core][util][dstring]")
+{
+  SECTION("const char*, std::string and std::string_view agree on ids")
+  {
+    const dstringt from_char_ptr{"hello"};
+    const dstringt from_string{std::string{"hello"}};
+    const dstringt from_view{std::string_view{"hello"}};
+
+    REQUIRE(from_char_ptr == from_string);
+    REQUIRE(from_char_ptr == from_view);
+    REQUIRE(from_char_ptr.get_no() == from_view.get_no());
+
+    // the hashing formula must agree across the entry points too
+    REQUIRE(hash_string(std::string_view{"hello"}) == hash_string("hello", 5));
+  }
+
+  SECTION("content with an embedded NUL is distinct and round-trips")
+  {
+    const std::string embedded{"a\0b", 3};
+    const dstringt with_nul{std::string_view{embedded}};
+    const dstringt just_a{"a"};
+
+    REQUIRE(with_nul != just_a);
+    REQUIRE(as_string(with_nul).size() == 3);
+    REQUIRE(as_string(with_nul) == embedded);
+  }
+
+  SECTION("a non-NUL-terminated sub-view stores exactly size() bytes")
+  {
+    // buffer[3] is 'd', i.e. the sub-view is not NUL-terminated at its end
+    const char buffer[] = "abcdef";
+    const std::string_view sub{buffer, 3};
+    const dstringt d{sub};
+
+    REQUIRE(as_string(d).size() == 3);
+    REQUIRE(as_string(d) == "abc");
+  }
+}


### PR DESCRIPTION
This introduces means to construct `dstringt` from `std::string_view`, so that call sites that already hold a `std::string_view` -- including a sub-range of a larger buffer, or content with embedded NULs -- can look up or construct a `dstringt` without first copying the contents into a NUL-terminated `std::string`.

This is an enabling change only: no call site is migrated to pass a `std::string_view` yet, so no performance improvement is realised here. The id/hash computation is unchanged (the `(ptr, len)` and `const char*` paths produce identical ids and hashes for NUL-terminated content), so no regression on the `dstring` construction hot path is expected either.

The change is designed not to break any usage of the functions; C++17 guarantees that there's an implicit conversion from `std::string` to `std::string_view`.  An exception are attempts to construct single-character strings from char.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message). `unit/util/dstring.cpp` covers the `const char*`/`std::string`/`std::string_view` id agreement, embedded-NUL content, and non-NUL-terminated sub-views.
- n/a My commit message includes data points confirming performance improvements (if claimed). This is an enabling change; no performance improvement is claimed.
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
