### PR TITLE
Push empty-type equality short-circuit into convert_expr_to_smt

### DIFF
--- a/regression/cbmc/havoc_slice_checks/test.desc
+++ b/regression/cbmc/havoc_slice_checks/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\[main\.assertion\.\d+\] line 9 assertion havoc_slice W_OK.*: FAILURE$

--- a/regression/cbmc/memset_null/test.desc
+++ b/regression/cbmc/memset_null/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^\[main.precondition_instance.1\] line .* memset destination region writeable: FAILURE$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -261,34 +261,6 @@ void smt2_convt::write_footer()
       << "\n";
 }
 
-/// Returns true iff \p type has effective width of zero bits.
-static bool is_zero_width(const typet &type, const namespacet &ns)
-{
-  if(type.id() == ID_empty)
-    return true;
-  else if(type.id() == ID_struct_tag)
-    return is_zero_width(ns.follow_tag(to_struct_tag_type(type)), ns);
-  else if(type.id() == ID_union_tag)
-    return is_zero_width(ns.follow_tag(to_union_tag_type(type)), ns);
-  else if(type.id() == ID_struct || type.id() == ID_union)
-  {
-    for(const auto &comp : to_struct_union_type(type).components())
-    {
-      if(!is_zero_width(comp.type(), ns))
-        return false;
-    }
-    return true;
-  }
-  else if(auto array_type = type_try_dynamic_cast<array_typet>(type))
-  {
-    // we ignore array_type->size().is_zero() for now as there may be
-    // out-of-bounds accesses that we need to model
-    return is_zero_width(array_type->element_type(), ns);
-  }
-  else
-    return false;
-}
-
 void smt2_convt::define_object_size(
   const irep_idt &id,
   const object_size_exprt &expr)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -8,7 +8,9 @@
 #include <util/expr_cast.h>
 #include <util/floatbv_expr.h>
 #include <util/mathematical_expr.h>
+#include <util/namespace.h>
 #include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
 #include <util/range.h>
 #include <util/std_expr.h>
@@ -517,8 +519,16 @@ static smt_termt convert_expr_to_smt(
 
 static smt_termt convert_expr_to_smt(
   const equal_exprt &equal,
-  const sub_expression_mapt &converted)
+  const sub_expression_mapt &converted,
+  const namespacet &ns)
 {
+  // Equality of two zero-width-typed (typically void) operands is
+  // vacuously true. Mirrors smt2_conv.cpp:1604 (`convert_expr(true_exprt())`
+  // for the same case). The visitor filter in the entry-point
+  // `convert_expr_to_smt` ensures that the operands are *not* in
+  // `converted`, so we short-circuit before any lookup.
+  if(is_zero_width(equal.lhs().type(), ns))
+    return smt_bool_literal_termt{true};
   return smt_core_theoryt::equal(
     converted.at(equal.op0()), converted.at(equal.op1()));
 }
@@ -1497,7 +1507,8 @@ static smt_termt dispatch_expr_to_smt_conversion(
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
   const smt_object_sizet::make_applicationt &call_object_size,
-  const smt_is_dynamic_objectt::make_applicationt &apply_is_dynamic_object)
+  const smt_is_dynamic_objectt::make_applicationt &apply_is_dynamic_object,
+  const namespacet &ns)
 {
   if(const auto symbol = expr_try_dynamic_cast<symbol_exprt>(expr))
   {
@@ -1587,7 +1598,7 @@ static smt_termt dispatch_expr_to_smt_conversion(
   }
   if(const auto equal = expr_try_dynamic_cast<equal_exprt>(expr))
   {
-    return convert_expr_to_smt(*equal, converted);
+    return convert_expr_to_smt(*equal, converted, ns);
   }
   if(const auto not_equal = expr_try_dynamic_cast<notequal_exprt>(expr))
   {
@@ -1934,7 +1945,8 @@ smt_termt convert_expr_to_smt(
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
   const smt_object_sizet::make_applicationt &object_size,
-  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object)
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object,
+  const namespacet &ns)
 {
 #ifndef CPROVER_INVARIANT_DO_NOT_CHECK
   static bool in_conversion = false;
@@ -1950,17 +1962,29 @@ smt_termt convert_expr_to_smt(
   const auto lowered_expr = lower_address_of_array_index(expr);
   filtered_visit_post(
     lowered_expr,
-    [](const exprt &expr) {
+    [&](const exprt &expr)
+    {
       // Code values inside "address of" expressions do not need to be converted
       // as the "address of" conversion only depends on the object identifier.
       // Avoiding the conversion side steps a need to convert arbitrary code to
       // SMT terms.
       const auto address_of = expr_try_dynamic_cast<address_of_exprt>(expr);
-      if(!address_of)
-        return true;
-      return !can_cast_type<code_typet>(address_of->object().type());
+      if(address_of && can_cast_type<code_typet>(address_of->object().type()))
+        return false;
+      // Equality of two zero-width-typed (typically void) operands is
+      // vacuously true; the dedicated overload of convert_expr_to_smt for
+      // equal_exprt handles this case without consulting the converted
+      // operands. Skipping descent here avoids attempting
+      // convert_type_to_smt_sort on an empty type, which is unimplemented.
+      if(const auto equal = expr_try_dynamic_cast<equal_exprt>(expr))
+      {
+        if(is_zero_width(equal->lhs().type(), ns))
+          return false;
+      }
+      return true;
     },
-    [&](const exprt &expr) {
+    [&](const exprt &expr)
+    {
       const auto find_result = sub_expression_map.find(expr);
       if(find_result != sub_expression_map.cend())
         return;
@@ -1970,7 +1994,8 @@ smt_termt convert_expr_to_smt(
         object_map,
         pointer_sizes,
         object_size,
-        is_dynamic_object);
+        is_dynamic_object,
+        ns);
       sub_expression_map.emplace_hint(find_result, expr, std::move(term));
     });
   return std::move(sub_expression_map.at(lowered_expr));

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.h
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.h
@@ -11,6 +11,7 @@
 #include <solvers/smt2_incremental/type_size_mapping.h>
 
 class exprt;
+class namespacet;
 class typet;
 
 /// \brief Converts the \p type to an smt encoding of the same expression
@@ -29,6 +30,7 @@ smt_termt convert_expr_to_smt(
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
   const smt_object_sizet::make_applicationt &object_size,
-  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object);
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object,
+  const namespacet &ns);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -6,6 +6,7 @@
 #include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/pointer_offset_size.h>
 #include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
@@ -70,7 +71,8 @@ get_problem_messages(const smt_responset &response)
 ///   returned by this`gather_dependent_expressions` function.
 /// \details `symbol_exprt`, `array_exprt` and `nondet_symbol_exprt` add
 ///   dependant expressions.
-static std::vector<exprt> gather_dependent_expressions(const exprt &root_expr)
+static std::vector<exprt>
+gather_dependent_expressions(const exprt &root_expr, const namespacet &ns)
 {
   std::vector<exprt> dependent_expressions;
 
@@ -88,7 +90,13 @@ static std::vector<exprt> gather_dependent_expressions(const exprt &root_expr)
       can_cast_expr<nondet_symbol_exprt>(expr_node) ||
       can_cast_expr<string_constantt>(expr_node))
     {
-      dependent_expressions.push_back(expr_node);
+      // Skip zero-width-typed leaves: they have no SMT representation
+      // (convert_type_to_smt_sort would hit UNIMPLEMENTED_FEATURE on
+      // empty_typet), and the only top-level consumer that could
+      // legitimately involve such a leaf -- equality of two void-typed
+      // operands -- is short-circuited in `set_to` below.
+      if(!is_zero_width(expr_node.type(), ns))
+        dependent_expressions.push_back(expr_node);
     }
     // The decision procedure does not depend on the values inside address of
     // code typed expressions. We can build the address without knowing the
@@ -192,7 +200,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
   std::stack<exprt> to_be_defined;
   const auto push_dependencies_needed = [&](const exprt &expr) {
     bool result = false;
-    for(const auto &dependency : gather_dependent_expressions(expr))
+    for(const auto &dependency : gather_dependent_expressions(expr, ns))
     {
       if(!seen_expressions.insert(dependency).second)
         continue;
@@ -561,7 +569,7 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
       return identifier_descriptor;
     }
     const exprt lowered = lower(expr);
-    if(gather_dependent_expressions(lowered).empty())
+    if(gather_dependent_expressions(lowered, ns).empty())
     {
       INVARIANT(
         objects_are_already_tracked(lowered, object_map),
@@ -616,6 +624,30 @@ void smt2_incremental_decision_proceduret::set_to(
           << in_expr.pretty(2, 0) << messaget::eom;
   });
   const exprt lowered_expr = lower(in_expr);
+  // Equality of two zero-width-typed (typically void) operands is
+  // vacuously true. For value == true we therefore have nothing to
+  // assert; for value == false we send `(assert false)` directly,
+  // matching the end-to-end behaviour of the non-incremental SMT2
+  // backend (smt2_conv.cpp), which converts `equal_exprt` over a
+  // zero-width type to `true_exprt` and then negates.
+  //
+  // Limitation: only the *top-level* equality is intercepted here.
+  // A nested case such as `set_to(and_exprt{equal_exprt{x_void,
+  // y_void}, other}, true)` would still descend into
+  // `convert_expr_to_smt`, which has no handling for void operands
+  // and would trip UNIMPLEMENTED_FEATURE in `convert_type_to_smt_sort`.
+  // CBMC's GOTO programs do not produce such nested shapes today,
+  // but a future refactor pushing this short-circuit into the
+  // `equal_exprt` overload of `convert_expr_to_smt` would handle the
+  // nested case for free.
+  if(
+    lowered_expr.id() == ID_equal &&
+    is_zero_width(to_equal_expr(lowered_expr).lhs().type(), ns))
+  {
+    if(!value)
+      solver_process->send(smt_assert_commandt{smt_bool_literal_termt{false}});
+    return;
+  }
   PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
 
   define_dependent_functions(lowered_expr);

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -400,7 +400,8 @@ smt2_incremental_decision_proceduret::convert_expr_to_smt(const exprt &expr)
     object_map,
     pointer_sizes_map,
     object_size_function.make_application,
-    is_dynamic_object_function.make_application);
+    is_dynamic_object_function.make_application,
+    ns);
 }
 
 exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
@@ -456,7 +457,8 @@ std::optional<exprt> smt2_incremental_decision_proceduret::get_expr(
       object_map,
       pointer_sizes_map,
       object_size_function.make_application,
-      is_dynamic_object_function.make_application);
+      is_dynamic_object_function.make_application,
+      ns);
     auto element = get_expr(
       smt_array_theoryt::select(array, index_term), type.element_type());
     if(!element)
@@ -580,7 +582,8 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
         object_map,
         pointer_sizes_map,
         object_size_function.make_application,
-        is_dynamic_object_function.make_application);
+        is_dynamic_object_function.make_application,
+        ns);
     }
     return {};
   }();
@@ -624,30 +627,6 @@ void smt2_incremental_decision_proceduret::set_to(
           << in_expr.pretty(2, 0) << messaget::eom;
   });
   const exprt lowered_expr = lower(in_expr);
-  // Equality of two zero-width-typed (typically void) operands is
-  // vacuously true. For value == true we therefore have nothing to
-  // assert; for value == false we send `(assert false)` directly,
-  // matching the end-to-end behaviour of the non-incremental SMT2
-  // backend (smt2_conv.cpp), which converts `equal_exprt` over a
-  // zero-width type to `true_exprt` and then negates.
-  //
-  // Limitation: only the *top-level* equality is intercepted here.
-  // A nested case such as `set_to(and_exprt{equal_exprt{x_void,
-  // y_void}, other}, true)` would still descend into
-  // `convert_expr_to_smt`, which has no handling for void operands
-  // and would trip UNIMPLEMENTED_FEATURE in `convert_type_to_smt_sort`.
-  // CBMC's GOTO programs do not produce such nested shapes today,
-  // but a future refactor pushing this short-circuit into the
-  // `equal_exprt` overload of `convert_expr_to_smt` would handle the
-  // nested case for free.
-  if(
-    lowered_expr.id() == ID_equal &&
-    is_zero_width(to_equal_expr(lowered_expr).lhs().type(), ns))
-  {
-    if(!value)
-      solver_process->send(smt_assert_commandt{smt_bool_literal_termt{false}});
-    return;
-  }
   PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
 
   define_dependent_functions(lowered_expr);

--- a/src/solvers/smt2_incremental/type_size_mapping.cpp
+++ b/src/solvers/smt2_incremental/type_size_mapping.cpp
@@ -47,7 +47,8 @@ void associate_pointer_sizes(
         object_map,
         type_size_map,
         object_size,
-        is_dynamic_object);
+        is_dynamic_object,
+        ns);
       type_size_map.emplace_hint(
         find_result, pointer_type->base_type(), pointer_size_term);
     }

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -497,6 +497,33 @@ std::optional<exprt> size_of_expr(const typet &type, const namespacet &ns)
     return {};
 }
 
+bool is_zero_width(const typet &type, const namespacet &ns)
+{
+  if(type.id() == ID_empty)
+    return true;
+  else if(type.id() == ID_struct_tag)
+    return is_zero_width(ns.follow_tag(to_struct_tag_type(type)), ns);
+  else if(type.id() == ID_union_tag)
+    return is_zero_width(ns.follow_tag(to_union_tag_type(type)), ns);
+  else if(type.id() == ID_struct || type.id() == ID_union)
+  {
+    for(const auto &comp : to_struct_union_type(type).components())
+    {
+      if(!is_zero_width(comp.type(), ns))
+        return false;
+    }
+    return true;
+  }
+  else if(auto array_type = type_try_dynamic_cast<array_typet>(type))
+  {
+    // we ignore array_type->size().is_zero() for now as there may be
+    // out-of-bounds accesses that we need to model
+    return is_zero_width(array_type->element_type(), ns);
+  }
+  else
+    return false;
+}
+
 std::optional<mp_integer>
 compute_pointer_offset(const exprt &expr, const namespacet &ns)
 {

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -39,6 +39,13 @@ pointer_offset_size(const typet &type, const namespacet &ns);
 std::optional<mp_integer>
 pointer_offset_bits(const typet &type, const namespacet &ns);
 
+/// Returns true iff \p type has effective width of zero bits.
+/// In addition to the obvious \c ID_empty, this recognises
+/// struct/union types whose components are all zero-width and arrays
+/// of zero-width elements, mirroring the semantics that the
+/// bit-blasting back-ends use to skip such types.
+bool is_zero_width(const typet &type, const namespacet &ns);
+
 std::optional<mp_integer>
 compute_pointer_offset(const exprt &expr, const namespacet &ns);
 

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -62,6 +62,8 @@ struct expr_to_smt_conversion_test_environmentt
   smt_object_sizet object_size_function;
   smt_is_dynamic_objectt is_dynamic_object_function;
   type_size_mapt pointer_sizes;
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
 
 private:
   // This is private to ensure the above make() function is used to make
@@ -86,7 +88,9 @@ expr_to_smt_conversion_test_environmentt::make(test_archt arch)
   default:
     UNREACHABLE;
   }
-  return {initial_smt_object_map(), smt_object_sizet{}};
+  expr_to_smt_conversion_test_environmentt env;
+  env.object_map = initial_smt_object_map();
+  return env;
 }
 
 smt_termt
@@ -97,7 +101,8 @@ expr_to_smt_conversion_test_environmentt::convert(const exprt &expression) const
     object_map,
     pointer_sizes,
     object_size_function.make_application,
-    is_dynamic_object_function.make_application);
+    is_dynamic_object_function.make_application,
+    ns);
 }
 
 TEST_CASE("\"array_typet\" to smt sort conversion", "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1141,11 +1141,15 @@ TEST_CASE(
   "[core][smt2_incremental]")
 {
   // Equality of two empty-typed (void) operands is vacuously true. The
-  // decision procedure should therefore short-circuit set_to without
-  // descending into convert_expr_to_smt (which has no SMT sort for
-  // empty_typet) and without declaring the void-typed leaves: for
-  // value == true nothing extra is sent; for value == false a single
-  // `(assert false)` is sent.
+  // dedicated overload of convert_expr_to_smt for equal_exprt returns
+  // the boolean literal `true` directly without descending into the
+  // void operands (which have no SMT sort), so:
+  //  - set_to(equal_exprt{x, y}, true)  yields `(assert true)`.
+  //  - set_to(equal_exprt{x, y}, false) yields `(assert (not true))`,
+  //    i.e. a contradiction.
+  // This mirrors the end-to-end behaviour of the non-incremental SMT2
+  // backend (smt2_conv.cpp:1604), which converts equal_exprt over a
+  // zero-width type to true_exprt and then negates as needed.
   auto test = decision_procedure_test_environmentt::make();
   const symbolt x{"x", empty_typet{}, ID_C};
   test.symbol_table.insert(x);
@@ -1157,14 +1161,54 @@ TEST_CASE(
   CHECK(test.procedure() == decision_proceduret::resultt::D_SATISFIABLE);
   test.sent_commands.clear();
 
-  INFO("set_to(equal_exprt{x, y}, true) sends no extra commands");
+  INFO("set_to(equal_exprt{x, y}, true) emits `(assert true)`");
   test.procedure.set_to(equal_exprt{x.symbol_expr(), y.symbol_expr()}, true);
-  CHECK(test.sent_commands == std::vector<smt_commandt>{});
+  const std::vector<smt_commandt> expected_true_commands{
+    smt_assert_commandt{smt_bool_literal_termt{true}}};
+  CHECK(test.sent_commands == expected_true_commands);
+  test.sent_commands.clear();
 
-  INFO("set_to(equal_exprt{x, y}, false) sends a single `(assert false)`");
+  INFO("set_to(equal_exprt{x, y}, false) emits `(assert (not true))`");
   test.procedure.set_to(equal_exprt{x.symbol_expr(), y.symbol_expr()}, false);
+  const std::vector<smt_commandt> expected_false_commands{smt_assert_commandt{
+    smt_core_theoryt::make_not(smt_bool_literal_termt{true})}};
+  CHECK(test.sent_commands == expected_false_commands);
+}
+
+TEST_CASE(
+  "smt2_incremental_decision_proceduret set_to over nested empty-type "
+  "equality",
+  "[core][smt2_incremental]")
+{
+  // Nested equal_exprt over empty (void) operands -- e.g. as the lhs of
+  // an and_exprt -- is handled by convert_expr_to_smt's equal_exprt
+  // overload, which returns the boolean literal `true`. The enclosing
+  // and_exprt then converts normally. Without the convert-side
+  // short-circuit this case used to trip UNIMPLEMENTED_FEATURE in
+  // convert_type_to_smt_sort(empty_typet).
+  auto test = decision_procedure_test_environmentt::make();
+  const symbolt x{"x", empty_typet{}, ID_C};
+  test.symbol_table.insert(x);
+  const symbolt y{"y", empty_typet{}, ID_C};
+  test.symbol_table.insert(y);
+  const symbolt b{"b", bool_typet{}, ID_C};
+  test.symbol_table.insert(b);
+
+  INFO("Sanity checking decision procedure and flushing size definitions");
+  test.mock_responses.push_front(smt_check_sat_responset{smt_sat_responset{}});
+  CHECK(test.procedure() == decision_proceduret::resultt::D_SATISFIABLE);
+  test.sent_commands.clear();
+
+  INFO("set_to(and_exprt{equal_exprt{x, y}, b}, true) succeeds");
+  test.procedure.set_to(
+    and_exprt{equal_exprt{x.symbol_expr(), y.symbol_expr()}, b.symbol_expr()},
+    true);
+  const smt_identifier_termt expected_b{"b", smt_bool_sortt{}};
+  const smt_termt expected_and =
+    smt_core_theoryt::make_and(smt_bool_literal_termt{true}, expected_b);
   const std::vector<smt_commandt> expected_commands{
-    smt_assert_commandt{smt_bool_literal_termt{false}}};
+    smt_declare_function_commandt{expected_b, {}},
+    smt_assert_commandt{expected_and}};
   CHECK(test.sent_commands == expected_commands);
 }
 

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1137,6 +1137,38 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "smt2_incremental_decision_proceduret set_to over empty type",
+  "[core][smt2_incremental]")
+{
+  // Equality of two empty-typed (void) operands is vacuously true. The
+  // decision procedure should therefore short-circuit set_to without
+  // descending into convert_expr_to_smt (which has no SMT sort for
+  // empty_typet) and without declaring the void-typed leaves: for
+  // value == true nothing extra is sent; for value == false a single
+  // `(assert false)` is sent.
+  auto test = decision_procedure_test_environmentt::make();
+  const symbolt x{"x", empty_typet{}, ID_C};
+  test.symbol_table.insert(x);
+  const symbolt y{"y", empty_typet{}, ID_C};
+  test.symbol_table.insert(y);
+
+  INFO("Sanity checking decision procedure and flushing size definitions");
+  test.mock_responses.push_front(smt_check_sat_responset{smt_sat_responset{}});
+  CHECK(test.procedure() == decision_proceduret::resultt::D_SATISFIABLE);
+  test.sent_commands.clear();
+
+  INFO("set_to(equal_exprt{x, y}, true) sends no extra commands");
+  test.procedure.set_to(equal_exprt{x.symbol_expr(), y.symbol_expr()}, true);
+  CHECK(test.sent_commands == std::vector<smt_commandt>{});
+
+  INFO("set_to(equal_exprt{x, y}, false) sends a single `(assert false)`");
+  test.procedure.set_to(equal_exprt{x.symbol_expr(), y.symbol_expr()}, false);
+  const std::vector<smt_commandt> expected_commands{
+    smt_assert_commandt{smt_bool_literal_termt{false}}};
+  CHECK(test.sent_commands == expected_commands);
+}
+
+TEST_CASE(
   "smt2_incremental_decision_proceduret getting value of struct-symbols with "
   "value in the symbol table",
   "[core][util][expr_initializer]")


### PR DESCRIPTION
Builds upon #8907.

Previously, equality of two zero-width-typed (typically void) operands was handled at the top level of smt2_incremental_decision_proceduret::set_to: the `equal_exprt` was matched textually before lowering reached convert_expr_to_smt, and a dedicated branch emitted either nothing (for value == true) or `(assert false)` (for value == false). This worked for the common case but failed for nested shapes such as

    set_to(and_exprt{equal_exprt{x_void, y_void}, other}, true)

because the recursive visitor in convert_expr_to_smt would still descend into the void operands of the inner equal_exprt and trip UNIMPLEMENTED_FEATURE in convert_type_to_smt_sort(empty_typet).

Move the short-circuit one layer down, into convert_expr_to_smt:

  - Add a `const namespacet &` parameter to the public convert_expr_to_smt and propagate it to the dispatcher and to the equal_exprt overload.
  - In the entry-point's `filtered_visit_post` filter, return false for an `equal_exprt` whose operands have zero-width type, so that the visitor does not descend into the void operands and does not attempt convert_type_to_smt_sort on them.
  - In the equal_exprt overload of convert_expr_to_smt, return `smt_bool_literal_termt{true}` directly when the operand type is zero-width, mirroring smt2_conv.cpp:1604 (`convert_expr(true_exprt())`).
  - Drop the now-redundant top-level short-circuit from set_to: convert_expr_to_smt produces the boolean literal `true`, which set_to asserts as-is for value == true and negates for value == false. This means the SMT output for the trivial top-level case becomes `(assert true)` / `(assert (not true))` rather than nothing / `(assert false)`. Both are semantically equivalent and match the end-to-end behaviour of the non-incremental SMT2 backend.

The gather-side filter in gather_dependent_expressions is kept: it is a separate walk that runs before the convert-side visitor and still needs to skip zero-width-typed leaves to avoid sending declare-fun for them (which would also call convert_type_to_smt_sort on an empty type).

Update the unit test for `set_to over empty type` to reflect the new SMT command sequence, and add a new unit test `set_to over nested empty-type equality` that exercises the nested shape (an `and_exprt` whose lhs is an empty-type `equal_exprt`).  The existing `getting value of empty struct` test, which uses empty structs (lowered to bv_typet{8} via struct_encoding) rather than true void, continues to pass unchanged.

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
