### PR TITLE
Support anonymous struct embedding via -fms-extensions

### DIFF
--- a/doc/cprover-manual/goto-cc.md
+++ b/doc/cprover-manual/goto-cc.md
@@ -96,6 +96,13 @@ for i in `find . -name Makefile`; do
 done
 ```
 
+goto-cc honours the `-fms-extensions` flag: when given, it accepts an
+anonymous member that is a *tagged* struct or union (a Microsoft/GCC
+extension used, for instance, throughout the Linux kernel), injecting that
+member's fields into the enclosing struct and accounting for its size.
+Without the flag such a member is ignored, matching the default gcc and
+Clang behaviour.
+
 Here are additional examples on how to use goto-cc:
 
 -   \ref man_goto-cc-linux "Linux Kernel"

--- a/regression/goto-gcc/ms_extensions_anonymous_member/main.c
+++ b/regression/goto-gcc/ms_extensions_anonymous_member/main.c
@@ -1,0 +1,51 @@
+// -fms-extensions: a *tagged* struct/union used as an unnamed (anonymous)
+// member.  Its members are injected into the enclosing struct and it
+// contributes its size.  Used pervasively in the Linux kernel (e.g.
+// struct __filename_head embedded in struct filename, whose static_asserts
+// require the size to be exact).  The _Static_asserts here are checked at
+// conversion time, so this fails to compile unless the anonymous tagged
+// member is laid out correctly.  Member types are deliberately fixed-width
+// (no pointers, no long) so the expected sizes are identical on 32-bit and
+// 64-bit targets.
+struct head
+{
+  int name;
+  int refcnt;
+  int aname;
+};
+
+struct filename
+{
+  struct head; // anonymous tagged-struct member
+  char iname[20];
+};
+
+_Static_assert(sizeof(struct head) == 12, "head size");
+_Static_assert(sizeof(struct filename) == 32, "filename size");
+_Static_assert(
+  __builtin_offsetof(struct filename, iname) == 12,
+  "iname offset");
+
+// a tagged union as an anonymous member, too
+struct u_outer
+{
+  union inner
+  {
+    int i;
+    char c[4];
+  };
+  int tail;
+};
+_Static_assert(sizeof(struct u_outer) == 8, "union-anon size");
+
+int main(void)
+{
+  struct filename f;
+  f.refcnt = 7; // inner field reachable through the anonymous member
+  f.name = 0;
+
+  struct u_outer u;
+  u.i = 3; // inner union field reachable
+
+  return f.refcnt + u.i;
+}

--- a/regression/goto-gcc/ms_extensions_anonymous_member/test.desc
+++ b/regression/goto-gcc/ms_extensions_anonymous_member/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+-fms-extensions -c -o main.gb
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+With -fms-extensions, goto-cc must accept a *tagged* struct/union as an
+anonymous member: it contributes its size and injects its members. The
+_Static_asserts (checked at conversion) require exact layout, and the
+field accesses require member injection. This is the pattern used by the
+Linux kernel's struct filename (struct __filename_head). Member sizes are
+fixed-width so the layout asserts hold on both 32-bit and 64-bit targets.
+Without -fms-extensions the member is ignored (standard GCC), which is
+covered by regression/ansi-c/anonymous_member*.

--- a/regression/goto-gcc/ms_extensions_anonymous_member_ignored/main.c
+++ b/regression/goto-gcc/ms_extensions_anonymous_member_ignored/main.c
@@ -1,0 +1,31 @@
+// Companion to ms_extensions_anonymous_member, compiled WITHOUT
+// -fms-extensions.  Without that flag goto-cc follows standard gcc/Clang
+// behaviour: a *tagged* struct/union used as an anonymous member declares
+// nothing -- it injects no members and contributes no size.  The
+// _Static_assert (checked at conversion time) therefore requires the
+// enclosing struct to be sized as if the tagged member were absent.
+// Member types are fixed-width so the expected size holds on 32-bit and
+// 64-bit targets.
+struct head
+{
+  int name;
+  int refcnt;
+  int aname;
+};
+
+struct filename
+{
+  struct
+    head; // anonymous tagged-struct member: ignored without -fms-extensions
+  char iname[20];
+};
+
+// The tagged member contributes no size, so the struct is just char[20].
+_Static_assert(sizeof(struct filename) == 20, "tagged anon member ignored");
+
+int main(void)
+{
+  struct filename f;
+  (void)f;
+  return 0;
+}

--- a/regression/goto-gcc/ms_extensions_anonymous_member_ignored/test.desc
+++ b/regression/goto-gcc/ms_extensions_anonymous_member_ignored/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+-c -o main.gb
+^EXIT=0$
+^SIGNAL=0$
+declaration does not declare anything
+--
+^CONVERSION ERROR$
+--
+Without -fms-extensions, goto-cc ignores a tagged struct/union used as an
+anonymous member (standard gcc/Clang behaviour): it injects no members and
+contributes no size.  The _Static_assert requires sizeof(struct filename)
+to exclude the tagged member; were the member accepted (as with
+-fms-extensions) the size would differ and conversion would fail.  This is
+the no-flag counterpart of ms_extensions_anonymous_member.

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -986,32 +986,25 @@ void c_typecheck_baset::typecheck_compound_body(
           }
           else
           {
-            // GCC and Clang ignore anything other than an untagged struct or
-            // union; we could print a warning, but there isn't any ambiguity in
-            // semantics here. Printing a warning could elevate this to an error
-            // when compiling code with goto-cc with -Werror.
-            // Note that our type checking always creates a struct_tag/union_tag
-            // type, but only named struct/union types have an ID_tag member.
+            // C11 allows an *untagged* struct/union as an anonymous member.
+            // -fms-extensions (and MSVC) additionally allow a *tagged*
+            // struct/union as an anonymous member, injecting its members
+            // and contributing its size -- used throughout the Linux kernel
+            // (e.g. `struct __filename_head;` embedded in struct filename).
+            // Anything else -- a non-struct/union unnamed member (e.g. a bare
+            // `int;`), or a tagged struct/union without -fms-extensions -- is
+            // ignored (the GCC/Clang behaviour we preserve).
+            const typet &member_type = new_component.type();
             if(
-              new_component.type().id() == ID_struct_tag &&
-              follow_tag(to_struct_tag_type(new_component.type()))
+              member_type.id() != ID_struct_tag &&
+              member_type.id() != ID_union_tag)
+              continue; // not a struct/union: ignore
+            const bool is_untagged =
+              follow_tag(to_struct_or_union_tag_type(member_type))
                 .find(ID_tag)
-                .is_nil())
-            {
-              // ok, anonymous struct
-            }
-            else if(
-              new_component.type().id() == ID_union_tag &&
-              follow_tag(to_union_tag_type(new_component.type()))
-                .find(ID_tag)
-                .is_nil())
-            {
-              // ok, anonymous union
-            }
-            else
-            {
-              continue;
-            }
+                .is_nil();
+            if(!is_untagged && !config.ansi_c.allow_anonymous_struct_embedding)
+              continue; // tagged anonymous member needs -fms-extensions
           }
         }
 

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -579,6 +579,15 @@ int gcc_modet::doit()
     config.ansi_c.wchar_t_is_unsigned=true;
   }
 
+  // -fms-extensions enables MS/GCC extensions such as anonymous members
+  // that are a *tagged* struct/union type (used throughout the Linux
+  // kernel, e.g. struct __filename_head embedded in struct filename).
+  // Only anonymous struct/union embedding is implemented here.
+  // Note: goto_cc_cmdlinet stores long options without the leading '-',
+  // so we query "fms-extensions" (cf. the "fshort-double" check below).
+  if(cmdline.isset("fms-extensions"))
+    config.ansi_c.allow_anonymous_struct_embedding = true;
+
   // -fsingle-precision-constant makes floating-point constants "float"
   // instead of double
   if(cmdline.isset("-fsingle-precision-constant"))

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -867,6 +867,7 @@ bool configt::set(const cmdlinet &cmdline)
   cpp.cpp_standard=cppt::default_cpp_standard();
 
   ansi_c.single_precision_constant=false;
+  ansi_c.allow_anonymous_struct_embedding = false;
   ansi_c.for_has_scope=true; // C99 or later
   ansi_c.ts_18661_3_Floatn_types=false;
   ansi_c.__float128_is_keyword = false;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -168,6 +168,7 @@ public:
     bool bf16_type;               // __bf16 (Clang >= 15, GCC >= 13)
     bool fp16_type;               // __fp16 (GCC >= 4.5 on ARM, Clang >= 6)
     bool single_precision_constant;
+    bool allow_anonymous_struct_embedding; // -fms-extensions (partial)
     enum class c_standardt
     {
       C89,


### PR DESCRIPTION
When -fms-extensions is passed, tagged struct/union members without a declarator name are treated as anonymous embedding (Plan 9 C extension). This allows code using the GCC extension where 'struct tag;' inside another struct inlines the tagged struct's fields.

The implementation lets the tagged anonymous member fall through to the existing anonymous member handling (the $anon naming + set_anonymous pass), rather than skipping it with 'continue'.

Only this one behavior is implemented — no other MSVC or Plan 9 extensions. The internal config field is named
allow_anonymous_struct_embedding to be explicit about scope.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
