### PR TITLE
dump-c: sign-extend signed bit-field temporaries

### DIFF
--- a/regression/goto-instrument/dump-bitfield-chained-assign/main.c
+++ b/regression/goto-instrument/dump-bitfield-chained-assign/main.c
@@ -1,0 +1,71 @@
+#include <assert.h>
+
+struct S2
+{
+  signed r : 2;
+};
+struct S1
+{
+  signed r : 1;
+};
+struct S7
+{
+  signed r : 7;
+};
+struct U3
+{
+  unsigned r : 3;
+};
+struct S32
+{
+  signed r : 32;
+};
+
+static int outer;
+static struct S2 s2;
+static struct S1 s1;
+static struct S7 s7;
+static struct U3 u3;
+static struct S32 s32;
+
+int main(void)
+{
+  // Per C11 6.5.16.1p3, the value of an assignment expression is the value of
+  // the left operand after the assignment. For a signed bit-field that is the
+  // stored value masked to the field width and then sign-extended. Each case
+  // below is a chained assignment `outer = bf = expr`, which goto-conversion
+  // lowers through a bit-field temporary -- the construct this fix is about.
+
+  // 2-bit signed, positive RHS: 2 -> bits 10 -> -2
+  outer = s2.r = 2;
+  assert(outer == -2);
+  assert((int)s2.r == -2);
+
+  // 2-bit signed, negative RHS: -3 -> bits 01 -> +1
+  outer = s2.r = -3;
+  assert(outer == 1);
+  assert((int)s2.r == 1);
+
+  // 1-bit signed boundary: 1 -> -1 (sign_bit == mask == 1)
+  outer = s1.r = 1;
+  assert(outer == -1);
+  assert((int)s1.r == -1);
+
+  // 7-bit signed with high bit set: 64 -> -64 (formula scales beyond 2 bits)
+  outer = s7.r = 64;
+  assert(outer == -64);
+  assert((int)s7.r == -64);
+
+  // unsigned 3-bit: unchanged AND-mask branch, 13 & 7 -> 5
+  outer = u3.r = 13;
+  assert(outer == 5);
+  assert((int)u3.r == 5);
+
+  // full-width (32-bit) signed: bf_width == underlying width, so this is
+  // routed through the AND-mask branch with no narrowing: -3 stays -3
+  outer = s32.r = -3;
+  assert(outer == -3);
+  assert((int)s32.r == -3);
+
+  return 0;
+}

--- a/regression/goto-instrument/dump-bitfield-chained-assign/test.desc
+++ b/regression/goto-instrument/dump-bitfield-chained-assign/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--dump-c
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test must verify successfully also for the output generated using dump-c.
+A chained assignment `outer = bf = expr;` through a signed bit-field previously
+produced dump-c output that lost sign-extension semantics: the temporary
+holding the assignment value was masked but not sign-extended, so `outer`
+ended up with the unsigned-truncated value rather than the value of the
+bit-field after the assignment (per C11 6.5.16.1p3). The cases cover the
+1-bit boundary, a width wider than two bits, a negative right-hand side, the
+unchanged unsigned branch, and a full-width (non-narrowing) signed field.

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1444,9 +1444,41 @@ void goto_program2codet::cleanup_code(
       code.op0().type() = bv_type;
       if(code.operands().size() == 2)
       {
-        exprt bit_mask =
-          from_integer(power(2, original_type.get_width()) - 1, bv_type);
-        code.op1() = bitand_exprt{code.op1(), bit_mask};
+        const std::size_t bf_width = original_type.get_width();
+        exprt bit_mask = from_integer(power(2, bf_width) - 1, bv_type);
+        // Sign-extension is only needed for a signed bit-field that is
+        // narrower than its underlying type. unsignedbv / c_bool / bv
+        // correctly keep the plain AND-mask below (no sign bit to extend).
+        // The bf_width >= 1 term guards the bf_width - 1 in the sign-bit
+        // computation against unsigned underflow; a zero-width bit-field is
+        // anonymous and not assignable, so this branch is not expected to see
+        // one, but we avoid crashing on it.
+        if(
+          bv_type.id() == ID_signedbv && bf_width >= 1 &&
+          bf_width < bv_type.get_width())
+        {
+          // For a signed bit-field that is narrower than its underlying type
+          // we need to sign-extend the stored value: writing to and reading
+          // back from such a bit-field yields a sign-extended value (per
+          // C11 6.5.16.1p3). Subsequent uses of this temporary - which we
+          // are about to give the underlying integer type - must therefore
+          // already observe the sign-extended value. We use the well-defined
+          // branchless sign-extension formula
+          //   ((v & mask) ^ sign_bit) - sign_bit
+          // where mask    = (1 << N) - 1
+          //       sign_bit = 1 << (N - 1)
+          // and N is the bit-field width. The intermediate result stays
+          // within the bit-field's value range, so this expression triggers
+          // neither signed overflow nor implementation-defined shifts.
+          const exprt sign_bit = from_integer(power(2, bf_width - 1), bv_type);
+          code.op1() = minus_exprt{
+            bitxor_exprt{bitand_exprt{code.op1(), bit_mask}, sign_bit},
+            sign_bit};
+        }
+        else
+        {
+          code.op1() = bitand_exprt{code.op1(), bit_mask};
+        }
       }
     }
 


### PR DESCRIPTION
When goto-conversion lowers a chained assignment `outer = bf = expr` through a bit-field lvalue, it introduces a temporary symbol whose declared type is the bit-field type. `goto_program2code` rewrites that temporary's type to the bit-field's underlying integer type and previously masked the initialiser with `& ((1 << N) - 1)` to model the bit-field truncation.

For unsigned bit-fields the AND-mask is enough, but for signed bit-fields the value of `bf = expr` is the value of `bf` after the assignment - i.e. the masked value sign-extended to the underlying type (per C11 6.5.16.1p3). Without the sign extension, the temporary held an unsigned-truncated value, so subsequent uses of it (here: the chained assignment to `outer`) observed the wrong value. The original program continued to verify correctly under CBMC, but the C code emitted by `--dump-c` no longer agreed with the source - which CSmith picks up as a checksum mismatch.

Apply branchless sign extension `((v & mask) ^ sign_bit) - sign_bit` for the signed-and-narrower case. This expression stays within the bit-field's value range and so triggers neither signed overflow nor implementation-defined shift behaviour in the dumped C.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
