### PR TITLE
ansi-c: treat a constant compound literal as a compile-time constant

### DIFF
--- a/regression/ansi-c/compound_literal_nonconst_static_init/main.c
+++ b/regression/ansi-c/compound_literal_nonconst_static_init/main.c
@@ -1,0 +1,24 @@
+// A static object's initializer must be a compile-time constant.  A compound
+// literal that embeds a non-constant value (here a runtime local) is therefore
+// rejected.  This pins down the operand recursion in
+// c_typecheck_baset::is_constant: ID_compound_literal must not over-approximate
+// constancy.  The accepting counterpart is regression/cbmc/
+// compound_literal_static_init.  Named types are used deliberately to keep the
+// signal on compound-literal constancy (no anonymous-member dependency).
+struct inner
+{
+  int val;
+};
+
+struct rl
+{
+  struct inner lock;
+  int interval;
+};
+
+int main(void)
+{
+  int nonconst;
+  static struct rl r = {.lock = (struct inner){.val = nonconst}, .interval = 5};
+  return r.interval;
+}

--- a/regression/ansi-c/compound_literal_nonconst_static_init/test.desc
+++ b/regression/ansi-c/compound_literal_nonconst_static_init/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+error: expected constant expression
+--
+^VERIFICATION SUCCESSFUL$
+--
+A static initializer embedding a non-constant value through a compound literal
+is not a constant expression and must be rejected.  Guards the operand
+recursion in is_constant from over-approximating compound-literal constancy
+(the accepting counterpart is regression/cbmc/compound_literal_static_init).

--- a/regression/cbmc/compound_literal_static_init/main.c
+++ b/regression/cbmc/compound_literal_static_init/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+
+// A compound literal with constant contents is a valid constant initializer
+// for a static object.  CBMC's is_compile_time_constantt did not list
+// ID_compound_literal, so this failed with "expected constant expression".
+// This is the kernel's DEFINE_RATELIMIT_STATE / pr_*_ratelimited pattern:
+//   static struct ratelimit_state _rs = { .lock = (raw_spinlock_t){...}, ... };
+typedef struct
+{
+  struct
+  {
+    union
+    {
+      int val;
+    };
+  } raw_lock;
+} raw_spinlock_t;
+
+struct rl
+{
+  raw_spinlock_t lock;
+  int interval;
+};
+
+int main(void)
+{
+  static struct rl r = {
+    .lock = (raw_spinlock_t){.raw_lock = {{.val = 0}}},
+    .interval = 5000,
+  };
+  assert(r.interval == 5000);
+  assert(r.lock.raw_lock.val == 0);
+  return 0;
+}

--- a/regression/cbmc/compound_literal_static_init/test.desc
+++ b/regression/cbmc/compound_literal_static_init/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring .*compound_literal
+^CONVERSION ERROR$
+--
+A compound literal with constant contents is a valid constant initializer
+for a static object (kernel DEFINE_RATELIMIT_STATE / pr_*_ratelimited).

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -4747,6 +4747,10 @@ protected:
     {
       return is_constant_address_of(to_address_of_expr(e).object());
     }
+    // For these expressions constancy is exactly the constancy of all
+    // operands, so recurse below.  This covers the aggregates
+    // (ID_struct/ID_union/ID_array) and, likewise, a compound literal, whose
+    // constancy is that of its single initializer operand.
     else if(
       e.id() == ID_typecast || e.id() == ID_array_of || e.id() == ID_plus ||
       e.id() == ID_mult || e.id() == ID_array || e.id() == ID_with ||
@@ -4755,7 +4759,8 @@ protected:
       e.id() == ID_le || e.id() == ID_gt || e.id() == ID_ge ||
       e.id() == ID_if || e.id() == ID_not || e.id() == ID_and ||
       e.id() == ID_or || e.id() == ID_bitnot || e.id() == ID_bitand ||
-      e.id() == ID_bitor || e.id() == ID_bitxor || e.id() == ID_vector)
+      e.id() == ID_bitor || e.id() == ID_bitxor || e.id() == ID_vector ||
+      e.id() == ID_compound_literal)
     {
       return std::all_of(
         e.operands().begin(), e.operands().end(), [this](const exprt &op) {


### PR DESCRIPTION
is_compile_time_constantt did not list ID_compound_literal, so a compound literal with constant contents -- e.g. `(raw_spinlock_t){ .raw_lock = {{ .val = 0 }} }` -- was rejected as a static initializer with "expected constant expression".  This is the kernel's DEFINE_RATELIMIT_STATE / pr_*_ratelimited pattern (a function-static struct ratelimit_state whose .lock field is a compound-literal spinlock initializer), which blocked compiling many kernel objects with goto-cc (net/tipc/link, fs/smb/server/smb2pdu, ...).

A compound literal's constancy is that of its initializer operand, so add ID_compound_literal to the operand-recursing set.

Regression test compound_literal_static_init.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
