### PR TITLE
Avoid host C library headers in cbmc-cover built-ins/location tests

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -809,7 +809,12 @@ jobs:
           path: .ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
   # This job takes approximately 49 to 70 minutes
-  check-vs-2025-cmake-build-and-test:
+  # Note: as of June 2026 the "windows-2025" runner label is being migrated to
+  # the Windows Server 2025 image that ships Visual Studio 2026 (MSVC 14.5x)
+  # instead of VS 2022/2025 (MSVC 14.4x); see actions/runner-images#14017.
+  # During the rollout both images are served under this label, so this job may
+  # run on either toolset.
+  check-vs-2026-cmake-build-and-test:
     runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/regression/cbmc-cover/built-ins1/main.c
+++ b/regression/cbmc-cover/built-ins1/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+__CPROVER_size_t strlen(const char *);
 
 int main()
 {

--- a/regression/cbmc-cover/built-ins2/main.c
+++ b/regression/cbmc-cover/built-ins2/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+void *memset(void *, int, __CPROVER_size_t);
 
 struct mystruct {
   int x;

--- a/regression/cbmc-cover/built-ins4/main.c
+++ b/regression/cbmc-cover/built-ins4/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+__CPROVER_size_t strlen(const char *);
 
 int main()
 {

--- a/regression/cbmc-cover/built-ins5/main.c
+++ b/regression/cbmc-cover/built-ins5/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+__CPROVER_size_t strlen(const char *);
 
 int main()
 {

--- a/regression/cbmc-cover/built-ins6/main.c
+++ b/regression/cbmc-cover/built-ins6/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+__CPROVER_size_t strlen(const char *);
 
 int main()
 {

--- a/regression/cbmc-cover/built-ins7/main.c
+++ b/regression/cbmc-cover/built-ins7/main.c
@@ -1,4 +1,4 @@
-#include <string.h>
+__CPROVER_size_t strlen(const char *);
 
 int main()
 {

--- a/regression/cbmc-cover/location2/main.c
+++ b/regression/cbmc-cover/location2/main.c
@@ -1,8 +1,9 @@
-#include <string.h>
+void *memset(void *, int, __CPROVER_size_t);
 
 #define BUFLEN 100
 
-static void *(*const volatile memset_func)(void *, int, size_t) = memset;
+static void *(*const volatile memset_func)(void *, int, __CPROVER_size_t) =
+  memset;
 
 int main()
 {

--- a/regression/cbmc-cover/location2/test.desc
+++ b/regression/cbmc-cover/location2/test.desc
@@ -3,12 +3,12 @@ main.c
 --cover location
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.coverage.1\] file main.c line 9 function main block 1 \(lines main.c:main:9,10\): SATISFIED$
-^\[main.coverage.3\] file main.c line 11 function main block 3 \(lines main.c:main:11\): SATISFIED$
+^\[main.coverage.1\] file main.c line 10 function main block 1 \(lines main.c:main:10,11\): SATISFIED$
+^\[main.coverage.3\] file main.c line 12 function main block 3 \(lines main.c:main:12\): SATISFIED$
 ^\*\* 3 of 3 covered \(100.0%\)
 --
 ^warning: ignoring
-main.c::5
+main.c::[56]
 --
 Expressions outside a function should not end up listed as part of source code
 blocks.


### PR DESCRIPTION
The "windows-2025" GitHub Actions runner label is being migrated to the Windows Server 2025 image that ships Visual Studio 2026 (MSVC 14.5x, e.g. 14.51) instead of VS 2022/2025 (MSVC 14.4x); see actions/runner-images#14017. Under the newer toolset the UCRT <string.h>/<corecrt_wstring.h> headers provide inline definitions of the Annex K bounds-checked functions strnlen_s and wcsnlen_s. Those inline bodies enter the goto model, so --cover instruments them and emits extra (unreachable) coverage goals. This changed the goal counts pinned by the cbmc-cover tests built-ins1, 2, 4, 5, 6, 7 and location2, making them fail intermittently depending on which image a job landed on (the failure is unrelated to the code under test).

Replace the system #include with explicit prototypes of just the functions used (strlen/memset), so no host library functions are pulled into the model regardless of toolset. The coverage counts are unchanged (verified on Linux). location2's memset function-pointer type now uses __CPROVER_size_t and is wrapped to stay within 80 columns, which shifts main down by one line; its expected goal line numbers are updated accordingly.

Also document on the check-vs-2025 job that windows-2025 now runs VS 2026.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
