### PR TITLE
use `std::string_view` for `safe_string2int`

### DIFF
--- a/src/goto-analyzer/taint_parser.cpp
+++ b/src/goto-analyzer/taint_parser.cpp
@@ -95,8 +95,8 @@ bool taint_parser(
     else if(std::string(where, 0, 9)=="parameter")
     {
       rule.where=taint_parse_treet::rulet::PARAMETER;
-      rule.parameter_number=
-        safe_string2unsigned(std::string(where, 9, std::string::npos));
+      rule.parameter_number =
+        safe_string2unsigned(std::string_view{where}.substr(9));
     }
     else
     {

--- a/src/goto-instrument/skip_loops.cpp
+++ b/src/goto-instrument/skip_loops.cpp
@@ -78,7 +78,7 @@ static bool parse_loop_ids(
       return true;
 
     std::string fn=val.substr(0, delim);
-    unsigned nr=safe_string2unsigned(val.substr(delim+1));
+    unsigned nr = safe_string2unsigned(std::string_view{val}.substr(delim + 1));
 
     loop_map[fn].insert(nr);
 

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -37,7 +37,8 @@ gdb_value_extractort::memory_scopet::memory_scopet(
   const mp_integer &byte_size,
   const irep_idt &name)
   : // the address is given in hex, starting with 0x....
-    begin_int(safe_string2size_t(begin.address_string.substr(2), 16)),
+    begin_int(
+      safe_string2size_t(std::string_view{begin.address_string}.substr(2), 16)),
     byte_size(byte_size),
     name(name)
 {
@@ -49,7 +50,8 @@ size_t gdb_value_extractort::memory_scopet::address2size_t(
 {
   // the address is given in hex, starting with 0x....
   PRECONDITION(point.address_string.substr(0, 2) == "0x");
-  return safe_string2size_t(point.address_string.substr(2), 16);
+  return safe_string2size_t(
+    std::string_view{point.address_string}.substr(2), 16);
 }
 
 mp_integer gdb_value_extractort::memory_scopet::distance(

--- a/src/util/string2int.cpp
+++ b/src/util/string2int.cpp
@@ -13,14 +13,14 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 
 #include "invariant.h"
 
-unsigned safe_string2unsigned(const std::string &str, int base)
+unsigned safe_string2unsigned(std::string_view str, int base)
 {
   auto converted = string2optional<unsigned>(str, base);
   CHECK_RETURN(converted.has_value());
   return *converted;
 }
 
-std::size_t safe_string2size_t(const std::string &str, int base)
+std::size_t safe_string2size_t(std::string_view str, int base)
 {
   auto converted = string2optional<std::size_t>(str, base);
   CHECK_RETURN(converted.has_value());
@@ -56,19 +56,18 @@ unsigned long long int unsafe_string2unsignedlonglong(
   return *string2optional<unsigned long long>(str, base);
 }
 
-std::optional<int> string2optional_int(const std::string &str, int base)
+std::optional<int> string2optional_int(std::string_view str, int base)
 {
   return string2optional<int>(str, base);
 }
 
-std::optional<unsigned>
-string2optional_unsigned(const std::string &str, int base)
+std::optional<unsigned> string2optional_unsigned(std::string_view str, int base)
 {
   return string2optional<unsigned>(str, base);
 }
 
 std::optional<std::size_t>
-string2optional_size_t(const std::string &str, int base)
+string2optional_size_t(std::string_view str, int base)
 {
   return string2optional<std::size_t>(str, base);
 }

--- a/src/util/string2int.h
+++ b/src/util/string2int.h
@@ -15,44 +15,45 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 #include <charconv>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 // These check that the string is indeed a valid number,
 // and fail an assertion otherwise.
 // We use those for data types that C++11's std::stoi etc. do not
 // cover.
-unsigned safe_string2unsigned(const std::string &str, int base=10);
-std::size_t safe_string2size_t(const std::string &str, int base=10);
+unsigned safe_string2unsigned(std::string_view, int base = 10);
+std::size_t safe_string2size_t(std::string_view, int base = 10);
 
 // The below mimic C's atoi/atol: any errors are silently ignored.
 // They are meant to replace atoi/atol.
-int unsafe_string2int(const std::string &str, int base=10);
-unsigned unsafe_string2unsigned(const std::string &str, int base=10);
-std::size_t unsafe_string2size_t(const std::string &str, int base=10);
+int unsafe_string2int(const std::string &, int base = 10);
+unsigned unsafe_string2unsigned(const std::string &, int base = 10);
+std::size_t unsafe_string2size_t(const std::string &, int base = 10);
 
 // Same for atoll
-long long int unsafe_string2signedlonglong(const std::string &str, int base=10);
-long long unsigned int unsafe_string2unsignedlonglong(
-  const std::string &str, int base=10);
+long long int unsafe_string2signedlonglong(const std::string &, int base = 10);
+long long unsigned int
+unsafe_string2unsignedlonglong(const std::string &, int base = 10);
 
 // if we had a `resultt` á la Boost.Outcome (https://ned14.github.io/outcome/)
 // we could also return the reason why the conversion failed
 
 /// Convert string to integer as per stoi, but return nullopt when
 /// stoi would throw
-std::optional<int> string2optional_int(const std::string &, int base = 10);
+std::optional<int> string2optional_int(std::string_view, int base = 10);
 
 /// Convert string to unsigned similar to the stoul or stoull functions,
 /// return nullopt when the conversion fails.
 /// Note: Unlike stoul or stoull negative inputs are disallowed
 std::optional<unsigned>
-string2optional_unsigned(const std::string &, int base = 10);
+string2optional_unsigned(std::string_view, int base = 10);
 
 /// Convert string to size_t similar to the stoul or stoull functions,
 /// return nullopt when the conversion fails.
 /// Note: Unlike stoul or stoull negative inputs are disallowed
 std::optional<std::size_t>
-string2optional_size_t(const std::string &, int base = 10);
+string2optional_size_t(std::string_view, int base = 10);
 
 /// Convert a string to an integer, given the base of the representation,
 /// works with signed and unsigned integer types,
@@ -62,7 +63,7 @@ string2optional_size_t(const std::string &, int base = 10);
 /// rejects any trailing non-numerical suffix.
 /// A prefix such as 0, 0x, 0X to change base is _not_ supported.
 template <typename T>
-std::optional<T> string2optional(const std::string &str, int base = 10)
+std::optional<T> string2optional(std::string_view str, int base = 10)
 {
   PRECONDITION(base == 2 || base == 8 || base == 10 || base == 16);
 

--- a/unit/util/string2int.cpp
+++ b/unit/util/string2int.cpp
@@ -164,3 +164,31 @@ TEST_CASE("string2optional with different bases", "[core][util][string2int]")
   REQUIRE(string2optional<int>("101", 2) == 5);
   REQUIRE(string2optional<unsigned long long>("DEADBEEF", 16) == 0xDEADBEEFULL);
 }
+
+TEST_CASE(
+  "string2optional accepts a non-null-terminated string_view",
+  "[core][util][string2int]")
+{
+  // The string_view is not null-terminated — this is the case where
+  // string_view is meaningfully different from std::string.
+  REQUIRE(string2optional<int>(std::string_view{"123abc", 3}) == 123);
+  REQUIRE(string2optional<int>(std::string_view{"abc", 1}, 16) == 0xa);
+  REQUIRE(string2optional<unsigned>(std::string_view{"42xyz", 2}) == 42u);
+  REQUIRE(!string2optional<int>(std::string_view{"123abc", 4}).has_value());
+}
+
+TEST_CASE(
+  "safe_string2unsigned and safe_string2size_t",
+  "[core][util][string2int]")
+{
+  REQUIRE(safe_string2unsigned("0") == 0u);
+  REQUIRE(safe_string2unsigned("123") == 123u);
+  REQUIRE(safe_string2unsigned("FF", 16) == 255u);
+  REQUIRE(safe_string2size_t("0") == 0u);
+  REQUIRE(safe_string2size_t("999") == 999u);
+  REQUIRE(safe_string2size_t("10", 16) == 16u);
+
+  // Verify these also work with a non-null-terminated string_view
+  REQUIRE(safe_string2unsigned(std::string_view{"42xyz", 2}) == 42u);
+  REQUIRE(safe_string2size_t(std::string_view{"99end", 2}) == 99u);
+}


### PR DESCRIPTION
The variants of `safe_string2int` now accept an `std::string_view`, instead of an std::string, in the hope of avoiding copies.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
