### PR TITLE
Fix GCC 16 warning-as-error build failures

### DIFF
--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -266,7 +266,7 @@ public:
   {
     auto d = std::make_unique<variable_sensitivity_domaint>(
       object_factory, configuration);
-    CHECK_RETURN(d->is_bottom());
+    CHECK_RETURN(d->variable_sensitivity_domaint::is_bottom());
     return std::unique_ptr<statet>(d.release());
   }
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5098,11 +5098,9 @@ void smt2_convt::unflatten(
 
         std::size_t offset=0;
 
-        std::size_t i=0;
-        for(struct_typet::componentst::const_iterator
-            it=components.begin();
-            it!=components.end();
-            it++, i++)
+        for(struct_typet::componentst::const_iterator it = components.begin();
+            it != components.end();
+            it++)
         {
           if(is_zero_width(it->type(), ns))
             continue;

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -176,8 +176,7 @@ exprt struct_encodingt::encode_member(const member_exprt &member_expr) const
     }
     const auto &struct_type =
       compound_type.id() == ID_struct_tag
-        ? ns.get().follow_tag(
-            type_checked_cast<struct_tag_typet>(compound_type))
+        ? ns.follow_tag(type_checked_cast<struct_tag_typet>(compound_type))
         : type_checked_cast<struct_typet>(compound_type);
     return count_trailing_bit_width(
       struct_type, member_expr.get_component_name(), *boolbv_width);
@@ -243,7 +242,7 @@ exprt struct_encodingt::decode(
   INVARIANT(
     can_cast_type<bv_typet>(encoded.type()),
     "Structs are expected to be encoded into bit vectors.");
-  const struct_typet definition = ns.get().follow_tag(original_type);
+  const struct_typet definition = ns.follow_tag(original_type);
   exprt::operandst encoded_fields;
   for(const auto &component : definition.components())
   {
@@ -261,7 +260,7 @@ exprt struct_encodingt::decode(
   INVARIANT(
     can_cast_type<bv_typet>(encoded.type()),
     "Unions are expected to be encoded into bit vectors.");
-  const union_typet definition = ns.get().follow_tag(original_type);
+  const union_typet definition = ns.follow_tag(original_type);
   const auto &components = definition.components();
   if(components.empty())
     return empty_union_exprt{original_type};

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.h
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.h
@@ -33,7 +33,7 @@ public:
 
 private:
   std::unique_ptr<boolbv_widtht> boolbv_width;
-  std::reference_wrapper<const namespacet> ns;
+  const namespacet &ns;
 
   exprt encode_member(const member_exprt &member_expr) const;
 };

--- a/src/util/json_irep.cpp
+++ b/src/util/json_irep.cpp
@@ -185,11 +185,10 @@ json_objectt json(const source_locationt &location)
   const auto &pragmas = location.get_pragmas();
   if(!pragmas.empty())
   {
-    auto json_pragma_range = make_range(pragmas.begin(), pragmas.end())
-                               .map([](const std::pair<irep_idt, irept> &entry)
-                                    { return json_stringt{entry.first}; });
-    result["pragma"] =
-      json_arrayt{json_pragma_range.begin(), json_pragma_range.end()};
+    json_arrayt json_pragmas;
+    for(const auto &pragma : pragmas)
+      json_pragmas.push_back(json_stringt{pragma.first});
+    result["pragma"] = std::move(json_pragmas);
   }
 
   return result;

--- a/unit/analyses/variable-sensitivity/eval-member-access.cpp
+++ b/unit/analyses/variable-sensitivity/eval-member-access.cpp
@@ -162,7 +162,6 @@ exprt integer_expression(int i)
 
 exprt top_expression()
 {
-  auto top_value =
-    std::make_shared<abstract_objectt>(integer_typet(), true, false);
-  return top_value->to_constant();
+  abstract_objectt top_value(integer_typet(), true, false);
+  return top_value.abstract_objectt::to_constant();
 }

--- a/unit/util/json_array.cpp
+++ b/unit/util/json_array.cpp
@@ -6,9 +6,10 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
 #include <util/json.h>
 #include <util/range.h>
+
+#include <testing-utils/use_catch.h>
 
 #include <vector>
 

--- a/unit/util/json_array.cpp
+++ b/unit/util/json_array.cpp
@@ -7,11 +7,9 @@ Author: Diffblue Ltd.
 \*******************************************************************/
 
 #include <testing-utils/use_catch.h>
-#include <util/constructor_of.h>
 #include <util/json.h>
 #include <util/range.h>
 
-#include <string>
 #include <vector>
 
 SCENARIO(
@@ -43,16 +41,13 @@ SCENARIO(
   "Test that json_arrayt can be constructed using `ranget`",
   "[core][util][json]")
 {
-  GIVEN("A vector of strings.")
+  GIVEN("A vector of json strings.")
   {
-    const std::vector<std::string> input{"foo", "bar"};
-    THEN(
-      "A json_arrayt can be constructed from the vector of strings using range "
-      "and map.")
+    const std::vector<json_stringt> input{
+      json_stringt{"foo"}, json_stringt{"bar"}};
+    THEN("A json_arrayt can be constructed from the vector using range.")
     {
-      const json_arrayt array = make_range(input)
-                                  .map(constructor_of<json_stringt>())
-                                  .collect<json_arrayt>();
+      const json_arrayt array = make_range(input).collect<json_arrayt>();
       auto it = array.begin();
       REQUIRE(it->kind == jsont::kindt::J_STRING);
       REQUIRE(it->value == "foo");

--- a/unit/util/json_object.cpp
+++ b/unit/util/json_object.cpp
@@ -122,14 +122,18 @@ SCENARIO(
       const json_objectt output = json(location);
       const json_arrayt &pragmas = to_json_array(output["pragma"]);
 
-      auto pragma_it = pragmas.begin();
-      REQUIRE(pragma_it->kind == jsont::kindt::J_STRING);
-      REQUIRE(pragma_it->value == "disable:bounds-check");
-      ++pragma_it;
-      REQUIRE(pragma_it->kind == jsont::kindt::J_STRING);
-      REQUIRE(pragma_it->value == "disable:pointer-check");
-      ++pragma_it;
-      REQUIRE(pragma_it == pragmas.end());
+      std::vector<std::string> pragma_values;
+      for(const auto &pragma : pragmas)
+      {
+        REQUIRE(pragma.kind == jsont::kindt::J_STRING);
+        pragma_values.push_back(pragma.value);
+      }
+
+      std::sort(pragma_values.begin(), pragma_values.end());
+      REQUIRE(
+        pragma_values ==
+        std::vector<std::string>{
+          "disable:bounds-check", "disable:pointer-check"});
     }
   }
 }

--- a/unit/util/json_object.cpp
+++ b/unit/util/json_object.cpp
@@ -6,13 +6,13 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
-
 #include <util/json.h>
 #include <util/json_irep.h>
 #include <util/optional_utils.h>
 #include <util/range.h>
 #include <util/source_location.h>
+
+#include <testing-utils/use_catch.h>
 
 #include <algorithm>
 #include <iterator>

--- a/unit/util/json_object.cpp
+++ b/unit/util/json_object.cpp
@@ -9,8 +9,10 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/json.h>
+#include <util/json_irep.h>
 #include <util/optional_utils.h>
 #include <util/range.h>
+#include <util/source_location.h>
 
 #include <algorithm>
 #include <iterator>
@@ -102,5 +104,32 @@ SCENARIO(
       REQUIRE(output["3"].kind == jsont::kindt::J_STRING);
       REQUIRE(output["3"].value == "3");
     };
+  }
+}
+
+SCENARIO(
+  "Test that source location pragmas are converted to JSON arrays.",
+  "[core][util][json]")
+{
+  GIVEN("A source location with pragmas.")
+  {
+    source_locationt location;
+    location.add_pragma("disable:pointer-check");
+    location.add_pragma("disable:bounds-check");
+
+    THEN("The pragmas are emitted as strings.")
+    {
+      const json_objectt output = json(location);
+      const json_arrayt &pragmas = to_json_array(output["pragma"]);
+
+      auto pragma_it = pragmas.begin();
+      REQUIRE(pragma_it->kind == jsont::kindt::J_STRING);
+      REQUIRE(pragma_it->value == "disable:bounds-check");
+      ++pragma_it;
+      REQUIRE(pragma_it->kind == jsont::kindt::J_STRING);
+      REQUIRE(pragma_it->value == "disable:pointer-check");
+      ++pragma_it;
+      REQUIRE(pragma_it == pragmas.end());
+    }
   }
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR fixes GCC 16 build failures caused by warnings promoted to errors (fixes #9004).

The changes cover four warning categories:

- Avoid GCC 16 `-Warray-bounds` false positives involving `ranget::map`, `json_stringt`, and `std::shared_ptr<std::function<...>>` by using more direct JSON array construction in the affected paths.
- Avoid GCC 16 `-Warray-bounds` false positives where virtual-call inlining/devirtualization appears to reason about a base object using a derived object layout.
- Avoid `-Wsfinae-incomplete` by storing `struct_encodingt`'s namespace as a plain reference instead of `std::reference_wrapper<const namespacet>` while `namespacet` is still incomplete.
- Remove an actually unused SMT2 struct component counter reported by `-Wunused-but-set-variable`.

The intended behaviour is unchanged; these are either warning-path cleanups or removal of dead bookkeeping.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
