### PR TITLE
Incremental SMT2: Remove unnecessary #if 0 for floating-point modulo

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1658,12 +1658,6 @@ static smt_termt dispatch_expr_to_smt_conversion(
   {
     return convert_expr_to_smt(*multiply, converted);
   }
-#if 0
-  else if(expr.id() == ID_floatbv_rem)
-  {
-    convert_floatbv_rem(to_binary_expr(expr));
-  }
-#endif
   if(const auto address_of = expr_try_dynamic_cast<address_of_exprt>(expr))
   {
     return convert_expr_to_smt(*address_of, converted, object_map);


### PR DESCRIPTION
All floating-point operations are handled via an earlier branch, even if changed to `#if 1` it would remain dead code. #8922 added full floating-point support to the incremental SMT2 back-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
