### PR TITLE
smt2: add missing separator in bvfromfloat equality assertion

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5726,7 +5726,7 @@ void smt2_convt::find_symbols(const exprt &expr)
       const auto &floatbv_type = to_floatbv_type(tc.op().type());
       out << "(assert (= ";
       out << "((_ to_fp " << floatbv_type.get_e() << " "
-          << floatbv_type.get_f() + 1 << ") " << id << ')';
+          << floatbv_type.get_f() + 1 << ") " << id << ") ";
       convert_expr(tc.op());
       out << ')'; // =
       out << ')' << '\n';


### PR DESCRIPTION
The `bvfromfloat` mechanism in smt2_convt::find_symbols emits, for a bit-wise `typecast` from an FPA-encoded float to a bit-vector, an assertion of the form

  (assert (= ((_ to_fp e f) <bv>)<float>))

with no whitespace between the closing parenthesis of the `to_fp` application and the second operand of the equality.  Most SMT-LIB tokenizers treat `)` as a token boundary, but CPROVER's own smt2 tokenizer does not, so it reads `)|float|` as a single (invalid) token and rejects the assertion.

This path is only reached when reading the raw bytes of an FPA-encoded float (e.g. a union-based bit access under --cprover-smt2 or an FPA solver), which is itself subject to other backend limitations, so the bug was latent.  Emit the missing space.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
