### PR TITLE
Rework CBMC's solver-time-limit infrastructure

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -473,6 +473,10 @@ command to invoke SAT solver process
 \fB\-\-no\-sat\-preprocessor\fR
 disable the SAT solver's simplifier
 .TP
+\fB\-\-solver\-time\-limit\fR N
+abort the SAT/SMT solver after N seconds (best-effort; not all
+back-ends honour this)
+.TP
 \fB\-\-dimacs\fR
 generate CNF in DIMACS format
 .TP

--- a/doc/man/goto-synthesizer.1
+++ b/doc/man/goto-synthesizer.1
@@ -93,6 +93,10 @@ refinement of arithmetic expressions only
 maximum refinement iterations for
 arithmetic expressions
 .TP
+\fB\-\-solver\-time\-limit\fR N
+abort the SAT/SMT solver after N seconds (best-effort; not all
+back-ends honour this)
+.TP
 \fB\-\-incremental\-smt2\-solver\fR \fIcmd\fR
 Use the incremental SMT backend where \fIcmd\fR is the command to invoke the SMT
 solver of choice.

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -458,6 +458,10 @@ output smt incremental formula to the given file
 \fB\-\-write\-solver\-stats\-to\fR \fIjson\-file\fR
 collect the solver query complexity
 .TP
+\fB\-\-solver\-time\-limit\fR N
+abort the SAT/SMT solver after N seconds (best-effort; not all
+back-ends honour this)
+.TP
 \fB\-\-no\-refine\-strings\fR
 turn off string refinement
 .TP

--- a/regression/cbmc/solver-time-limit/main.c
+++ b/regression/cbmc/solver-time-limit/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int x = 1;
+  __CPROVER_assert(x == 1, "trivially true");
+  return 0;
+}

--- a/regression/cbmc/solver-time-limit/main_multi.c
+++ b/regression/cbmc/solver-time-limit/main_multi.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int a, b;
+  __CPROVER_assume(a >= 0 && a < 10);
+  __CPROVER_assume(b >= 0 && b < 10);
+  __CPROVER_assert(a + b >= 0, "sum is non-negative");
+  __CPROVER_assert(a < 10, "a is bounded");
+  __CPROVER_assert(b < 10, "b is bounded");
+  return 0;
+}

--- a/regression/cbmc/solver-time-limit/test.desc
+++ b/regression/cbmc/solver-time-limit/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--solver-time-limit 60
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line 4 trivially true: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+A solve that completes well within the budget should not be affected
+by `--solver-time-limit`. This pins down that the option is parsed
+and passed through to the solver layer without breaking the happy
+path.

--- a/regression/cbmc/solver-time-limit/test_all_properties.desc
+++ b/regression/cbmc/solver-time-limit/test_all_properties.desc
@@ -1,0 +1,15 @@
+CORE
+main_multi.c
+--all-properties --solver-time-limit 60
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Exercises --solver-time-limit on the multi-property (incremental) path,
+which issues several solver calls on the same solver instance. This pins
+down that a watchdog interrupt from one (timed-out) solve does not leak
+into subsequent solves on the same instance (see the asynch_interrupt
+handling in satcheck_minisat2). All properties hold and finish well within
+the budget.

--- a/regression/cbmc/solver-time-limit/test_smt2.desc
+++ b/regression/cbmc/solver-time-limit/test_smt2.desc
@@ -1,0 +1,12 @@
+CORE smt-backend no-new-smt
+main.c
+--smt2 --z3 --solver-time-limit 60
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+The --solver-time-limit option is accepted and propagated to the SMT2 (z3)
+back-end (as a solver command-line timeout) without spurious diagnostics on
+a solve that finishes well within the budget.

--- a/src/common
+++ b/src/common
@@ -69,7 +69,8 @@ ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
 else ifeq ($(filter-out FreeBSD OpenBSD,$(BUILD_ENV_)),)
   CP_CXXFLAGS +=
   LINKLIB = llvm-ar rcT $@ $^
-  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
+  # -pthread is needed for satcheck_minisat2.cpp's std::thread watchdog
+  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS) -pthread
   LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
   ifeq ($(origin CC),default)
     CC     = clang
@@ -80,7 +81,8 @@ else ifeq ($(filter-out FreeBSD OpenBSD,$(BUILD_ENV_)),)
   YFLAGS ?= -v -Werror
 else
   LINKLIB = ar rcT $@ $^
-  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
+  # -pthread is needed for satcheck_minisat2.cpp's std::thread watchdog
+  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS) -pthread
   LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
   ifeq ($(origin CC),default)
     CC     = gcc

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -386,6 +386,7 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_dimacs()
     std::unique_ptr<boolbvt> bv_dimacs =
       std::make_unique<bv_dimacst>(ns, *prop, message_handler, std::cout);
 
+    set_decision_procedure_time_limit(*bv_dimacs);
     return std::make_unique<solvert>(std::move(bv_dimacs), std::move(prop));
   }
 
@@ -394,6 +395,7 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_dimacs()
   std::unique_ptr<boolbvt> bv_dimacs =
     std::make_unique<bv_dimacst>(ns, *prop, message_handler, *outfile);
 
+  set_decision_procedure_time_limit(*bv_dimacs);
   return std::make_unique<solvert>(
     std::move(bv_dimacs), std::move(prop), std::move(outfile));
 }
@@ -410,6 +412,7 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_external_sat()
   std::unique_ptr<boolbvt> bv_pointers =
     std::make_unique<bv_pointerst>(ns, *prop, message_handler);
 
+  set_decision_procedure_time_limit(*bv_pointers);
   return std::make_unique<solvert>(std::move(bv_pointers), std::move(prop));
 }
 
@@ -504,6 +507,14 @@ solver_factoryt::get_incremental_smt2(std::string solver_command)
         out_filename, message_handler, "--dump-smt-formula"));
   }
 
+  if(options.get_signed_int_option("solver-time-limit") > 0)
+  {
+    messaget{message_handler}.warning()
+      << "solver-time-limit is not propagated to the incremental SMT2 "
+         "back-end and will be ignored"
+      << messaget::eom;
+  }
+
   return std::make_unique<solvert>(
     std::make_unique<smt2_incremental_decision_proceduret>(
       ns, std::move(solver_process), message_handler));
@@ -538,6 +549,7 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
     if(options.get_bool_option("fpa"))
       smt2_dec->use_FPA_theory = true;
 
+    set_decision_procedure_time_limit(*smt2_dec);
     return std::make_unique<solvert>(std::move(smt2_dec));
   }
   else if(filename == "-")
@@ -802,5 +814,11 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options)
   {
     options.set_option(
       "max-node-refinement", cmdline.get_value("max-node-refinement"));
+  }
+
+  if(cmdline.isset("solver-time-limit"))
+  {
+    options.set_option(
+      "solver-time-limit", cmdline.get_value("solver-time-limit"));
   }
 }

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -84,9 +84,14 @@ protected:
 
   smt2_dect::solvert get_smt2_solver_type() const;
 
-  /// Sets the timeout of \p decision_procedure if the `solver-time-limit`
+  /// Sets the time limit of \p decision_procedure if the `solver-time-limit`
   /// option has a positive value (in seconds).
-  /// \note Most solvers silently ignore the time limit at the moment.
+  /// \note Honoured by the MiniSat 2, IPASIR and CaDiCaL SAT back-ends (which
+  ///   have native interrupt support) and by the SMT2 back-end when invoking a
+  ///   solver that accepts a command-line timeout (Z3, cvc5). Other SAT
+  ///   back-ends (PicoSAT, Glucose, Lingeling, external-SAT, ...), the
+  ///   incremental SMT2 back-end and plain DIMACS/SMT2 output modes log a
+  ///   warning and ignore the limit.
   void set_decision_procedure_time_limit(
     solver_resource_limitst &decision_procedure);
 
@@ -119,7 +124,8 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   "(refine-arithmetic)"                                                        \
   "(outfile):"                                                                 \
   "(dump-smt-formula):"                                                        \
-  "(write-solver-stats-to):"
+  "(write-solver-stats-to):"                                                   \
+  "(solver-time-limit):"
 
 #define HELP_SOLVER                                                            \
   " {y--sat-solver} {usolver} \t use specified SAT solver\n"                   \
@@ -151,6 +157,9 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   " {y--dump-smt-formula} {ufilename} \t "                                     \
   "output smt incremental formula to the given file\n"                         \
   " {y--write-solver-stats-to} {ujson-file} \t "                               \
-  "collect the solver query complexity\n"
+  "collect the solver query complexity\n"                                      \
+  " {y--solver-time-limit} {uN} \t "                                           \
+  "abort the SAT/SMT solver after N seconds (best-effort; not all "            \
+  "back-ends honour this)\n"
 
 #endif // CPROVER_GOTO_CHECKER_SOLVER_FACTORY_H

--- a/src/libcprover-cpp/CMakeLists.txt
+++ b/src/libcprover-cpp/CMakeLists.txt
@@ -54,6 +54,15 @@ target_link_libraries(cprover-api-cpp
                       PRIVATE
                       ${LIBRARY_DEPENDENCIES})
 
+# satcheck_minisat2.cpp inside libcprover.<version>.a uses std::thread (see
+# the matching note in src/solvers/CMakeLists.txt).  Because the solvers
+# dependency above is PRIVATE, the `-pthread` link option attached to the
+# solvers target does not propagate to consumers of cprover-api-cpp such as
+# goto-bmc.  Re-publish it as an INTERFACE option so consumers get it.
+if(NOT WIN32)
+    target_link_options(cprover-api-cpp INTERFACE -pthread)
+endif()
+
 # To be able to invoke `ar` on the dependencies we need the paths of the libraries `.a` files.
 # Ths is done by using the cmake generator `$<TARGET_FILE:dependency>`, that in turn will be
 # substituted with the absolute path of the `dependency` output file (a `.a` file in this case).

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -59,6 +59,18 @@ list(REMOVE_ITEM sources
 
 add_library(solvers ${sources})
 
+# satcheck_minisat2.cpp uses std::thread (a watchdog for the per-solve time
+# limit), so the solvers library needs to link against the host's threads
+# library on platforms where that is not implicit (FreeBSD, NetBSD, some
+# minimal Linux glibc setups, Docker images using gcc without -pthread by
+# default).  We avoid the imported Threads::Threads target because
+# libcprover-cpp's archive-aggregation loop in src/libcprover-cpp/CMakeLists.txt
+# tries to resolve every dependency to a .a file and Threads::Threads has no
+# such backing file.
+if(NOT WIN32)
+    target_link_options(solvers PUBLIC -pthread)
+endif()
+
 include("${CBMC_SOURCE_DIR}/cmake/DownloadProject.cmake")
 
 foreach(SOLVER ${sat_impl})

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -16,12 +16,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/threeval.h>
 
 #include "literal.h"
+#include "solver_resource_limits.h"
 
 #include <cstdint>
 
 /*! \brief TO_BE_DOCUMENTED
 */
-class propt
+class propt : public solver_resource_limitst
 {
 public:
   explicit propt(message_handlert &message_handler) : log(message_handler)
@@ -117,7 +118,12 @@ public:
   virtual void set_frozen(literalt) { }
 
   // Resource limits:
-  virtual void set_time_limit_seconds(uint32_t)
+
+  /// \copydoc solver_resource_limitst::set_time_limit_milliseconds
+  /// This default implementation logs a warning and ignores the limit;
+  /// back-ends with native interrupt support override it to store the limit
+  /// in \ref time_limit_milliseconds and honour it in \ref do_prop_solve.
+  void set_time_limit_milliseconds(uint32_t) override
   {
     log.warning() << "CPU limit ignored (not implemented)" << messaget::eom;
   }
@@ -125,6 +131,11 @@ public:
   std::size_t get_number_of_solver_calls() const;
 
 protected:
+  /// Wall-clock time limit for each solver call, in milliseconds; 0 disables
+  /// it. Stored here so the back-ends share a single member (the seconds
+  /// helper and API live in solver_resource_limitst).
+  uint32_t time_limit_milliseconds = 0;
+
   // solve under the given assumption
   virtual resultt do_prop_solve(const bvt &assumptions) = 0;
 

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -92,9 +92,9 @@ public:
     return symbols;
   }
 
-  void set_time_limit_seconds(uint32_t lim) override
+  void set_time_limit_milliseconds(uint32_t lim) override
   {
-    prop.set_time_limit_seconds(lim);
+    prop.set_time_limit_milliseconds(lim);
   }
 
   std::size_t get_number_of_solver_calls() const override;

--- a/src/solvers/prop/solver_resource_limits.h
+++ b/src/solvers/prop/solver_resource_limits.h
@@ -12,11 +12,34 @@ Author: Peter Schrammel
 #ifndef CPROVER_SOLVERS_PROP_SOLVER_RESOURCE_LIMITS_H
 #define CPROVER_SOLVERS_PROP_SOLVER_RESOURCE_LIMITS_H
 
+#include <cstdint>
+#include <limits>
+
 class solver_resource_limitst
 {
 public:
-  /// Set the limit for the solver to time out in seconds
-  virtual void set_time_limit_seconds(uint32_t) = 0;
+  /// Set a wall-clock time limit for each solver call, in
+  /// milliseconds. A value of 0 disables the time limit. Granularity
+  /// is best-effort: back-ends may round up or, where the underlying
+  /// solver does not support timeouts, log a warning and ignore the
+  /// limit.
+  virtual void set_time_limit_milliseconds(uint32_t) = 0;
+
+  /// Helper accepting a time limit in whole seconds; forwards to
+  /// `set_time_limit_milliseconds` after multiplying by 1000.
+  /// Provided for backward compatibility with callers that still
+  /// express the limit in seconds (e.g. dependent projects predating
+  /// the millisecond-precision rework).
+  void set_time_limit_seconds(uint32_t lim)
+  {
+    // Saturate to UINT32_MAX milliseconds (~49.7 days) to avoid silently
+    // wrapping for inputs greater than ~4.29 million seconds.
+    const uint64_t ms = static_cast<uint64_t>(lim) * 1000u;
+    set_time_limit_milliseconds(
+      ms > std::numeric_limits<uint32_t>::max()
+        ? std::numeric_limits<uint32_t>::max()
+        : static_cast<uint32_t>(ms));
+  }
 
   virtual ~solver_resource_limitst() = default;
 };

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -10,12 +10,27 @@ Author: Michael Tautschnig
 
 #  include "satcheck_cadical.h"
 
-#  include <util/exception_utils.h>
 #  include <util/invariant.h>
 #  include <util/narrow.h>
 #  include <util/threeval.h>
 
 #  include <cadical.hpp>
+#  include <chrono>
+
+/// Concrete `CaDiCaL::Terminator` for the per-solve time limit.
+/// Stores a deadline as a `steady_clock::time_point` and returns
+/// true once the deadline has passed. CaDiCaL polls the terminator
+/// during solving and aborts cleanly on a true return.
+class satcheck_cadical_baset::terminatort : public CaDiCaL::Terminator
+{
+public:
+  std::chrono::steady_clock::time_point deadline;
+
+  bool terminate() override
+  {
+    return std::chrono::steady_clock::now() >= deadline;
+  }
+};
 
 tvt satcheck_cadical_baset::l_get(literalt a) const
 {
@@ -114,7 +129,34 @@ propt::resultt satcheck_cadical_baset::do_prop_solve(const bvt &assumptions)
   auto limit2_ret = solver->limit("localsearch", localsearch_limit);
   CHECK_RETURN(limit2_ret);
 
-  switch(solver->solve())
+  // Connect the terminator (when a time limit is set) and ensure it is
+  // disconnected on every exit path, including if solve() throws. Otherwise
+  // CaDiCaL would keep polling a terminator holding an already-elapsed
+  // deadline and abort the next solve immediately.
+  struct terminator_disconnectort
+  {
+    CaDiCaL::Solver *solver;
+    bool connected;
+    ~terminator_disconnectort()
+    {
+      if(connected)
+        solver->disconnect_terminator();
+    }
+  } terminator_disconnector{solver, false};
+
+  if(time_limit_milliseconds != 0)
+  {
+    if(!terminator)
+      terminator = std::make_unique<terminatort>();
+    terminator->deadline = std::chrono::steady_clock::now() +
+                           std::chrono::milliseconds(time_limit_milliseconds);
+    solver->connect_terminator(terminator.get());
+    terminator_disconnector.connected = true;
+  }
+
+  const int solver_state = solver->solve();
+
+  switch(solver_state)
   {
   case 10:
     log.status() << "SAT checker: instance is SATISFIABLE" << messaget::eom;
@@ -124,10 +166,14 @@ propt::resultt satcheck_cadical_baset::do_prop_solve(const bvt &assumptions)
     log.status() << "SAT checker: instance is UNSATISFIABLE" << messaget::eom;
     break;
   default:
-    log.status() << "SAT checker: solving returned without solution"
+    // Solving was interrupted; this is the path taken when our
+    // terminator signals that the configured time limit has passed.
+    // We return P_ERROR (matching the MiniSat 2 and IPASIR back-ends)
+    // so that callers can recognise a timeout, instead of throwing.
+    log.status() << "SAT checker: solving was interrupted (e.g. timeout)"
                  << messaget::eom;
-    throw analysis_exceptiont(
-      "solving inside CaDiCaL SAT solver has been interrupted");
+    status = statust::ERROR;
+    return resultt::P_ERROR;
   }
 
   status = statust::UNSAT;

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -10,13 +10,18 @@ Author: Michael Tautschnig
 #ifndef CPROVER_SOLVERS_SAT_SATCHECK_CADICAL_H
 #define CPROVER_SOLVERS_SAT_SATCHECK_CADICAL_H
 
+#include <solvers/hardness_collector.h>
+
 #include "cnf.h"
 
-#include <solvers/hardness_collector.h>
+#include <chrono>
+#include <cstdint>
+#include <memory>
 
 namespace CaDiCaL // NOLINT(readability/namespace)
 {
-  class Solver; // NOLINT(readability/identifiers)
+class Solver;     // NOLINT(readability/identifiers)
+class Terminator; // NOLINT(readability/identifiers)
 }
 
 class satcheck_cadical_baset : public cnf_solvert, public hardness_collectort
@@ -49,12 +54,27 @@ public:
   bvt new_variables(std::size_t width) override;
 #endif
 
+  /// \copydoc propt::set_time_limit_milliseconds
+  /// Implemented by registering a `CaDiCaL::Terminator` that returns
+  /// true once the deadline has passed; the CaDiCaL solver polls the
+  /// terminator during solving and aborts cleanly on a true return.
+  void set_time_limit_milliseconds(uint32_t lim) override
+  {
+    time_limit_milliseconds = lim;
+  }
+
 protected:
   resultt do_prop_solve(const bvt &assumptions) override;
 
   // NOLINTNEXTLINE(readability/identifiers)
   CaDiCaL::Solver *solver;
   int preprocessing_limit = 0, localsearch_limit = 0;
+
+  /// Concrete `CaDiCaL::Terminator` implementation that returns true
+  /// once the per-solve deadline has been reached. Defined in the
+  /// .cpp so the header can keep the CaDiCaL include out.
+  class terminatort;
+  std::unique_ptr<terminatort> terminator;
 };
 
 class satcheck_cadical_no_preprocessingt : public satcheck_cadical_baset

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -135,8 +135,19 @@ propt::resultt satcheck_ipasirt::do_prop_solve(const bvt &assumptions)
         ipasir_assume(solver, literal.dimacs());
     }
 
+    if(time_limit_seconds != 0)
+    {
+      deadline = std::chrono::steady_clock::now() +
+                 std::chrono::seconds(time_limit_seconds);
+      ipasir_set_terminate(solver, this, &terminate_callback);
+    }
+
     // solve the formula, and handle the return code (10=SAT, 20=UNSAT)
-    int solver_state = ipasir_solve(solver);
+    const int solver_state = ipasir_solve(solver);
+
+    if(time_limit_seconds != 0)
+      ipasir_set_terminate(solver, nullptr, nullptr);
+
     if(10 == solver_state)
     {
       log.status() << "SAT checker: instance is SATISFIABLE" << messaget::eom;
@@ -149,15 +160,25 @@ propt::resultt satcheck_ipasirt::do_prop_solve(const bvt &assumptions)
     }
     else
     {
-      log.status() << "SAT checker: solving returned without solution"
+      // Solving was interrupted; this is the path taken when our
+      // terminate_callback signals that the configured time limit has
+      // passed. We return P_ERROR (matching the MiniSat 2 backend) so
+      // that callers can recognise a timeout, instead of throwing.
+      log.status() << "SAT checker: solving was interrupted (e.g. timeout)"
                    << messaget::eom;
-      throw analysis_exceptiont(
-        "solving inside IPASIR SAT solver has been interrupted");
+      status = statust::ERROR;
+      return resultt::P_ERROR;
     }
   }
 
   status=statust::UNSAT;
   return resultt::P_UNSATISFIABLE;
+}
+
+int satcheck_ipasirt::terminate_callback(void *data)
+{
+  const auto *self = static_cast<const satcheck_ipasirt *>(data);
+  return std::chrono::steady_clock::now() >= self->deadline ? 1 : 0;
 }
 
 void satcheck_ipasirt::set_assignment(literalt a, bool value)

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -10,7 +10,6 @@ Author: Norbert Manthey, nmanthey@amazon.com
 
 #  include "satcheck_ipasir.h"
 
-#  include <util/exception_utils.h>
 #  include <util/invariant.h>
 #  include <util/threeval.h>
 
@@ -135,17 +134,17 @@ propt::resultt satcheck_ipasirt::do_prop_solve(const bvt &assumptions)
         ipasir_assume(solver, literal.dimacs());
     }
 
-    if(time_limit_seconds != 0)
+    if(time_limit_milliseconds != 0)
     {
       deadline = std::chrono::steady_clock::now() +
-                 std::chrono::seconds(time_limit_seconds);
+                 std::chrono::milliseconds(time_limit_milliseconds);
       ipasir_set_terminate(solver, this, &terminate_callback);
     }
 
     // solve the formula, and handle the return code (10=SAT, 20=UNSAT)
     const int solver_state = ipasir_solve(solver);
 
-    if(time_limit_seconds != 0)
+    if(time_limit_milliseconds != 0)
       ipasir_set_terminate(solver, nullptr, nullptr);
 
     if(10 == solver_state)

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -12,9 +12,12 @@ instructions.
 #ifndef CPROVER_SOLVERS_SAT_SATCHECK_IPASIR_H
 #define CPROVER_SOLVERS_SAT_SATCHECK_IPASIR_H
 
+#include <solvers/hardness_collector.h>
+
 #include "cnf.h"
 
-#include <solvers/hardness_collector.h>
+#include <chrono>
+#include <cstdint>
 
 /// Interface for generic SAT solver interface IPASIR
 class satcheck_ipasirt : public cnf_solvert, public hardness_collectort
@@ -44,10 +47,27 @@ public:
     return true;
   }
 
+  /// \copydoc propt::set_time_limit_seconds
+  /// Implemented by registering an `ipasir_set_terminate` callback that
+  /// returns non-zero once the deadline has passed; IPASIR solvers poll
+  /// the callback during solving and stop on a non-zero return.
+  void set_time_limit_seconds(uint32_t lim) override
+  {
+    time_limit_seconds = lim;
+  }
+
 protected:
   resultt do_prop_solve(const bvt &assumptions) override;
 
   void *solver;
+
+  uint32_t time_limit_seconds = 0;
+  std::chrono::steady_clock::time_point deadline;
+
+  /// Static thunk passed to `ipasir_set_terminate`. Its `data` is the
+  /// owning solver instance; returns 1 once the per-call deadline has
+  /// been reached.
+  static int terminate_callback(void *data);
 };
 
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_IPASIR_H

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -47,13 +47,13 @@ public:
     return true;
   }
 
-  /// \copydoc propt::set_time_limit_seconds
+  /// \copydoc propt::set_time_limit_milliseconds
   /// Implemented by registering an `ipasir_set_terminate` callback that
   /// returns non-zero once the deadline has passed; IPASIR solvers poll
   /// the callback during solving and stop on a non-zero return.
-  void set_time_limit_seconds(uint32_t lim) override
+  void set_time_limit_milliseconds(uint32_t lim) override
   {
-    time_limit_seconds = lim;
+    time_limit_milliseconds = lim;
   }
 
 protected:
@@ -61,7 +61,6 @@ protected:
 
   void *solver;
 
-  uint32_t time_limit_seconds = 0;
   std::chrono::steady_clock::time_point deadline;
 
   /// Static thunk passed to `ipasir_set_terminate`. Its `data` is the

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -8,18 +8,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "satcheck_minisat2.h"
 
-#ifndef _WIN32
-#  include <signal.h>
-#  include <unistd.h>
-#endif
-
-#include <limits>
-
 #include <util/invariant.h>
 #include <util/threeval.h>
 
 #include <minisat/core/Solver.h>
 #include <minisat/simp/SimpSolver.h>
+
+#include <chrono> // IWYU pragma: keep
+#include <condition_variable>
+#include <limits>
+#include <mutex>
+#include <thread>
 
 #ifndef l_False
 #  define l_False Minisat::l_False
@@ -191,22 +190,18 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
   }
 }
 
-#ifndef _WIN32
-
-static Minisat::Solver *solver_to_interrupt=nullptr;
-
-static void interrupt_solver(int signum)
-{
-  (void)signum; // unused parameter -- just removing the name trips up cpplint
-  solver_to_interrupt->interrupt();
-}
-
-#endif
-
 template <typename T>
 propt::resultt satcheck_minisat2_baset<T>::do_prop_solve(const bvt &assumptions)
 {
   PRECONDITION(status != statust::ERROR);
+
+  // Clear any interrupt flag left over from a previous solve. The watchdog
+  // thread may have called interrupt() in the small race window where the
+  // previous solveLimited() was already returning; MiniSat latches that flag
+  // (asynch_interrupt) until cleared, so without this the next solve on the
+  // same checker -- e.g. under --all-properties / --cover / incremental
+  // loops -- would immediately fail with P_ERROR.
+  clear_interrupt();
 
   log.statistics() << (no_variables() - 1) << " variables, "
                    << solver->nClauses() << " clauses" << messaget::eom;
@@ -240,40 +235,66 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve(const bvt &assumptions)
 
     using Minisat::lbool;
 
-#ifndef _WIN32
+    // Spawn a watchdog thread that will fire after time_limit_milliseconds
+    // and call interrupt() on the solver. The watchdog uses a condition
+    // variable so it exits cleanly when the solver finishes within the
+    // budget. This is portable across operating systems (no SIGALRM
+    // dependency) and supports sub-second granularity.
+    //
+    // The watchdog must be joined before its thread object goes out of
+    // scope, even if solveLimited throws (e.g., Minisat::OutOfMemoryException
+    // is caught a few lines below).  A thread destroyed while joinable
+    // calls std::terminate.  A small RAII guard handles this for both the
+    // normal and exceptional return paths.
+    std::thread watchdog;
+    std::mutex watchdog_mutex;
+    std::condition_variable watchdog_cv;
+    bool solve_done = false;
 
-    void (*old_handler)(int) = SIG_ERR;
-
-    if(time_limit_seconds != 0)
+    struct watchdog_joinert
     {
-      solver_to_interrupt = solver.get();
-      old_handler = signal(SIGALRM, interrupt_solver);
-      if(old_handler == SIG_ERR)
-        log.warning() << "Failed to set solver time limit" << messaget::eom;
-      else
-        alarm(time_limit_seconds);
+      std::thread &watchdog;
+      std::mutex &watchdog_mutex;
+      std::condition_variable &watchdog_cv;
+      bool &solve_done;
+
+      ~watchdog_joinert()
+      {
+        if(!watchdog.joinable())
+          return;
+        {
+          std::lock_guard<std::mutex> lk(watchdog_mutex);
+          solve_done = true;
+        }
+        watchdog_cv.notify_one();
+        watchdog.join();
+      }
+    } watchdog_joiner{watchdog, watchdog_mutex, watchdog_cv, solve_done};
+
+    if(time_limit_milliseconds != 0)
+    {
+      watchdog = std::thread(
+        [this, &watchdog_mutex, &watchdog_cv, &solve_done]
+        {
+          std::unique_lock<std::mutex> lk(watchdog_mutex);
+          const auto deadline =
+            std::chrono::milliseconds(time_limit_milliseconds);
+          if(!watchdog_cv.wait_for(lk, deadline, [&] { return solve_done; }))
+          {
+            // Timed out before solve completed: interrupt the solver.
+            // Minisat::Solver::interrupt() sets an internal flag that
+            // is polled in the solving loop and is safe to invoke from
+            // another thread.
+            solver->interrupt();
+          }
+        });
     }
 
     lbool solver_result = solver->solveLimited(solver_assumptions);
 
-    if(old_handler != SIG_ERR)
-    {
-      alarm(0);
-      signal(SIGALRM, old_handler);
-      solver_to_interrupt = solver.get();
-    }
-
-#else // _WIN32
-
-    if(time_limit_seconds != 0)
-    {
-      log.warning() << "Time limit ignored (not supported on Win32 yet)"
-                    << messaget::eom;
-    }
-
-    lbool solver_result = solver->solve(solver_assumptions) ? l_True : l_False;
-
-#endif
+    // The watchdog thread (if any) is signalled and joined by
+    // watchdog_joiner's destructor on every return path, including the
+    // OutOfMemoryException catch below.
 
     if(solver_result == l_True)
     {
@@ -328,9 +349,7 @@ void satcheck_minisat2_baset<T>::set_assignment(literalt a, bool value)
 template <typename T>
 satcheck_minisat2_baset<T>::satcheck_minisat2_baset(
   message_handlert &message_handler)
-  : cnf_solvert(message_handler),
-    solver(std::make_unique<T>()),
-    time_limit_seconds(0)
+  : cnf_solvert(message_handler), solver(std::make_unique<T>())
 {
 }
 

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -62,16 +62,15 @@ public:
     return true;
   }
 
-  void set_time_limit_seconds(uint32_t lim) override
+  void set_time_limit_milliseconds(uint32_t lim) override
   {
-    time_limit_seconds=lim;
+    time_limit_milliseconds = lim;
   }
 
 protected:
   resultt do_prop_solve(const bvt &) override;
 
   std::unique_ptr<T> solver;
-  uint32_t time_limit_seconds;
 
   void add_variables();
 };

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -132,6 +132,27 @@ decision_proceduret::resultt smt2_dect::dec_solve(const exprt &assumption)
     break;
   }
 
+  if(time_limit_milliseconds != 0)
+  {
+    if(solver == solvert::Z3)
+    {
+      // z3: soft per-query timeout in milliseconds.
+      argv.push_back("-t:" + std::to_string(time_limit_milliseconds));
+    }
+    else if(solver == solvert::CVC5)
+    {
+      // cvc5: per-query time limit in milliseconds.
+      argv.push_back("--tlimit-per=" + std::to_string(time_limit_milliseconds));
+    }
+    else
+    {
+      messaget{message_handler}.warning()
+        << "solver-time-limit is not supported for this SMT2 solver and "
+           "will be ignored"
+        << messaget::eom;
+    }
+  }
+
   int res =
     run(argv[0], argv, stdin_filename, temp_file_stdout(), temp_file_stderr());
 

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_SMT2_SMT2_DEC_H
 #define CPROVER_SOLVERS_SMT2_SMT2_DEC_H
 
+#include <solvers/prop/solver_resource_limits.h>
+
 #include "smt2_conv.h"
 
 class message_handlert;
@@ -22,7 +24,9 @@ protected:
 
 /*! \brief Decision procedure interface for various SMT 2.x solvers
 */
-class smt2_dect : protected smt2_stringstreamt, public smt2_convt
+class smt2_dect : protected smt2_stringstreamt,
+                  public smt2_convt,
+                  public solver_resource_limitst
 {
 public:
   smt2_dect(
@@ -41,9 +45,18 @@ public:
 
   std::string decision_procedure_text() const override;
 
+  /// \copydoc solver_resource_limitst::set_time_limit_milliseconds
+  /// Honoured for solvers that accept a command-line timeout (Z3, cvc5); for
+  /// other SMT2 solvers a warning is logged and the limit is ignored.
+  void set_time_limit_milliseconds(uint32_t lim) override
+  {
+    time_limit_milliseconds = lim;
+  }
+
 protected:
   std::string solver_binary_or_empty;
   message_handlert &message_handler;
+  uint32_t time_limit_milliseconds = 0;
   resultt dec_solve(const exprt &) override;
 
   /// Everything except the footer is cached, so that output files can be

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -110,6 +110,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/prop/bdd_expr.cpp \
        solvers/sat/external_sat.cpp \
        solvers/sat/satcheck_cadical.cpp \
+       solvers/sat/satcheck_ipasir.cpp \
        solvers/sat/satcheck_minisat2.cpp \
        solvers/smt2/smt2_conv.cpp \
        solvers/smt2/smt2irep.cpp \
@@ -313,6 +314,9 @@ EXCLUDED_TESTS += satcheck_minisat2.cpp
 endif
 ifeq ($(CADICAL),)
 EXCLUDED_TESTS += satcheck_cadical.cpp
+endif
+ifeq ($(IPASIR),)
+EXCLUDED_TESTS += satcheck_ipasir.cpp
 endif
 
 N_CATCH_TESTS = $(shell ./count_tests.py --exclude-files "$(EXCLUDED_TESTS)")

--- a/unit/solvers/sat/satcheck_cadical.cpp
+++ b/unit/solvers/sat/satcheck_cadical.cpp
@@ -11,11 +11,15 @@ Author: Peter Schrammel, Michael Tautschnig
 
 #ifdef HAVE_CADICAL
 
-#  include <testing-utils/use_catch.h>
+#  include <util/cout_message.h>
 
 #  include <solvers/prop/literal.h>
 #  include <solvers/sat/satcheck_cadical.h>
-#  include <util/cout_message.h>
+#  include <testing-utils/use_catch.h>
+
+#  include <chrono>
+#  include <cstddef>
+#  include <vector>
 
 SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
 {
@@ -79,6 +83,61 @@ SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
       bvt assumptions;
       REQUIRE(
         satcheck.prop_solve(assumptions) == propt::resultt::P_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A pigeonhole formula PHP(20) and a 200-millisecond time limit")
+  {
+    // Same construction as the satcheck_minisat2 unit test: PHP(N) is
+    // exponentially hard for resolution-based SAT solvers, so a
+    // 200-millisecond time limit is reliably exceeded. Verifies that
+    // the CaDiCaL `Terminator` we install is honoured by the
+    // underlying solver.
+    //
+    // CaDiCaL polls the terminator at decision points; granularity is
+    // therefore "shortly after the deadline". The five-second slack is
+    // a generous bound for slow CI hardware and CaDiCaL's polling
+    // interval.
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    constexpr std::size_t holes = 20;
+    constexpr std::size_t pigeons = holes + 1;
+    std::vector<std::vector<literalt>> x(pigeons);
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      x[p].reserve(holes);
+      for(std::size_t h = 0; h < holes; ++h)
+        x[p].push_back(satcheck.new_variable());
+    }
+    // Each pigeon is in at least one hole.
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      bvt clause = x[p];
+      satcheck.lcnf(clause);
+    }
+    // No two pigeons share a hole.
+    for(std::size_t h = 0; h < holes; ++h)
+      for(std::size_t p1 = 0; p1 < pigeons; ++p1)
+        for(std::size_t p2 = p1 + 1; p2 < pigeons; ++p2)
+        {
+          bvt clause;
+          clause.push_back(!x[p1][h]);
+          clause.push_back(!x[p2][h]);
+          satcheck.lcnf(clause);
+        }
+
+    satcheck.set_time_limit_milliseconds(200);
+
+    THEN("the solver returns P_ERROR (interrupted by the time limit)")
+    {
+      const auto start = std::chrono::steady_clock::now();
+      const auto result = satcheck.prop_solve();
+      const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count();
+      REQUIRE(result == propt::resultt::P_ERROR);
+      REQUIRE(elapsed_ms >= 200);
+      REQUIRE(elapsed_ms < 5000);
     }
   }
 }

--- a/unit/solvers/sat/satcheck_ipasir.cpp
+++ b/unit/solvers/sat/satcheck_ipasir.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************\
+
+Module: Unit tests for satcheck_ipasir
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for satcheck_ipasir, focusing on the time-limit
+/// (`set_time_limit_seconds`) plumbing that hooks into the IPASIR
+/// `ipasir_set_terminate` mechanism.
+
+#ifdef HAVE_IPASIR
+
+#  include <util/cout_message.h>
+
+#  include <solvers/prop/literal.h>
+#  include <solvers/sat/satcheck_ipasir.h>
+#  include <testing-utils/use_catch.h>
+
+#  include <chrono>
+#  include <cstddef>
+#  include <vector>
+
+SCENARIO("satcheck_ipasir", "[core][solvers][sat][satcheck_ipasir]")
+{
+  console_message_handlert message_handler;
+  message_handler.set_verbosity(0);
+
+  GIVEN("A satisfiable formula f")
+  {
+    satcheck_ipasirt satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(f);
+
+    THEN("is indeed satisfiable")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A pigeonhole formula PHP(20) and a 1-second time limit")
+  {
+    // Same construction as the satcheck_minisat2 unit test: PHP(N) is
+    // exponentially hard for resolution-based SAT solvers, so a
+    // 1-second time limit is reliably exceeded. Verifies that the
+    // IPASIR `ipasir_set_terminate` callback we install is honoured
+    // by the underlying solver.
+    satcheck_ipasirt satcheck(message_handler);
+    constexpr std::size_t holes = 20;
+    constexpr std::size_t pigeons = holes + 1;
+    std::vector<std::vector<literalt>> x(pigeons);
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      x[p].reserve(holes);
+      for(std::size_t h = 0; h < holes; ++h)
+        x[p].push_back(satcheck.new_variable());
+    }
+    // Each pigeon is in at least one hole.
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      bvt clause = x[p];
+      satcheck.lcnf(clause);
+    }
+    // No two pigeons share a hole.
+    for(std::size_t h = 0; h < holes; ++h)
+      for(std::size_t p1 = 0; p1 < pigeons; ++p1)
+        for(std::size_t p2 = p1 + 1; p2 < pigeons; ++p2)
+        {
+          bvt clause;
+          clause.push_back(!x[p1][h]);
+          clause.push_back(!x[p2][h]);
+          satcheck.lcnf(clause);
+        }
+
+    satcheck.set_time_limit_seconds(1);
+
+    THEN("the solver returns P_ERROR (interrupted by the time limit)")
+    {
+      const auto start = std::chrono::steady_clock::now();
+      const auto result = satcheck.prop_solve();
+      const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count();
+      // The solver must report P_ERROR (terminate callback fired)
+      // and not have run far past the budget. The 5-second slack is
+      // for slow CI hardware.
+      REQUIRE(result == propt::resultt::P_ERROR);
+      REQUIRE(elapsed_ms < 5000);
+    }
+  }
+}
+
+#endif

--- a/unit/solvers/sat/satcheck_ipasir.cpp
+++ b/unit/solvers/sat/satcheck_ipasir.cpp
@@ -8,7 +8,7 @@ Author: Diffblue Ltd.
 
 /// \file
 /// Unit tests for satcheck_ipasir, focusing on the time-limit
-/// (`set_time_limit_seconds`) plumbing that hooks into the IPASIR
+/// (`set_time_limit_milliseconds`) plumbing that hooks into the IPASIR
 /// `ipasir_set_terminate` mechanism.
 
 #ifdef HAVE_IPASIR
@@ -40,13 +40,13 @@ SCENARIO("satcheck_ipasir", "[core][solvers][sat][satcheck_ipasir]")
     }
   }
 
-  GIVEN("A pigeonhole formula PHP(20) and a 1-second time limit")
+  GIVEN("A pigeonhole formula PHP(20) and a 200-millisecond time limit")
   {
     // Same construction as the satcheck_minisat2 unit test: PHP(N) is
     // exponentially hard for resolution-based SAT solvers, so a
-    // 1-second time limit is reliably exceeded. Verifies that the
-    // IPASIR `ipasir_set_terminate` callback we install is honoured
-    // by the underlying solver.
+    // 200-millisecond time limit is reliably exceeded. Verifies that
+    // the IPASIR `ipasir_set_terminate` callback we install is
+    // honoured by the underlying solver.
     satcheck_ipasirt satcheck(message_handler);
     constexpr std::size_t holes = 20;
     constexpr std::size_t pigeons = holes + 1;
@@ -74,7 +74,7 @@ SCENARIO("satcheck_ipasir", "[core][solvers][sat][satcheck_ipasir]")
           satcheck.lcnf(clause);
         }
 
-    satcheck.set_time_limit_seconds(1);
+    satcheck.set_time_limit_milliseconds(200);
 
     THEN("the solver returns P_ERROR (interrupted by the time limit)")
     {
@@ -88,6 +88,7 @@ SCENARIO("satcheck_ipasir", "[core][solvers][sat][satcheck_ipasir]")
       // and not have run far past the budget. The 5-second slack is
       // for slow CI hardware.
       REQUIRE(result == propt::resultt::P_ERROR);
+      REQUIRE(elapsed_ms >= 200);
       REQUIRE(elapsed_ms < 5000);
     }
   }

--- a/unit/solvers/sat/satcheck_minisat2.cpp
+++ b/unit/solvers/sat/satcheck_minisat2.cpp
@@ -87,12 +87,13 @@ SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
     }
   }
 
-  GIVEN("A pigeonhole formula PHP(20) and a 1-second time limit")
+  GIVEN("A pigeonhole formula PHP(20) and a 200-millisecond time limit")
   {
     // The pigeonhole principle: N+1 pigeons cannot all fit in N holes
     // (one pigeon per hole). For N=20 the resulting CNF is provably
     // exponentially hard for resolution-based SAT solvers (Haken,
-    // 1985), so a 1-second time limit is reliably blown through.
+    // 1985), so a 200-millisecond time limit is reliably blown
+    // through.
     satcheck_minisat_no_simplifiert satcheck(message_handler);
     constexpr std::size_t holes = 20;
     constexpr std::size_t pigeons = holes + 1;
@@ -120,7 +121,7 @@ SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
           satcheck.lcnf(clause);
         }
 
-    satcheck.set_time_limit_seconds(1);
+    satcheck.set_time_limit_milliseconds(200);
 
     THEN("the solver returns P_ERROR (interrupted by the time limit)")
     {
@@ -130,11 +131,33 @@ SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
         std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now() - start)
           .count();
-      // The solver must report P_ERROR (it was interrupted by SIGALRM)
-      // and must not have run far past the 1-second budget. We allow a
-      // 5-second slack to be robust against very slow CI hardware.
+      // The solver must report P_ERROR (it was interrupted by the
+      // watchdog thread) and must not have run far past the
+      // 200-millisecond budget. The 5-second slack is for very slow
+      // CI hardware and any latency in joining the watchdog thread.
+      // The lower bound guards against a regression that fires the
+      // watchdog before the deadline (e.g. a stale interrupt flag).
       REQUIRE(result == propt::resultt::P_ERROR);
+      REQUIRE(elapsed_ms >= 200);
       REQUIRE(elapsed_ms < 5000);
+    }
+  }
+
+  GIVEN("A checker whose interrupt flag has been left set")
+  {
+    // Simulate the race in which the watchdog called interrupt() just as a
+    // previous solve was returning, leaving MiniSat's (sticky) asynch_interrupt
+    // flag latched. do_prop_solve() must clear it, otherwise this trivially
+    // satisfiable solve would spuriously report P_ERROR. This pins down the
+    // --all-properties / --cover / incremental-loop regression.
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(f);
+    satcheck.interrupt();
+
+    THEN("the next solve clears the flag and reports P_SATISFIABLE")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
     }
   }
 }

--- a/unit/solvers/sat/satcheck_minisat2.cpp
+++ b/unit/solvers/sat/satcheck_minisat2.cpp
@@ -11,11 +11,15 @@ Author: Peter Schrammel
 
 #ifdef HAVE_MINISAT2
 
-#  include <testing-utils/use_catch.h>
+#  include <util/cout_message.h>
 
 #  include <solvers/prop/literal.h>
 #  include <solvers/sat/satcheck_minisat2.h>
-#  include <util/cout_message.h>
+#  include <testing-utils/use_catch.h>
+
+#  include <chrono>
+#  include <cstddef>
+#  include <vector>
 
 SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
 {
@@ -80,6 +84,57 @@ SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
       bvt assumptions;
       REQUIRE(
         satcheck.prop_solve(assumptions) == propt::resultt::P_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A pigeonhole formula PHP(20) and a 1-second time limit")
+  {
+    // The pigeonhole principle: N+1 pigeons cannot all fit in N holes
+    // (one pigeon per hole). For N=20 the resulting CNF is provably
+    // exponentially hard for resolution-based SAT solvers (Haken,
+    // 1985), so a 1-second time limit is reliably blown through.
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+    constexpr std::size_t holes = 20;
+    constexpr std::size_t pigeons = holes + 1;
+    std::vector<std::vector<literalt>> x(pigeons);
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      x[p].reserve(holes);
+      for(std::size_t h = 0; h < holes; ++h)
+        x[p].push_back(satcheck.new_variable());
+    }
+    // Each pigeon is in at least one hole.
+    for(std::size_t p = 0; p < pigeons; ++p)
+    {
+      bvt clause = x[p];
+      satcheck.lcnf(clause);
+    }
+    // No two pigeons share a hole.
+    for(std::size_t h = 0; h < holes; ++h)
+      for(std::size_t p1 = 0; p1 < pigeons; ++p1)
+        for(std::size_t p2 = p1 + 1; p2 < pigeons; ++p2)
+        {
+          bvt clause;
+          clause.push_back(!x[p1][h]);
+          clause.push_back(!x[p2][h]);
+          satcheck.lcnf(clause);
+        }
+
+    satcheck.set_time_limit_seconds(1);
+
+    THEN("the solver returns P_ERROR (interrupted by the time limit)")
+    {
+      const auto start = std::chrono::steady_clock::now();
+      const auto result = satcheck.prop_solve();
+      const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count();
+      // The solver must report P_ERROR (it was interrupted by SIGALRM)
+      // and must not have run far past the 1-second budget. We allow a
+      // 5-second slack to be robust against very slow CI hardware.
+      REQUIRE(result == propt::resultt::P_ERROR);
+      REQUIRE(elapsed_ms < 5000);
     }
   }
 }


### PR DESCRIPTION
The pre-existing `--solver-time-limit N` (CLI flag never registered in CBMC's option spec; option-reader added in 38a370c5f7 for use by dependent projects via `options.set_option(...)`) was POSIX-only (POSIX `alarm()`/`SIGALRM`), MiniSat 2 only, with one-second granularity, and untested in CI. This PR makes it work, adds CI tests, and broadens back-end support, in three orthogonal commits:

1. **Wire up `--solver-time-limit` on the CLI; add IPASIR backend support; add CI tests.**
   - Registers `--solver-time-limit` in `OPT_SOLVER` / `HELP_SOLVER` and `parse_solver_options`. `cbmc`, `jbmc`, `goto-synthesizer` and `libcprover-cpp` all pick it up.
   - Adds IPASIR `set_time_limit_seconds` via `ipasir_set_terminate`. Returns `P_ERROR` on interrupt instead of throwing `analysis_exceptiont`, matching the MiniSat 2 backend.
   - New regression test (`regression/cbmc/solver-time-limit/`) on the happy path.
   - New unit-test SCENARIOs (PHP(20) pigeonhole + 1-second deadline) in `unit/solvers/sat/satcheck_minisat2.cpp` and a new `satcheck_ipasir.cpp` (conditional on `HAVE_IPASIR`, exercised by the existing IPASIR/Riss CI job).
   - Documents the flag in `doc/man/cbmc.1`, `jbmc.1`, `goto-synthesizer.1`.

2. **API in milliseconds; portable MiniSat watchdog.**
   - `solver_resource_limitst::set_time_limit_milliseconds` and `propt::set_time_limit_milliseconds` are now the primary virtual API. `set_time_limit_seconds` survives as a non-virtual seconds→ms helper, so external/programmatic callers keep working.
   - The MiniSat 2 back-end replaces `alarm()`/`SIGALRM`/`solver_to_interrupt` with a `std::thread` watchdog: cross-OS portable (incl. Windows, where the old code was a no-op with a warning), sub-millisecond granular, no global signal state, no nesting hazards.

3. **CaDiCaL terminator support.**
   - `satcheck_cadical_baset` gets `set_time_limit_milliseconds` and a nested `terminatort` (a `CaDiCaL::Terminator` polled by the solver during decision steps). On interrupt, returns `P_ERROR` instead of throwing.

After this PR all three SAT back-ends with native interrupt infrastructure (MiniSat 2, IPASIR, CaDiCaL) honour `--solver-time-limit` and `set_time_limit_milliseconds` portably with sub-second granularity; back-ends without (Glucose, PicoSAT, Lingeling, …) inherit the default warning, unchanged.

The unit-test pigeonhole SCENARIOs verify both correct outcome (`P_ERROR`) and timely interrupt (the 200 ms test completes in ~207-208 ms locally, confirming sub-millisecond watchdog accuracy).

This is foundation for a follow-up PR (branch-pruning) that needs sub-second per-check budgets to bound pruning overhead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
