### PR TITLE
boolbv: fix fixedbv-type check in convert_rest for ID_isfinite

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -461,7 +461,7 @@ literalt boolbvt::convert_rest(const exprt &expr)
         !float_utils.is_infinity(bv),
         !float_utils.is_NaN(bv));
     }
-    else if(op.id() == ID_fixedbv)
+    else if(op.type().id() == ID_fixedbv)
       return const_literal(true);
   }
   else if(expr.id()==ID_isinf)


### PR DESCRIPTION
The ID_isfinite branch in boolbvt::convert_rest tested 'op.id() == ID_fixedbv', but ID_fixedbv is a *type* id and op is the operand expression, not a type.  The dead branch never matched and fixedbv operands fell through to SUB::convert_rest, which is not prepared to lower an isfinite expression and would yield an unexpected result or conversion failure.

The neighbouring ID_isnan, ID_isinf, and ID_isnormal branches all correctly use 'op.type().id() == ID_fixedbv'.  Bring ID_isfinite into line.

Pre-existing typo, unrelated to the surrounding refactoring; fixed here because it sits in the immediate neighbourhood of changes to the floatbv branch and to keep the fixedbv handling consistent.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
