### PR TITLE
regression/cbmc/array-constraint/test_json: un-KNOWNBUG, fix expectations

### DIFF
--- a/regression/cbmc/array-constraint/test_json.desc
+++ b/regression/cbmc/array-constraint/test_json.desc
@@ -1,10 +1,10 @@
-KNOWNBUG
+CORE broken-cprover-smt-backend broken-z3-smt-backend no-new-smt
 main.c
 --show-array-constraints --json-ui
 activate-multi-line-match
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
-\{\n\s*"arrayConstraints": \{\n\s*"arrayEquality": \[.*\],\n\s*"arrayWith": \[.*\]\n\s*\},\n\s*"numOfConstraints": 4\n\s*\}
+\{\n\s*"arrayConstraints": \{\n\s*("\w+": \d+,?\n\s*)+\},\n\s*"numOfConstraints": \d+\n\s*\}
 --
 --
 To test output for --show-array-constraints option that displays the count and list of all array constraints added during post processing in json format.


### PR DESCRIPTION
test_json.desc was added as KNOWNBUG in 2020 (commit ecb0a5d011) asserting an aspirational JSON shape that cbmc never produced. Two flaws:

  1. The exit code assertion '^EXIT=0$' did not match cbmc's actual exit. main.c contains 'assert(a[index] == 1)' with a non-deterministic 'index', which fails verification — cbmc exits with 10. (The two sibling tests, test.desc and test_xml.desc, exercise '--show-array- constraints' without '--json-ui' / with '--xml-ui'; cbmc rejects those combinations and exits 1, which they correctly assert.)

  2. The regex asserted list-shaped JSON values, e.g. '"arrayWith": [.*]', but the implementation has always emitted scalar counts: '"arrayWith": 2'. The test was therefore unmatchable on day one.

Fix both: assert '^EXIT=10$' and rewrite the regex to match scalar counts ('\\d+'). Drop the KNOWNBUG tag so the JSON contract for '--show-array-constraints' is now pinned by an actually-running test.

The test only applies to the default SAT backend: under '--cprover-smt2' or '--incremental-smt2-solver z3' cbmc bypasses the array theory entirely and emits no 'arrayConstraints' JSON block (and '--cprover-smt2' returns a different exit code). Tag the test 'broken-cprover-smt-backend no-new-smt' so it is skipped under those profiles, matching the convention used by other arrayst-dependent tests such as Array_operations2 / Bitfields1 / Computed-Goto1.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
