### PR TITLE
string_container: use std::string_view as the interning map key

### DIFF
--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -11,21 +11,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_container.h"
 
-#include <cstring>
 #include <iostream>
 #include <numeric>
-
-string_ptrt::string_ptrt(const char *_s):s(_s), len(strlen(_s))
-{
-}
-
-bool string_ptrt::operator==(const string_ptrt &other) const
-{
-  if(len!=other.len)
-    return false;
-
-  return len==0 || memcmp(s, other.s, len)==0;
-}
+#include <string_view>
 
 string_containert::~string_containert()
 {
@@ -33,9 +21,7 @@ string_containert::~string_containert()
 
 unsigned string_containert::get(std::string_view s)
 {
-  string_ptrt string_ptr(s);
-
-  hash_tablet::iterator it=hash_table.find(string_ptr);
+  hash_tablet::iterator it = hash_table.find(s);
 
   if(it!=hash_table.end())
     return it->second;
@@ -44,9 +30,10 @@ unsigned string_containert::get(std::string_view s)
 
   // these are stable
   string_list.push_back(std::string(s));
-  string_ptrt result(string_list.back());
 
-  hash_table[result]=r;
+  // the key is a view into the stable, interned copy -- not the (possibly
+  // transient) argument
+  hash_table[std::string_view{string_list.back()}] = r;
 
   // these are not
   string_vector.push_back(&string_list.back());

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -12,48 +12,21 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_STRING_CONTAINER_H
 #define CPROVER_UTIL_STRING_CONTAINER_H
 
-#include <list>
-#include <unordered_map>
-#include <vector>
-
 #include "memory_units.h"
 #include "string_hash.h"
 
-class string_ptrt
-{
-public:
-  explicit string_ptrt(const char *_s);
-
-  explicit string_ptrt(std::string_view _s) : s(_s.data()), len(_s.size())
-  {
-  }
-
-  explicit string_ptrt(const std::string &_s) : s(_s.data()), len(_s.size())
-  {
-  }
-
-  // this compares the contents of the string, not the address
-  bool operator==(const string_ptrt &other) const;
-
-  size_t hash() const
-  {
-    return hash_string(s, len);
-  }
-
-private:
-  // s/len are a (pointer, length) pair into externally-owned storage; the
-  // referenced string need not be zero terminated (there is no c_str()).
-  const char *s;
-  size_t len;
-};
+#include <list>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 // NOLINTNEXTLINE(readability/identifiers)
-class string_ptr_hasht
+class string_view_hasht
 {
 public:
-  size_t operator()(const string_ptrt &s) const
+  std::size_t operator()(std::string_view s) const
   {
-    return s.hash();
+    return hash_string(s);
   }
 };
 
@@ -99,8 +72,12 @@ public:
   string_container_statisticst compute_statistics() const;
 
 protected:
+  // The keys are std::string_views into the std::string objects owned by
+  // string_list below; std::list keeps those addresses stable and the interned
+  // strings are never mutated, so the keys remain valid for the lifetime of
+  // the map.
   // the 'unsigned' ought to be size_t
-  typedef std::unordered_map<string_ptrt, unsigned, string_ptr_hasht>
+  typedef std::unordered_map<std::string_view, unsigned, string_view_hasht>
     hash_tablet;
   hash_tablet hash_table;
 


### PR DESCRIPTION
string_ptrt was a (const char*, size_t) pair with content comparison and a hash_string-based hash -- i.e. exactly a std::string_view plus a hasher, and entirely internal to string_containert. Replace it (and string_ptr_hasht) with std::string_view keyed by a thin string_view_hasht that reuses hash_string, so the stored representation, the hash and the comparison are all unchanged.

Performance: end-to-end cbmc timings (develop vs this change, both built with g++ -O2, best of several runs) show no regression -- equal or marginally faster in every scenario:
  - front-end + symex (--program-only, --unwind 401): 0.497s -> 0.496s
  - parse/goto-heavy (600 functions, --program-only): 0.415s -> 0.412s
  - full end-to-end incl. solver (--unwind 401):      0.716s -> 0.711s
A perf profile of the interning-heavy run shows the string-interning hot path
costing about the same (~2.3% of samples before, ~2.1% after), with hash_string
unchanged (0.37% in both) and string_containert::get inlining more cleanly into
the hashtable lookup with the string_view key. An isolated micro-benchmark of
6M lookups put the string_view key within ~2% of string_ptrt, which is within
run-to-run noise and not observable end to end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
