### PR TITLE
smt2_solver: iterate over operands in expand_function_applications

### DIFF
--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -73,47 +73,57 @@ void smt2_solvert::define_constants()
 
 void smt2_solvert::expand_function_applications(exprt &expr)
 {
-  for(exprt &op : expr.operands())
-    expand_function_applications(op);
-
-  if(expr.id()==ID_function_application)
-  {
-    auto &app=to_function_application_expr(expr);
-
-    if(app.function().id() == ID_symbol)
+  // Replace every function application that has a definition by its
+  // (instantiated) body, bottom-up. exprt::visit_post applies the visitor to
+  // each sub-expression after its operands using an explicit stack rather than
+  // recursion, so this does not overflow the call stack on the deeply-nested
+  // expressions the parser can produce (e.g. chains of thousands of bvand /
+  // store operations in SMT-COMP QF_ABV benchmarks).
+  expr.visit_post(
+    [this](exprt &e)
     {
+      if(e.id() != ID_function_application)
+        return;
+
+      auto &app = to_function_application_expr(e);
+
+      if(app.function().id() != ID_symbol)
+        return;
+
       // look up the symbol
       auto identifier = to_symbol_expr(app.function()).identifier();
       auto f_it = id_map.find(identifier);
 
-      if(f_it != id_map.end())
-      {
-        const auto &f = f_it->second;
+      if(f_it == id_map.end())
+        return;
 
-        DATA_INVARIANT(
-          f.type.id() == ID_mathematical_function,
-          "type of function symbol must be mathematical_function_type");
+      const auto &f = f_it->second;
 
-        const auto &domain = to_mathematical_function_type(f.type).domain();
+      DATA_INVARIANT(
+        f.type.id() == ID_mathematical_function,
+        "type of function symbol must be mathematical_function_type");
 
-        DATA_INVARIANT(
-          domain.size() == app.arguments().size(),
-          "number of parameters must match number of arguments");
+      const auto &domain = to_mathematical_function_type(f.type).domain();
 
-        // Does it have a definition? It's otherwise uninterpreted.
-        if(!f.definition.is_nil())
-        {
-          exprt body = f.definition;
+      DATA_INVARIANT(
+        domain.size() == app.arguments().size(),
+        "number of parameters must match number of arguments");
 
-          if(body.id() == ID_lambda)
-            body = to_lambda_expr(body).application(app.arguments());
+      // Does it have a definition? It's otherwise uninterpreted.
+      if(f.definition.is_nil())
+        return;
 
-          expand_function_applications(body); // rec. call
-          expr = body;
-        }
-      }
-    }
-  }
+      exprt body = f.definition;
+
+      if(body.id() == ID_lambda)
+        body = to_lambda_expr(body).application(app.arguments());
+
+      // The freshly inlined body may itself contain function applications. It
+      // was not part of this traversal, so expand it here. Bodies are typically
+      // shallow -- this is the pre-existing behaviour.
+      expand_function_applications(body);
+      e = body;
+    });
 }
 
 void smt2_solvert::setup_commands()

--- a/unit/util/expr.cpp
+++ b/unit/util/expr.cpp
@@ -34,3 +34,38 @@ SCENARIO("bitfield-expr-is-zero", "[core][util][expr]")
     }
   }
 }
+
+TEST_CASE(
+  "exprt::visit_post handles deeply nested expressions",
+  "[core][util][expr]")
+{
+  // visit_post is an iterative (explicit-stack) post-order traversal. A chain
+  // this deep would overflow the call stack were it implemented recursively --
+  // it is far beyond the depth at which recursion exceeds the default (~8 MiB)
+  // unit-test stack -- yet light enough to stay cheap. Several rewrites rely on
+  // visit_post for exactly this depth-safety (e.g. smt2_solvert's
+  // expand_function_applications).
+  const std::size_t depth = 100000;
+
+  exprt e{ID_symbol};
+  for(std::size_t i = 0; i < depth; ++i)
+  {
+    exprt parent{ID_typecast};
+    parent.add_to_operands(std::move(e));
+    e = std::move(parent);
+  }
+
+  std::size_t visited = 0;
+  e.visit_post([&visited](exprt &) { ++visited; });
+
+  // Dismantle the chain iteratively before it goes out of scope: this branch
+  // does not include the depth-safe irept destructor, so destroying a chain
+  // this deep recursively would overflow the stack.
+  while(!e.operands().empty())
+  {
+    exprt child = std::move(e.operands().front());
+    e = std::move(child);
+  }
+
+  REQUIRE(visited == depth + 1);
+}


### PR DESCRIPTION
expand_function_applications() is a post-order rewrite: for every node, first rewrite the operands, then — if the current node is a function_application with a known definition — substitute it with the (already-rewritten) body. The recursive form overflowed the call stack on deeply-nested inputs produced by the iterative SMT2 parser (e.g. 50k-deep bvand chains in the try5_*.flanagansaxe.smt2 family), which turned into stack overflows in the solver phase for files that the parser now successfully accepts.

Replace the recursion with a two-pass iterative walk:

1. gather all nodes in post-order into an explicit work list, and
2. process them back-to-front, by which point every operand has already been rewritten.

The only residual recursion is on the inlined body of a user-defined function, which is typically shallow; this matches the pre-existing behaviour.

Regression: bf13.smt2 (the single remaining crash in the QF_ABV run with the iterative parser) now runs into the 2 s solver timeout instead of dumping core. The full QF_ABV sweep (15,148 files, 2 s timeout, 2 GB RLIMIT_AS, 32-way parallel) goes from 1 crash to 0.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
