### PR TITLE
util: make irept destruction depth-safe without recursion

### DIFF
--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -233,7 +233,6 @@ protected:
   static dt empty_d;
 
   static void remove_ref(dt *old_data);
-  static void nonrecursive_destructor(dt *old_data);
   void detach();
 
 public:
@@ -547,77 +546,96 @@ void sharing_treet<derivedt, named_subtreest>::remove_ref(dt *old_data)
   if(old_data == &empty_d)
     return;
 
-#if 0
-    nonrecursive_destructor(old_data);
-#else
-
   PRECONDITION(old_data->ref_count != 0);
 
 #ifdef IREP_DEBUG
   std::cout << "R: " << old_data << " " << old_data->ref_count << '\n';
 #endif
 
-  old_data->ref_count--;
-  if(old_data->ref_count == 0)
+  if(--old_data->ref_count != 0)
+    return; // still referenced; nothing to delete (common case)
+
+  // For the overwhelmingly common case of shallow trees, delete recursively:
+  // this is as cheap as the natural recursive destructor (no child detaching
+  // and no work-stack allocation). A thread-local counter tracks the recursion
+  // depth; once it reaches max_recursion_depth we collapse the remainder of the
+  // subtree iteratively instead (below), so that deeply nested ireps cannot
+  // overflow the call stack.
+  //
+  // Recursive destruction uses on the order of a few hundred bytes of stack per
+  // nesting level, so this bound keeps the destructor's own recursion within
+  // roughly 150 KiB: safe even on a small (~1 MiB, e.g. Windows) stack, and
+  // even when remove_ref is entered from an already-deep call stack. (The unit
+  // test in unit/util/irep.cpp deliberately uses a much greater depth: it runs
+  // on the larger default unit-test stack (~8 MiB) and must overflow a
+  // *recursive* destructor there to guard against regressions.)
+  constexpr std::size_t max_recursion_depth = 512;
+  static thread_local std::size_t depth = 0;
+
+  if(depth < max_recursion_depth)
   {
 #ifdef IREP_DEBUG
-    std::cout << "D: " << pretty() << '\n';
+    std::cout << "D: " << old_data->data << '\n';
     std::cout << "DELETING " << old_data->data << " " << old_data << '\n';
     old_data->clear();
     std::cout << "DEALLOCATING " << old_data << "\n";
 #endif
 
-    // may cause recursive call
-    delete old_data;
+    ++depth;
+    delete old_data; // recurses via child destructors into remove_ref
+    --depth;
 
 #ifdef IREP_DEBUG
     std::cout << "DONE\n";
 #endif
+
+    return;
   }
-#endif
-}
 
-/// Does the same as remove_ref, but using an explicit stack instead of
-/// recursion.
-template <typename derivedt, typename named_subtreest>
-void sharing_treet<derivedt, named_subtreest>::nonrecursive_destructor(
-  dt *old_data)
-{
-  std::vector<dt *> stack(1, old_data);
+  // Deep subtree: delete old_data and any descendants that thereby reach zero
+  // references using an explicit stack instead of recursion. Each node's
+  // children are detached (pointed at empty_d) before the node is deleted, so
+  // that deleting it does not recurse back into remove_ref.
+  std::vector<dt *> stack;
+  dt *d = old_data;
 
-  while(!stack.empty())
+  while(true)
   {
-    dt *d = stack.back();
-    stack.erase(--stack.end());
-    if(d == &empty_d)
-      continue;
-
-    INVARIANT(d->ref_count != 0, "All contents of the stack must be in use");
-    d->ref_count--;
-
-    if(d->ref_count == 0)
+    for(typename named_subt::iterator it = d->named_sub.begin();
+        it != d->named_sub.end();
+        it++)
     {
-      stack.reserve(
-        stack.size() + std::distance(d->named_sub.begin(), d->named_sub.end()) +
-        d->sub.size());
-
-      for(typename named_subt::iterator it = d->named_sub.begin();
-          it != d->named_sub.end();
-          it++)
+      dt *const child = it->second.data;
+      it->second.data = &empty_d;
+      if(child != &empty_d)
       {
-        stack.push_back(it->second.data);
-        it->second.data = &empty_d;
+        INVARIANT(
+          child->ref_count != 0, "a reachable irep child must be referenced");
+        if(--child->ref_count == 0)
+          stack.push_back(child);
       }
-
-      for(typename subt::iterator it = d->sub.begin(); it != d->sub.end(); it++)
-      {
-        stack.push_back(it->data);
-        it->data = &empty_d;
-      }
-
-      // now delete, won't do recursion
-      delete d;
     }
+
+    for(typename subt::iterator it = d->sub.begin(); it != d->sub.end(); it++)
+    {
+      dt *const child = it->data;
+      it->data = &empty_d;
+      if(child != &empty_d)
+      {
+        INVARIANT(
+          child->ref_count != 0, "a reachable irep child must be referenced");
+        if(--child->ref_count == 0)
+          stack.push_back(child);
+      }
+    }
+
+    delete d; // children detached above, so this does not recurse
+
+    if(stack.empty())
+      break;
+
+    d = stack.back();
+    stack.pop_back();
   }
 }
 

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -310,3 +310,61 @@ TEST_CASE(
   const irept bar{"bar"};
   REQUIRE(foo == bar);
 }
+
+TEST_CASE(
+  "Destroying a deeply nested irept does not overflow the stack",
+  "[core][utils][irept]")
+{
+  // A chain of ireps this deep, destroyed by naive recursion, overflows the
+  // call stack: a recursive destructor exceeds the default (~8 MiB) unit-test
+  // stack well below this depth. remove_ref must therefore bound its recursion
+  // (it caps recursive deletion at a depth sized for a small ~1 MiB stack) and
+  // collapse the deep remainder iteratively. The depth is kept far below what
+  // memory would allow, so the test stays cheap, while remaining well past
+  // both that recursion bound and the recursive-overflow depth on this stack.
+  const std::size_t depth = 100000;
+
+  SECTION("chain through positional sub")
+  {
+    irept root;
+    for(std::size_t i = 0; i < depth; ++i)
+    {
+      irept parent{ID_symbol};
+      parent.move_to_sub(root); // root becomes parent's child; root left nil
+      root.swap(parent);        // root is now the new outermost node
+    }
+
+    // The chain is `depth` deep (traversed iteratively, not recursively).
+    std::size_t measured = 0;
+    for(const irept *p = &root; !p->get_sub().empty();
+        p = &p->get_sub().front())
+      ++measured;
+    REQUIRE(measured == depth);
+
+    // Destroying the chain (freeing root's deep data) must not overflow the
+    // stack; reaching the next line without crashing is the test.
+    root = irept{};
+    REQUIRE(root.get_sub().empty());
+  }
+
+  SECTION("chain through named_sub")
+  {
+    // Exercises the named_sub branch of the iterative deletion path.
+    irept root;
+    for(std::size_t i = 0; i < depth; ++i)
+    {
+      irept parent{ID_symbol};
+      parent.move_to_named_sub("child", root);
+      root.swap(parent);
+    }
+
+    std::size_t measured = 0;
+    for(const irept *p = &root; !p->get_named_sub().empty();
+        p = &p->get_named_sub().begin()->second)
+      ++measured;
+    REQUIRE(measured == depth);
+
+    root = irept{};
+    REQUIRE(root.get_named_sub().empty());
+  }
+}


### PR DESCRIPTION
Deeply nested ireps (e.g. a deep SMT-LIB let chain) overflow the call stack when the recursive destructor unwinds them. Bound the destruction recursion: remove_ref still deletes recursively -- which is as cheap as the natural recursive destructor for the shallow trees that dominate -- but tracks the recursion depth in a thread-local counter and, once it reaches a fixed bound, collapses the remainder of the subtree with an explicit work stack instead. Only the deep tail pays the cost of detaching children and allocating a work stack; shallow destruction (the overwhelmingly common case) is unaffected, so this avoids the regression on destruction-heavy workloads (symbolic execution and simplification churn) that an always-iterative destructor incurs.

Add a unit test that builds and destroys a chain of ireps far deeper than any plausible call stack; it passes with the bounded destructor and segfaults with a purely recursive one.

Chose a bounded-recursive (hybrid) destructor over an always-iterative one to avoid a regression on destruction-heavy work. SAT-free, destruction-heavy benchmark (`cbmc --program-only` over a tight struct-update loop — symex/simplification churn), median user CPU: recursive baseline 1.71 s, always-iterative 1.84 s (+~8%), this hybrid 1.73 s (+~1%).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
