### PR TITLE
Shard the long-running JBMC symex-driven-lazy-loading test suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ regression/solver-hardness/solver-hardness-simple/solver_hardness.json
 regression/goto-instrument-wmm-core/*/*.txt
 regression/goto-instrument-wmm-core/*/*.dot
 jbmc/regression/**/tests.log
-jbmc/regression/**/tests-symex-driven-loading.log
+jbmc/regression/**/tests-symex-driven-loading*.log
 unit/memory-analyzer/input.inc
 unit/memory-analyzer/test.inc
 unit/gdb.txt

--- a/jbmc/regression/Makefile
+++ b/jbmc/regression/Makefile
@@ -27,6 +27,40 @@ $(DIRS):
 	@echo "Running $@..." ;
 	$(MAKE) -C "$@" test || exit 1;
 
+# Suites whose long-running symex-driven-lazy-loading profile is split into
+# shards so it parallelises across workers instead of running as a single job
+# (mirrors the ctest sharding in the CMake build). Each *_SHARDS value lists
+# the shard indices; the shard count is the number of indices.
+SHARDED_DIRS = jbmc-strings jbmc strings-smoke-tests
+jbmc-strings_SHARDS = 1 2 3 4
+jbmc_SHARDS = 1 2 3
+strings-smoke-tests_SHARDS = 1 2
+
+# Expand the directory list into parallel "jobs": non-sharded directories run
+# as a single job (make -C <dir> test); each sharded directory contributes one
+# job for its non-sdll tests (<dir>@normal) plus one job per sdll shard
+# (<dir>@<index>@<count>). The job name encodes the work; the rules below parse
+# it. This keeps the longest suites from serialising a whole worker.
+PLAIN_DIRS = $(filter-out $(SHARDED_DIRS),$(DIRS))
+NORMAL_JOBS = $(foreach d,$(SHARDED_DIRS),$(d)@normal)
+SDLL_JOBS = $(foreach d,$(SHARDED_DIRS),\
+              $(foreach i,$($(d)_SHARDS),$(d)@$(i)@$(words $($(d)_SHARDS))))
+PARALLEL_JOBS = $(PLAIN_DIRS) $(NORMAL_JOBS) $(SDLL_JOBS)
+
+.PHONY: $(NORMAL_JOBS)
+$(NORMAL_JOBS):
+	@suite=`echo "$@" | cut -d@ -f1`; \
+	echo "Running $$suite (non-sdll tests)..."; \
+	$(MAKE) -C "$$suite" test-normal
+
+.PHONY: $(SDLL_JOBS)
+$(SDLL_JOBS):
+	@suite=`echo "$@" | cut -d@ -f1`; \
+	idx=`echo "$@" | cut -d@ -f2`; \
+	cnt=`echo "$@" | cut -d@ -f3`; \
+	echo "Running $$suite (symex-driven-lazy-loading shard $$idx/$$cnt)..."; \
+	$(MAKE) -C "$$suite" test-symex-driven-lazy-loading SHARD=$$idx/$$cnt
+
 # Run all test directories using GNU Parallel
 .PHONY: test-parallel
 .NOTPARALLEL: test-parallel
@@ -40,20 +74,22 @@ test-parallel:
 		--linebuffer \
 		--jobs $(JOBS) \
 		$(MAKE) "{}" \
-		::: $(DIRS)
+		::: $(PARALLEL_JOBS)
 
 # Run all test directories in parallel when invoked with make -j<N>
 # (no GNU Parallel needed).
 # Example: make -j8 test-parallel-jobs
 # Without -j, the directories will run sequentially.
-PARALLEL_DIRS = $(addprefix parallel__,$(DIRS))
-.PHONY: mvn-package test-parallel-jobs $(PARALLEL_DIRS)
+PARALLEL_JOB_TARGETS = $(addprefix parallel__,$(PARALLEL_JOBS))
+.PHONY: mvn-package test-parallel-jobs $(PARALLEL_JOB_TARGETS)
 mvn-package:
 	mvn --quiet clean package -T1C
-test-parallel-jobs: $(PARALLEL_DIRS)
-$(PARALLEL_DIRS): parallel__%: mvn-package
-	@echo "Running $*..."
-	$(MAKE) -C "$*" test
+test-parallel-jobs: $(PARALLEL_JOB_TARGETS)
+# Run each job only after mvn-package has produced the jars; the work happens
+# in a recursive make of the bare job goal (whose recipe has no mvn-package
+# prerequisite, so the same goals are reusable by the GNU Parallel path above).
+$(PARALLEL_JOB_TARGETS): parallel__%: mvn-package
+	+$(MAKE) $*
 
 
 .PHONY: clean

--- a/jbmc/regression/jbmc-strings/CMakeLists.txt
+++ b/jbmc/regression/jbmc-strings/CMakeLists.txt
@@ -2,11 +2,18 @@ add_test_pl_tests(
     "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
-add_test_pl_profile(
+# The symex-driven-lazy-loading run of this suite is the single largest CORE
+# ctest on the macOS runners (~1-1.5h), and a single ctest test runs serially
+# on one worker regardless of `ctest -jN`. Register it as several shards (see
+# test.pl's --shard option) so the pieces run in parallel and the suite stops
+# dominating the job's wall-clock.
+add_sharded_test_pl_profile(
   "jbmc-strings-symex-driven-lazy-loading"
   "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
-  "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
+  "-C;-X;symex-driven-lazy-loading-expected-failure"
   "CORE"
-  )
-set_tests_properties("jbmc-strings-symex-driven-lazy-loading-CORE" PROPERTIES TIMEOUT 10800)
+  "symex-driven-loading"
+  4
+  10800
+)
 set_tests_properties("jbmc-strings-CORE" PROPERTIES TIMEOUT 1800)

--- a/jbmc/regression/jbmc-strings/Makefile
+++ b/jbmc/regression/jbmc-strings/Makefile
@@ -2,9 +2,23 @@ default: tests.log
 
 include ../../src/config.inc
 
-test:
+# SHARD restricts the long-running symex-driven-lazy-loading run to a single
+# shard "<index>/<count>" (see test.pl --shard); the parent Makefile sets it to
+# spread this profile across parallel workers. An empty SHARD runs the whole
+# profile. Each shard writes a distinct log so concurrent shards do not clobber
+# one another.
+SHARD =
+symex_driven_log = symex-driven-loading$(if $(SHARD),-$(firstword $(subst /, ,$(SHARD))))
+symex_driven_opts = -X symex-driven-lazy-loading-expected-failure $(if $(SHARD),--shard $(SHARD)) -s $(symex_driven_log)
+
+.PHONY: test test-normal test-symex-driven-lazy-loading
+test: test-normal test-symex-driven-lazy-loading
+
+test-normal:
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+
+test-symex-driven-lazy-loading:
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" $(symex_driven_opts)
 
 testfuture:
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CF
@@ -28,4 +42,4 @@ show:
 clean:
 	find -name '*.out' -execdir $(RM) '{}' \;
 	find -name '*.gb' -execdir $(RM) '{}' \;
-	$(RM) tests.log tests-symex-driven-loading.log
+	$(RM) tests.log tests-symex-driven-loading*.log

--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -2,19 +2,28 @@ add_test_pl_tests(
     "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace"
 )
 
+# note: BDD_GUARDS is supplied as a C++ preprocessor flag (-DBDD_GUARDS via
+# CMAKE_CXX_FLAGS, see COMPILING.md), not as a CMake variable, and nothing
+# define()s it here. if(DEFINED BDD_GUARDS) is therefore effectively always
+# false, so the else() branch (excluding bdd-expected-timeout) always wins.
+# This preserves the pre-existing behaviour rather than implementing a working
+# guards check; do not mistake it for one.
 if(DEFINED BDD_GUARDS)
-    add_test_pl_profile(
-            "jbmc-symex-driven-lazy-loading"
-            "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
-            "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
-            "CORE"
-    )
+    set(symex_driven_exclude "-C;-X;symex-driven-lazy-loading-expected-failure")
 else()
-    add_test_pl_profile(
-            "jbmc-symex-driven-lazy-loading"
-            "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
-            "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout;-s;symex-driven-loading"
-            "CORE"
-    )
+    set(symex_driven_exclude
+        "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout")
 endif()
-set_tests_properties("jbmc-symex-driven-lazy-loading-CORE" PROPERTIES TIMEOUT 4800)
+
+# Shard the long-running symex-driven-lazy-loading run (see test.pl's --shard
+# option) so it runs as several parallel ctest entries instead of one serial
+# test.
+add_sharded_test_pl_profile(
+  "jbmc-symex-driven-lazy-loading"
+  "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
+  "${symex_driven_exclude}"
+  "CORE"
+  "symex-driven-loading"
+  3
+  4800
+)

--- a/jbmc/regression/jbmc/Makefile
+++ b/jbmc/regression/jbmc/Makefile
@@ -2,21 +2,34 @@ default: tests.log
 
 include ../../src/config.inc
 
-test:
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+# SHARD restricts the long-running symex-driven-lazy-loading run to a single
+# shard "<index>/<count>" (see test.pl --shard); the parent Makefile sets it to
+# spread this profile across parallel workers. An empty SHARD runs the whole
+# profile. Each shard writes a distinct log so concurrent shards do not clobber
+# one another.
+SHARD =
+symex_driven_log = symex-driven-loading$(if $(SHARD),-$(firstword $(subst /, ,$(SHARD))))
+# With BDD_GUARDS the bdd-expected-timeout tests are additionally excluded
+# (preserving the historic behaviour of this Makefile).
 ifeq ($(filter %DBDD_GUARDS, $(CXXFLAGS)),)
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+symex_driven_extra_exclude =
 else
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -X bdd-expected-timeout -s symex-driven-loading
+symex_driven_extra_exclude = -X bdd-expected-timeout
 endif
+symex_driven_opts = -X symex-driven-lazy-loading-expected-failure $(symex_driven_extra_exclude) $(if $(SHARD),--shard $(SHARD)) -s $(symex_driven_log)
+
+.PHONY: test test-normal test-symex-driven-lazy-loading
+test: test-normal test-symex-driven-lazy-loading
+
+test-normal:
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+
+test-symex-driven-lazy-loading:
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" $(symex_driven_opts)
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
-ifeq ($(filter %DBDD_GUARDS, $(CXXFLAGS)),)
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
-else
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -X bdd-expected-timeout -s symex-driven-loading
-endif
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure $(symex_driven_extra_exclude) -s symex-driven-loading
 
 show:
 	@for dir in *; do \
@@ -28,7 +41,7 @@ show:
 clean:
 	find -name '*.out' -execdir $(RM) '{}' \;
 	find -name '*.gb' -execdir $(RM) '{}' \;
-	$(RM) tests.log tests-symex-driven-loading.log
+	$(RM) tests.log tests-symex-driven-loading*.log
 
 %.class: %.java ../../src/org.cprover.jar
 	javac -g -cp ../../src/org.cprover.jar:. $<

--- a/jbmc/regression/strings-smoke-tests/CMakeLists.txt
+++ b/jbmc/regression/strings-smoke-tests/CMakeLists.txt
@@ -2,10 +2,15 @@ add_test_pl_tests(
     "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
-add_test_pl_profile(
-    "strings-smoke-tests-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
-    "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
-    "CORE"
+# Shard the long-running symex-driven-lazy-loading run (see test.pl's --shard
+# option) so it runs as several parallel ctest entries instead of one serial
+# test.
+add_sharded_test_pl_profile(
+  "strings-smoke-tests-symex-driven-lazy-loading"
+  "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
+  "-C;-X;symex-driven-lazy-loading-expected-failure"
+  "CORE"
+  "symex-driven-loading"
+  2
+  1800
 )
-set_tests_properties("strings-smoke-tests-symex-driven-lazy-loading-CORE" PROPERTIES TIMEOUT 1800)

--- a/jbmc/regression/strings-smoke-tests/Makefile
+++ b/jbmc/regression/strings-smoke-tests/Makefile
@@ -2,9 +2,23 @@ default: tests.log
 
 include ../../src/config.inc
 
-test:
+# SHARD restricts the long-running symex-driven-lazy-loading run to a single
+# shard "<index>/<count>" (see test.pl --shard); the parent Makefile sets it to
+# spread this profile across parallel workers. An empty SHARD runs the whole
+# profile. Each shard writes a distinct log so concurrent shards do not clobber
+# one another.
+SHARD =
+symex_driven_log = symex-driven-loading$(if $(SHARD),-$(firstword $(subst /, ,$(SHARD))))
+symex_driven_opts = -X symex-driven-lazy-loading-expected-failure $(if $(SHARD),--shard $(SHARD)) -s $(symex_driven_log)
+
+.PHONY: test test-normal test-symex-driven-lazy-loading
+test: test-normal test-symex-driven-lazy-loading
+
+test-normal:
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
-	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+
+test-symex-driven-lazy-loading:
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" $(symex_driven_opts)
 
 testfuture:
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CF
@@ -28,4 +42,4 @@ show:
 clean:
 	find -name '*.out' -execdir $(RM) '{}' \;
 	find -name '*.gb' -execdir $(RM) '{}' \;
-	$(RM) tests.log tests-symex-driven-loading.log
+	$(RM) tests.log tests-symex-driven-loading*.log

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -24,6 +24,26 @@ macro(add_test_pl_profile name cmdline flag profile)
     endif()
 endmacro(add_test_pl_profile)
 
+# Register a test.pl profile split into <shard_count> shards (see test.pl's
+# --shard option) so a long-running suite runs as several parallel ctest
+# entries instead of one indivisible test. <base_flags> are the test.pl flags
+# shared by all shards (excluding -s and --shard, which are appended per
+# shard); each shard is named "<name>-<i>", logs to "<log_suffix>-<i>" and is
+# given the supplied TIMEOUT.
+function(add_sharded_test_pl_profile
+         name cmdline base_flags profile log_suffix shard_count timeout)
+    foreach(shard RANGE 1 ${shard_count})
+        add_test_pl_profile(
+            "${name}-${shard}"
+            "${cmdline}"
+            "${base_flags};--shard;${shard}/${shard_count};-s;${log_suffix}-${shard}"
+            "${profile}"
+        )
+        set_tests_properties("${name}-${shard}-${profile}" PROPERTIES
+            TIMEOUT ${timeout})
+    endforeach()
+endfunction(add_sharded_test_pl_profile)
+
 macro(add_test_pl_tests cmdline)
     get_filename_component(TEST_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
     message(STATUS "Adding tests in directory: ${TEST_DIR_NAME}")

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -300,6 +300,11 @@ sub test($$$$$$$$$$$$) {
   return ($should_fail != $failed);
 }
 
+# Sharding state (set from --shard <index>/<count> during option parsing
+# below). Declared here, before dirs(), so dirs() can see them under strict.
+our $shard_index = 1;
+our $shard_count = 1;
+
 sub dirs() {
   my @list;
 
@@ -308,6 +313,21 @@ sub dirs() {
   closedir CWD;
 
   @list = sort @list;
+
+  # When sharding is enabled (--shard <index>/<count>), keep only the tests
+  # assigned to this shard. The sorted list is distributed round-robin (by
+  # position modulo <count>), which interleaves alphabetically adjacent --
+  # and hence often similarly sized -- tests across shards for a more even
+  # split than contiguous chunks would give. This lets a single large suite
+  # be registered as several independent ctest entries that run in parallel,
+  # reducing the suite's serial wall-clock contribution.
+  if($shard_count > 1) {
+    my @sharded;
+    for my $k (0 .. $#list) {
+      push @sharded, $list[$k] if($k % $shard_count == $shard_index - 1);
+    }
+    @list = @sharded;
+  }
 
   return @list;
 }
@@ -355,6 +375,9 @@ Usage: test.pl -c CMD [OPTIONS] [DIRECTORIES ...]
   --[no]color enable/disable color output; enabled by default unless
               TESTPL_COLOR_OUTPUT is set to 0, in which case it is
               disabled by default.
+  --shard <i>/<n> run only shard <i> (1-based) of <n>; the sorted test list is
+              partitioned round-robin so a heavy suite can be split across
+              several parallel runs
 
 test.pl expects a test.desc file in each subdirectory. The file test.desc
 follows the format specified below. Any line starting with // will be ignored.
@@ -399,9 +422,21 @@ if (exists $ENV{'TESTPL_COLOR_OUTPUT'}) {
   $color_output_enabled = $ENV{'TESTPL_COLOR_OUTPUT'};
 }
 
-GetOptions("D=s" => \%defines, "X=s" => \@exclude_tags, "I=s" => \@include_tags, 'color!' => \$color_output_enabled);
+GetOptions("D=s" => \%defines, "X=s" => \@exclude_tags, "I=s" => \@include_tags, 'color!' => \$color_output_enabled, "shard=s" => \my $shard);
 getopts('c:efi:j:nphCTFKs:S:t:') or &main::HELP_MESSAGE(\*STDOUT, "", $main::VERSION, "");
 $opt_c or &main::HELP_MESSAGE(\*STDOUT, "", $main::VERSION, "");
+
+# --shard <index>/<count>: run only the tests assigned to shard <index> (1-based)
+# out of <count> shards (see dirs() for the round-robin partitioning). Lets a
+# heavy suite be split across several parallel ctest registrations.
+if(defined($shard)) {
+  if($shard =~ m{^([0-9]+)/([0-9]+)$} && $1 >= 1 && $2 >= 1 && $1 <= $2) {
+    $shard_index = $1;
+    $shard_count = $2;
+  } else {
+    die "Invalid --shard '$shard'; expected <index>/<count> with 1 <= index <= count\n";
+  }
+}
 $opt_j = $opt_j || $ENV{'TESTPL_JOBS'} || 0;
 if($opt_j && $opt_j != 1 && !$has_thread_pool) {
   warn "Jobs set but thread pool module not found,\n"


### PR DESCRIPTION
## What

Adds a `--shard <index>/<count>` option to `regression/test.pl` and uses it to split the three long-running JBMC `symex-driven-lazy-loading` regression runs (`jbmc-strings`, `jbmc`, `strings-smoke-tests`) into several independent, parallelisable pieces in both the CMake/ctest and the Makefile test builds.

## Why

On the CI test runners these three runs dominate the regression wall-clock, and because each suite is a single, indivisible unit of scheduling, they cannot be parallelised no matter how many cores are available:

- In both build systems a whole suite is one scheduling unit: a ctest test (`ctest -jN`) or a `DIRS` entry handed to GNU Parallel (`make ... test-parallel JOBS=N`). It therefore runs serially on a single worker.
- On a representative post-merge macOS run the three `symex-driven-lazy-loading` variants accounted for roughly 60% of the total CORE ctest work, and `jbmc-strings-symex-driven-lazy-loading` on its own was the single longest-running test (well over an hour). macOS runners are only 3 cores, so `ctest -j3` is already saturated; the longest suite alone sets a floor on the job's wall-clock that extra parallelism cannot lower, and the `check-macos-14-cmake-clang` job has been intermittently timing out.

Splitting each heavy suite into shards lets the existing `-jN` scheduling spread that work across workers instead of serialising it on one, lowering the floor towards "total work / number of cores".

Note: the absolute timings above are only diagnostic motivation -- macOS runner times vary substantially (tens of percent) run-to-run, so the realised wall-clock improvement is best confirmed from the post-merge CI trend rather than a single before/after pair.

## How

Three commits:

1. `test.pl: add --shard <index>/<count>` -- restricts a run to a round-robin slice (by position modulo `<count>`) of the sorted test directories.  Round-robin interleaves alphabetically adjacent, and hence often similarly sized, tests across shards for a more even split than contiguous chunks. Invalid specifications are rejected.

2. `jbmc/regression: shard ... (CMake)` -- registers each heavy suite as N ctest entries (4 / 3 / 2) via `add_test_pl_profile`, each with a distinct test name, a distinct `-s` log suffix and `--shard i/N`, preserving the CORE label, the tag exclusions (including the `BDD_GUARDS`-dependent `bdd-expected-timeout` exclusion for `jbmc`) and the timeouts.

3. `jbmc/regression: shard ... (Makefile)` -- mirrors the above for the Makefile build used by the make-based CI jobs. Each heavy suite's Makefile gains a shardable `test-symex-driven-lazy-loading` target (and a `test-normal` target for its remaining tests) parameterised by `SHARD=<index>/<count>`; the parent `jbmc/regression/Makefile` expands the heavy suites into one non-sdll job plus N shard jobs, scheduled by both the GNU Parallel (`test-parallel`) and `make -j` (`test-parallel-jobs`) runners.  `.gitignore` and the suites' `clean` targets are updated to cover the per-shard logs.

With an empty `SHARD` / single shard, the emitted `test.pl` command lines are identical to before, so non-CI / local single-suite runs are unaffected.

## Testing

- `test.pl --shard`: verified that the shards form a complete, disjoint partition of a suite's tests (e.g. for `jbmc-strings` the three-way split reproduced the full set with no overlap) and that invalid specifications such as `4/3` are rejected.
- CMake: a `cmake` configure followed by `ctest -N -L CORE` confirms the sharded tests are registered under the CORE label with the correct `--shard` / `-s` arguments and timeouts, that the old un-sharded test names are gone, and that the `jbmc` shards carry `-X bdd-expected-timeout`.
- Makefile: verified the parent job expansion and the per-job dispatch for the plain, `@normal` and shard jobs, the generated `test.pl` command lines (including both `BDD_GUARDS` branches and the unchanged no-shard fallback), and that `mvn package` still runs exactly once before the work.

No new tests are added: this changes only how the existing regression tests are partitioned and scheduled; the same set of tests runs, exercised by the CI regression jobs themselves.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
