### PR TITLE
file_converter: emit a character-array initialiser

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -15,7 +15,7 @@ function(make_inc name)
     get_filename_component(inc_path "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc" DIRECTORY)
     add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
         COMMAND ${CMAKE_COMMAND} -E make_directory ${inc_path}
-        COMMAND file_converter "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" > "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
+        COMMAND file_converter --line "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" > "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" file_converter
     )
 endfunction(make_inc)
@@ -127,6 +127,7 @@ file(GLOB_RECURSE sources "*.cpp" "*.h")
 list(REMOVE_ITEM sources
     "${CMAKE_CURRENT_SOURCE_DIR}/library/converter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/file_converter.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/file_converter.h"
 )
 
 add_library(ansi-c

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -138,7 +138,7 @@ cprover_library.inc: library/converter$(EXEEXT) library/*.c
 	library/converter$(EXEEXT) library/*.c > $@
 
 %.inc: %.h file_converter$(EXEEXT)
-	./file_converter$(EXEEXT) $< > $@
+	./file_converter$(EXEEXT) --line $< > $@
 
 ansi_c_internal_additions$(OBJEXT): $(BUILTIN_FILES)
 

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -18,41 +18,35 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_parser.h"
 
 const char gcc_builtin_headers_types[] =
-  "#line 1 \"gcc_builtin_headers_types.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_types.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_generic[] =
-  "#line 1 \"gcc_builtin_headers_generic.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_generic.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_math[] =
-  "#line 1 \"gcc_builtin_headers_math.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_math.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_mem_string[] =
-  "#line 1 \"gcc_builtin_headers_mem_string.h\"\n"
 // NOLINTNEXTLINE(whitespace/line_length)
 #include "compiler_headers/gcc_builtin_headers_mem_string.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char gcc_builtin_headers_omp[] = "#line 1 \"gcc_builtin_headers_omp.h\"\n"
+const char gcc_builtin_headers_omp[] =
 #include "compiler_headers/gcc_builtin_headers_omp.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char gcc_builtin_headers_tm[] = "#line 1 \"gcc_builtin_headers_tm.h\"\n"
+const char gcc_builtin_headers_tm[] =
 #include "compiler_headers/gcc_builtin_headers_tm.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_ubsan[] =
-  "#line 1 \"gcc_builtin_headers_ubsan.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_ubsan.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_ia32[] =
-  "#line 1 \"gcc_builtin_headers_ia32.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_ia32.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 const char gcc_builtin_headers_ia32_2[] =
@@ -81,41 +75,38 @@ const char gcc_builtin_headers_ia32_9[] =
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_alpha[] =
-  "#line 1 \"gcc_builtin_headers_alpha.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_alpha.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char gcc_builtin_headers_arm[] = "#line 1 \"gcc_builtin_headers_arm.h\"\n"
+const char gcc_builtin_headers_arm[] =
 #include "compiler_headers/gcc_builtin_headers_arm.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_mips[] =
-  "#line 1 \"gcc_builtin_headers_mips.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_mips.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
 const char gcc_builtin_headers_power[] =
-  "#line 1 \"gcc_builtin_headers_power.h\"\n"
 #include "compiler_headers/gcc_builtin_headers_power.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char arm_builtin_headers[] = "#line 1 \"arm_builtin_headers.h\"\n"
+const char arm_builtin_headers[] =
 #include "compiler_headers/arm_builtin_headers.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char cw_builtin_headers[] = "#line 1 \"cw_builtin_headers.h\"\n"
+const char cw_builtin_headers[] =
 #include "compiler_headers/cw_builtin_headers.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char clang_builtin_headers[] = "#line 1 \"clang_builtin_headers.h\"\n"
+const char clang_builtin_headers[] =
 #include "compiler_headers/clang_builtin_headers.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 
-const char cprover_builtin_headers[] = "#line 1 \"cprover_builtin_headers.h\"\n"
+const char cprover_builtin_headers[] =
 #include "cprover_builtin_headers.inc" // IWYU pragma: keep
   ;                                    // NOLINT(whitespace/semicolon)
 
-const char windows_builtin_headers[] = "#line 1 \"windows_builtin_headers.h\"\n"
+const char windows_builtin_headers[] =
 #include "compiler_headers/windows_builtin_headers.inc" // IWYU pragma: keep
   ; // NOLINT(whitespace/semicolon)
 

--- a/src/ansi-c/file_converter.cpp
+++ b/src/ansi-c/file_converter.cpp
@@ -7,54 +7,55 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 /// \file
-/// Convert file contents to C strings
+/// Convert file contents to a C character-array initialiser
 
+#include "file_converter.h"
+
+#include <filesystem>
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
 #include <string>
 
-static void convert_line(const std::string &line)
-{
-  std::cout << "\"";
-
-  for(std::size_t i = 0; i < line.size(); i++)
-  {
-    const char ch = line[i];
-    if(ch == '\\')
-      std::cout << "\\\\";
-    else if(ch == '"')
-      std::cout << "\\\"";
-    else if(ch == '\r' || ch == '\n')
-    {
-    }
-    else if((ch & 0x80) != 0)
-    {
-      std::cout << "\\x" << std::hex << (unsigned(ch) & 0xff) << std::dec;
-    }
-    else
-      std::cout << ch;
-  }
-
-  std::cout << "\\n\"\n";
-}
-
 int main(int argc, char *argv[])
 {
-  std::string line;
+  // --line applies to the input files that follow it: the flag is acted upon
+  // as argv is scanned left to right, so it must precede those files (the
+  // build always passes it first).
+  bool line_marker = false;
+
+  // Emit a character-array initialiser rather than a string literal: string
+  // literals are limited to 65536 characters after concatenation (a limit
+  // clang enforces under -pedantic), whereas a character array has no such
+  // limit. The enclosing braces are supplied here.
+  std::cout << '{';
 
   for(int i = 1; i < argc; ++i)
   {
-    std::ifstream input_file(argv[i]);
+    const std::string arg = argv[i];
+
+    if(arg == "--line")
+    {
+      line_marker = true;
+      continue;
+    }
+
+    std::ifstream input_file(arg);
 
     if(!input_file)
     {
-      std::cerr << "Failed to open " << argv[i] << '\n';
+      std::cerr << "Failed to open " << arg << '\n';
       return 1;
     }
 
-    while(getline(input_file, line))
-      convert_line(line);
+    file_converter_append(
+      input_file,
+      std::cout,
+      line_marker,
+      std::filesystem::path{arg}.filename().string());
   }
+
+  // null terminator, closing brace and a trailing newline
+  std::cout << "0}\n";
 
   return 0;
 }

--- a/src/ansi-c/file_converter.h
+++ b/src/ansi-c/file_converter.h
@@ -1,0 +1,65 @@
+/*******************************************************************\
+
+Module: Convert file contents to C strings
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Convert file contents to a C character-array initialiser
+
+#ifndef CPROVER_ANSI_C_FILE_CONVERTER_H
+#define CPROVER_ANSI_C_FILE_CONVERTER_H
+
+#include <istream>
+#include <string>
+
+/// Emit the bytes of \p s to \p out as comma-separated decimal byte values
+/// (not character literals). A byte with the high bit set is written with a
+/// `(char)` cast so the surrounding braced initialiser is valid regardless of
+/// whether `char` is signed or unsigned -- a brace initialiser would otherwise
+/// reject the narrowing conversion of a value > 127.
+inline void file_converter_emit_bytes(std::ostream &out, const std::string &s)
+{
+  for(const char c : s)
+  {
+    const unsigned char ch = static_cast<unsigned char>(c);
+    if(ch >= 0x80)
+      out << "(char)" << unsigned(ch) << ',';
+    else
+      out << unsigned(ch) << ',';
+  }
+}
+
+/// Append the contents of \p in to \p out as the body of a C character-array
+/// initialiser; the enclosing braces and trailing null terminator are supplied
+/// by the caller. Each input line contributes its bytes followed by a newline
+/// byte (the sole character literal emitted) and a physical line break, so one
+/// output line corresponds to one input line -- this keeps the generated
+/// initialiser diffable and within compiler line-length limits. When
+/// \p line_marker is set, a `#line` directive naming \p file_name is emitted
+/// first so that diagnostics refer to the original file.
+inline void file_converter_append(
+  std::istream &in,
+  std::ostream &out,
+  bool line_marker,
+  const std::string &file_name)
+{
+  if(line_marker)
+  {
+    file_converter_emit_bytes(out, "#line 1 \"" + file_name + "\"\n");
+    out << '\n';
+  }
+
+  std::string line;
+  while(std::getline(in, line))
+  {
+    if(!line.empty() && line.back() == '\r')
+      line.pop_back();
+    file_converter_emit_bytes(out, line);
+    out << "'\\n',\n";
+  }
+}
+
+#endif // CPROVER_ANSI_C_FILE_CONVERTER_H

--- a/src/common
+++ b/src/common
@@ -58,7 +58,7 @@ ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   endif
   LINKLIB = /usr/bin/libtool -static -o $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ $^ $(LIBS)
-  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -std=c++17 -o $@ $^
   ifeq ($(origin CC),default)
     CC     = clang
   endif
@@ -70,7 +70,7 @@ else ifeq ($(filter-out FreeBSD OpenBSD,$(BUILD_ENV_)),)
   CP_CXXFLAGS +=
   LINKLIB = llvm-ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -std=c++17 -o $@ $^
   ifeq ($(origin CC),default)
     CC     = clang
   endif
@@ -81,7 +81,7 @@ else ifeq ($(filter-out FreeBSD OpenBSD,$(BUILD_ENV_)),)
 else
   LINKLIB = ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -std=c++17 -o $@ $^
   ifeq ($(origin CC),default)
     CC     = gcc
     #CC     = icc
@@ -145,7 +145,7 @@ else ifeq ($(BUILD_ENV_),MSVC)
   CP_CXXFLAGS +=
   LINKLIB = lib /NOLOGO /OUT:$@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) /Fe$@ /Z7 /nologo $^ DbgHelp.lib $(LIBS)
-  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) /Fe$@ /nologo /EHsc $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) /std:c++17 /Fe$@ /nologo /EHsc $^
 ifeq ($(origin CC),default)
   CC = cl
 endif

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -50,6 +50,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp \
        ansi-c/allocate_objects.cpp \
        ansi-c/expr2c.cpp \
+       ansi-c/file_converter.cpp \
        ansi-c/type2name.cpp \
        ansi-c/c_typecheck_base.cpp \
        big-int/big-int.cpp \

--- a/unit/ansi-c/file_converter.cpp
+++ b/unit/ansi-c/file_converter.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************\
+
+Module: Unit tests for file_converter
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for the file_converter byte-array generator
+
+#include <ansi-c/file_converter.h>
+#include <testing-utils/use_catch.h>
+
+#include <sstream>
+
+TEST_CASE(
+  "file_converter emits byte-value initialisers",
+  "[core][ansi-c][file_converter]")
+{
+  SECTION("a byte with the high bit set is cast to char")
+  {
+    // {0x80, 'A'}; the cast keeps the initialiser valid for signed char.
+    std::istringstream in(std::string{
+      "\x80"
+      "A",
+      2});
+    std::ostringstream out;
+    file_converter_append(in, out, false, "x");
+    REQUIRE(out.str() == "(char)128,65,'\\n',\n");
+  }
+
+  SECTION("a trailing carriage return is stripped (CRLF input)")
+  {
+    std::istringstream in("ab\r\ncd\r\n");
+    std::ostringstream out;
+    file_converter_append(in, out, false, "x");
+    REQUIRE(out.str() == "97,98,'\\n',\n99,100,'\\n',\n");
+  }
+
+  SECTION("--line emits a #line directive naming the file")
+  {
+    std::istringstream in("z");
+    std::ostringstream out;
+    file_converter_append(in, out, true, "hdr.h");
+    // bytes of `#line 1 "hdr.h"\n`, a physical break, then `z` + newline byte
+    REQUIRE(
+      out.str() ==
+      "35,108,105,110,101,32,49,32,34,104,100,114,46,104,34,10,\n"
+      "122,'\\n',\n");
+  }
+}

--- a/unit/memory-analyzer/gdb_api.cpp
+++ b/unit/memory-analyzer/gdb_api.cpp
@@ -28,9 +28,10 @@ struct compile_test_filet
     std::ofstream of(tmp().c_str());
     REQUIRE(of.is_open());
 
-    of <<
+    const char test_c[] =
 #include <memory-analyzer/test.inc> // IWYU pragma: keep
       ;                             // NOLINT(whitespace/semicolon)
+    of << test_c;
     of.close();
 
     REQUIRE(run("gcc", {"gcc", "-g", "-o", compiled(), tmp()}) == 0);
@@ -84,9 +85,10 @@ void gdb_api_internals_test()
     std::ofstream of(tmp().c_str());
     REQUIRE(of.is_open());
 
-    of <<
+    const char input_txt[] =
 #include <memory-analyzer/input.inc> // IWYU pragma: keep
       ;                              // NOLINT(whitespace/semicolon)
+    of << input_txt;
     of.close();
 
     gdb_api_testt gdb_api(args);


### PR DESCRIPTION
Embed builtin headers as a C character-array initialiser ({ 'a', 'b', ..., 0 }) rather than a string literal. String literals are limited to 65536 characters after concatenation -- a limit clang enforces under -pedantic -- which forced large headers (e.g. the ia32 ones) to be split across several files; a character array has no such limit. The #line directive that the use sites used to prepend as a separate string literal is now baked into the array by file_converter, so each use site is just `const char x[] = #include "x.inc";`.

This unblocks embedding arbitrarily large generated headers and lets the artificially split headers be recombined (done separately).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
