### PR TITLE
Constant-fold unsigned division/remainder in bv_utils

### DIFF
--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -24,6 +24,16 @@ bvt bv_utilst::build_constant(const mp_integer &n, std::size_t width)
   return result;
 }
 
+mp_integer bv_utilst::from_constant(const bvt &bv)
+{
+  PRECONDITION(is_constant(bv));
+  const std::size_t width = bv.size();
+  std::string s(width, '0');
+  for(std::size_t i = 0; i < width; i++)
+    s[width - i - 1] = bv[i].is_true() ? '1' : '0';
+  return binary2integer(s, false);
+}
+
 literalt bv_utilst::is_one(const bvt &bv)
 {
   PRECONDITION(!bv.empty());
@@ -1170,18 +1180,10 @@ void bv_utilst::unsigned_divider(
   // (non-deterministic) encoding below.
   if(is_constant(op0) && is_constant(op1))
   {
-    // Reconstruct each operand into mp_integer via binary2integer, mirroring
-    // the inverse used by build_constant (which calls integer2binary).
-    std::string s0(width, '0'), s1(width, '0');
-    for(std::size_t i = 0; i < width; i++)
-    {
-      s0[width - i - 1] = op0[i].is_true() ? '1' : '0';
-      s1[width - i - 1] = op1[i].is_true() ? '1' : '0';
-    }
-    const mp_integer n0 = binary2integer(s0, false);
-    const mp_integer n1 = binary2integer(s1, false);
+    const mp_integer n1 = from_constant(op1);
     if(n1 != 0)
     {
+      const mp_integer n0 = from_constant(op0);
       res = build_constant(n0 / n1, width);
       rem = build_constant(n0 % n1, width);
       return;

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -1161,7 +1161,32 @@ void bv_utilst::unsigned_divider(
   bvt &res,
   bvt &rem)
 {
+  PRECONDITION(op0.size() == op1.size());
   std::size_t width=op0.size();
+
+  // If both operands are constant, compute the result directly so it folds to
+  // constant literals downstream instead of introducing fresh variables and a
+  // multiplier constraint.  Division by zero falls through to the general
+  // (non-deterministic) encoding below.
+  if(is_constant(op0) && is_constant(op1))
+  {
+    // Reconstruct each operand into mp_integer via binary2integer, mirroring
+    // the inverse used by build_constant (which calls integer2binary).
+    std::string s0(width, '0'), s1(width, '0');
+    for(std::size_t i = 0; i < width; i++)
+    {
+      s0[width - i - 1] = op0[i].is_true() ? '1' : '0';
+      s1[width - i - 1] = op1[i].is_true() ? '1' : '0';
+    }
+    const mp_integer n0 = binary2integer(s0, false);
+    const mp_integer n1 = binary2integer(s1, false);
+    if(n1 != 0)
+    {
+      res = build_constant(n0 / n1, width);
+      rem = build_constant(n0 % n1, width);
+      return;
+    }
+  }
 
   // check if we divide by a power of two
   #if 0

--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -29,6 +29,11 @@ public:
 
   static bvt build_constant(const mp_integer &i, std::size_t width);
 
+  /// Returns the unsigned integer value of the constant bitvector \p bv.
+  /// This is the inverse of \ref build_constant for non-negative values.
+  /// \pre all literals in \p bv are constant (see \ref is_constant)
+  static mp_integer from_constant(const bvt &bv);
+
   bvt incrementer(const bvt &op, literalt carry_in);
   bvt inc(const bvt &op) { return incrementer(op, const_literal(true)); }
   void incrementer(bvt &op, literalt carry_in, literalt &carry_out);

--- a/unit/solvers/flattening/bv_utils.cpp
+++ b/unit/solvers/flattening/bv_utils.cpp
@@ -17,7 +17,9 @@ Author: Daniel Kroening
 #include <util/symbol_table.h>
 
 #include <solvers/flattening/boolbv.h>
+#include <solvers/flattening/bv_utils.h>
 #include <solvers/sat/satcheck.h>
+#include <testing-utils/message.h>
 #include <testing-utils/use_catch.h>
 
 SCENARIO("1-bit signed less-than", "[core][solvers][flattening][bv_utils]")
@@ -79,6 +81,112 @@ SCENARIO("1-bit signed less-than", "[core][solvers][flattening][bv_utils]")
     {
       boolbv << less_than_or_equal_exprt(x, y);
       REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+}
+
+SCENARIO(
+  "unsigned_divider folds constant operands",
+  "[core][solvers][flattening][bv_utils]")
+{
+  GIVEN("a bv_utilst over a SAT back-end")
+  {
+    satcheckt satcheck(null_message_handler);
+    bv_utilst bv_utils(satcheck);
+    const std::size_t width = 32;
+
+    WHEN("dividing two constants 100 / 7")
+    {
+      bvt res, rem;
+      bv_utils.divider(
+        bv_utilst::build_constant(100, width),
+        bv_utilst::build_constant(7, width),
+        res,
+        rem,
+        bv_utilst::representationt::UNSIGNED);
+
+      THEN("the result is constant (no fresh variables) and correct")
+      {
+        REQUIRE(bv_utilst::is_constant(res));
+        REQUIRE(bv_utilst::is_constant(rem));
+        REQUIRE(res == bv_utilst::build_constant(14, width));
+        REQUIRE(rem == bv_utilst::build_constant(2, width));
+      }
+    }
+
+    WHEN("dividing a constant by a non-constant divisor")
+    {
+      bvt res, rem;
+      bv_utils.divider(
+        bv_utilst::build_constant(100, width),
+        satcheck.new_variables(width),
+        res,
+        rem,
+        bv_utilst::representationt::UNSIGNED);
+
+      THEN("the fast path is bypassed and the result is non-constant")
+      {
+        // The is_constant(op0) && is_constant(op1) guard must remain
+        // a conjunction: a non-constant divisor must not be folded.
+        REQUIRE_FALSE(bv_utilst::is_constant(res));
+        REQUIRE_FALSE(bv_utilst::is_constant(rem));
+      }
+    }
+
+    WHEN("exact division 100 / 5")
+    {
+      bvt res, rem;
+      bv_utils.divider(
+        bv_utilst::build_constant(100, width),
+        bv_utilst::build_constant(5, width),
+        res,
+        rem,
+        bv_utilst::representationt::UNSIGNED);
+
+      THEN("the result is constant with quotient 20 and rem 0")
+      {
+        REQUIRE(bv_utilst::is_constant(res));
+        REQUIRE(bv_utilst::is_constant(rem));
+        REQUIRE(res == bv_utilst::build_constant(20, width));
+        REQUIRE(rem == bv_utilst::build_constant(0, width));
+      }
+    }
+
+    WHEN("dividing by one")
+    {
+      bvt res, rem;
+      bv_utils.divider(
+        bv_utilst::build_constant(100, width),
+        bv_utilst::build_constant(1, width),
+        res,
+        rem,
+        bv_utilst::representationt::UNSIGNED);
+
+      THEN("res equals the numerator and rem is zero")
+      {
+        REQUIRE(bv_utilst::is_constant(res));
+        REQUIRE(bv_utilst::is_constant(rem));
+        REQUIRE(res == bv_utilst::build_constant(100, width));
+        REQUIRE(rem == bv_utilst::build_constant(0, width));
+      }
+    }
+
+    WHEN("dividing a constant by a constant zero")
+    {
+      bvt res, rem;
+      bv_utils.divider(
+        bv_utilst::build_constant(100, width),
+        bv_utilst::build_constant(0, width),
+        res,
+        rem,
+        bv_utilst::representationt::UNSIGNED);
+
+      THEN("the fall-through (nondeterministic) encoding is used")
+      {
+        // division by zero must not be folded; it keeps fresh variables
+        REQUIRE_FALSE(bv_utilst::is_constant(res));
+        REQUIRE_FALSE(bv_utilst::is_constant(rem));
+      }
     }
   }
 }


### PR DESCRIPTION
bv_utilst::unsigned_divider always allocated fresh variables for the quotient and remainder, with a quotient*divisor + rem == dividend multiplier constraint, even when both operands are constant.  The result was therefore never a constant literal, so a constant division feeding a later multiply produced a (hard) variable*variable multiplier instead of folding away.

Add a fast path: when both operands are constant (and the divisor is non-zero), compute the quotient and remainder directly as constants. Division by zero falls through to the existing nondeterministic encoding, so semantics are unchanged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
