### PR TITLE
boolbv_let: pass lowered value to record_array_let_binding

### DIFF
--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -57,6 +57,8 @@ public:
   /// array theory. For unbounded-array-typed bindings this connects the
   /// two expressions in the union-find so that element-wise constraints
   /// propagate correctly.
+  /// \pre \p value must be free of byte_update operators; lower them at the
+  ///   call site (collect_arrays otherwise fails a DATA_INVARIANT).
   void record_array_let_binding(const symbol_exprt &symbol, const exprt &value);
 
 protected:

--- a/src/solvers/flattening/boolbv_let.cpp
+++ b/src/solvers/flattening/boolbv_let.cpp
@@ -80,7 +80,7 @@ bvt boolbvt::convert_let(const let_exprt &expr)
       const exprt lowered_value = has_byte_operator(pair.second)
                                     ? lower_byte_operators(pair.second, ns)
                                     : pair.second;
-      record_array_let_binding(pair.first, pair.second);
+      record_array_let_binding(pair.first, lowered_value);
     }
   }
 

--- a/unit/solvers/flattening/boolbv.cpp
+++ b/unit/solvers/flattening/boolbv.cpp
@@ -11,6 +11,9 @@ Author: Daniel Kroening
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/byte_operators.h>
+#include <util/c_types.h>
+#include <util/config.h>
 #include <util/cout_message.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
@@ -18,6 +21,7 @@ Author: Daniel Kroening
 #include <solvers/flattening/boolbv.h>
 #include <solvers/sat/satcheck.h>
 #include <testing-utils/empty_namespace.h>
+#include <testing-utils/message.h>
 #include <testing-utils/use_catch.h>
 
 SCENARIO("boolbvt", "[core][solvers][flattening][boolbvt]")
@@ -43,6 +47,52 @@ SCENARIO("boolbvt", "[core][solvers][flattening][boolbvt]")
         equal_exprt(symbol_exprt("x", u32), from_integer(11, u32));
       REQUIRE(
         boolbv(assumption) == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+}
+
+SCENARIO(
+  "boolbvt convert_let with a byte_update in an unbounded array value",
+  "[core][solvers][flattening][boolbvt]")
+{
+  // A let-bound symbol of unbounded array type whose value still contains a
+  // byte_update operator must have that operator lowered before it is handed
+  // to the array theory: boolbvt::convert_let computes a lowered value but,
+  // before the fix, passed the un-lowered value to record_array_let_binding,
+  // tripping `DATA_INVARIANT(false, "byte_update should be removed before
+  // collect_arrays")` in collect_arrays.  This pins that fix.
+  GIVEN("a let binding an unbounded array to a byte_update expression")
+  {
+    config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+    config.ansi_c.set_arch_spec_x86_64();
+    satcheckt satcheck{null_message_handler};
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    boolbvt boolbv{ns, satcheck, null_message_handler};
+
+    const unsignedbv_typet u8{8};
+    // non-constant size => unbounded array
+    const array_typet array_type{u8, symbol_exprt{"N", size_type()}};
+    const symbol_exprt a{"a", array_type};
+    const symbol_exprt x{"x", u8};
+
+    const symbol_exprt b{"b", array_type};
+    const exprt array_value = byte_update_exprt{
+      ID_byte_update_little_endian,
+      b,
+      from_integer(0, c_index_type()),
+      x,
+      /* bits_per_byte */ 8};
+
+    const let_exprt let{
+      a,
+      array_value,
+      equal_exprt{index_exprt{a, from_integer(0, c_index_type())}, x}};
+
+    THEN("the let converts without tripping a DATA_INVARIANT")
+    {
+      boolbv << let;
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
     }
   }
 }


### PR DESCRIPTION
convert_let computes 'lowered_value' (the let's bound expression with byte_update / byte_extract operators rewritten away by lower_byte_operators) but then dropped it on the floor and passed the *un*-lowered 'pair.second' to record_array_let_binding. If the let-bound array value happens to contain a byte_update, the array theory's collect_arrays will see it and trip

  DATA_INVARIANT(false,
    "byte_update should be removed before collect_arrays")

Fix: pass 'lowered_value' so the value handed to the array theory matches the lowering already done at the call site.

The bug was introduced by commit 14105d503d7 ("Connect let-bound arrays to originals in array theory"), which added the byte-operator lowering computation but forgot to thread the result through to record_array_let_binding.

Note on regression coverage: I attempted to construct a test case that triggers the DATA_INVARIANT, but could not. The set of CBMC input paths that produce an array-typed let_exprt (which is the gate at line 78 above) is currently limited to:

  * SMT2 input parsed by smt2_parser.cpp — but SMT2 has no byte_update construct, so the let value cannot contain one.
  * value_set_dereference.cpp — produces let-bound *pointer*-typed values, not array-typed; the gate above filters them out.

So the bug is currently unreachable through standard CBMC entry points, and the fix is defensive against a future code path that might funnel byte-operator-bearing array expressions into a let. The existing regression/smt2_solver/let-array/let-array.smt2 test continues to exercise the convert_let array-typed branch and passes unchanged with the fix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
