### PR TITLE
ansi-c: constant-fold GCC `a ? : b` in constant contexts

### DIFF
--- a/regression/cbmc/gcc_conditional_expr1/main.c
+++ b/regression/cbmc/gcc_conditional_expr1/main.c
@@ -2,9 +2,45 @@
 
 int g, k;
 
+// GCC's `a ? : b` (omitted middle operand) evaluates `a` exactly once at run
+// time, but in a constant context there are no side effects, so it must fold
+// to `(a != 0) ? a : b`.  The constant-context form is the Linux kernel
+// cache-line alignment pattern: __cacheline_group_begin_aligned expands to
+// __attribute__((aligned((__VA_ARGS__ + 0) ? : SMP_CACHE_BYTES))).
+
+// --- constant contexts: the value must fold at compile time ---
+
+// aligned attribute (folded via make_constant)
+struct zero_cond
+{
+  int a;
+  int grp __attribute__((aligned((0 + 0) ?: 64))); // 0 ?: 64 -> aligned 64
+};
+
+struct nonzero_cond
+{
+  int a;
+  int grp __attribute__((aligned((16 + 0) ?: 64))); // 16 ?: 64 -> aligned 16
+};
+
+// array dimensions: make the folded value observable -- a wrong fold yields a
+// negative dimension and fails the build
+int check_nonzero[((16 + 0) ?: 64) == 16 ? 1 : -1];
+int check_zero[((0 + 0) ?: 64) == 64 ? 1 : -1];
+
+// enum values fold via their own path (typecheck_c_enum_type)
+enum e
+{
+  enum_zero = (0 ?: 64),    // -> 64
+  enum_nonzero = (16 ?: 64) // -> 16
+};
+int check_enum_zero[enum_zero == 64 ? 1 : -1];
+int check_enum_nonzero[enum_nonzero == 16 ? 1 : -1];
+
 // See https://gcc.gnu.org/onlinedocs/gcc/Conditionals.html
 int main()
 {
+  // --- run-time contexts: `a` is evaluated exactly once ---
   int r1, r2;
 
   r1= (g++) ? : 2;

--- a/regression/cbmc/gcc_conditional_expr1/test.desc
+++ b/regression/cbmc/gcc_conditional_expr1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$
@@ -6,3 +6,9 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+^CONVERSION ERROR$
+--
+GCC's `a ? : b` (omitted middle operand): `a` is evaluated exactly once at
+run time, and the expression constant-folds in constant contexts (aligned
+attribute, array dimension, enum value), as used by the Linux kernel
+cache-line alignment macros.

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -38,6 +38,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_typecast.h"
 #include "c_typecheck_base.h"
 #include "expr2c.h"
+#include "gcc_conditional_expression.h"
 #include "padding.h"
 #include "type2name.h"
 
@@ -4805,6 +4806,14 @@ protected:
 void c_typecheck_baset::make_constant(exprt &expr)
 {
   source_locationt location = expr.find_source_location();
+
+  // GCC's `a ? : b` (omitted middle operand) is kept as a side-effect
+  // expression for goto-conversion (a is evaluated once).  In a constant
+  // context there are no side effects, so it is equivalent to
+  // `(a != 0) ? a : b`; lower it to an if-expression here so that the
+  // simplifier can fold it (e.g. the kernel's `__aligned((x + 0) ? :
+  // SMP_CACHE_BYTES)` cache-line alignment).
+  lower_gcc_conditional_expressions(expr);
 
   // Floating-point expressions may require a rounding mode.
   // ISO 9899:1999 F.7.2 says that the default is "round to nearest".

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_declaration.h"
 #include "c_qualifiers.h"
 #include "c_typecheck_base.h"
+#include "gcc_conditional_expression.h"
 #include "gcc_types.h"
 #include "padding.h"
 #include "type2name.h"
@@ -619,6 +620,11 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
     // We simplify it, for the benefit of array initialisation.
 
     exprt tmp_size=size;
+    // GCC's `a ? : b` is kept as a side effect for once-only evaluation; in
+    // this constant context there are no side effects, so lower it to an
+    // if-expression that the simplifier below can fold (e.g. a kernel array
+    // sized `(N + 0) ? : DEFAULT`).
+    lower_gcc_conditional_expressions(tmp_size);
     add_rounding_mode(tmp_size);
     simplify(tmp_size, *this);
 
@@ -1313,6 +1319,10 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
     {
       exprt tmp_v=v;
       typecheck_expr(tmp_v);
+      // GCC's `a ? : b` is kept as a side effect for once-only evaluation;
+      // in this constant context there are no side effects, so lower it to
+      // an if-expression that the simplifier below can fold.
+      lower_gcc_conditional_expressions(tmp_v);
       add_rounding_mode(tmp_v);
       simplify(tmp_v, *this);
       if(tmp_v == true)

--- a/src/ansi-c/gcc_conditional_expression.h
+++ b/src/ansi-c/gcc_conditional_expression.h
@@ -1,0 +1,63 @@
+/*******************************************************************\
+
+Module: Lowering of GCC's `a ? : b` conditional expression
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Lowering of GCC's `a ? : b` (omitted middle operand) conditional
+/// expression into an equivalent if-expression.
+
+#ifndef CPROVER_ANSI_C_GCC_CONDITIONAL_EXPRESSION_H
+#define CPROVER_ANSI_C_GCC_CONDITIONAL_EXPRESSION_H
+
+#include <util/invariant.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
+
+/// Lower a single GCC `a ? : b` conditional-expression side effect into the
+/// equivalent `(a != 0) ? a : b` if-expression.  This drops the guarantee
+/// that `a` is evaluated only once, so it is only valid where `a` has no
+/// side effects -- i.e. in constant contexts, or after side effects have
+/// already been removed (as in goto conversion).
+/// \param expr: a side_effect_exprt whose statement is
+///   ID_gcc_conditional_expression and which has exactly two operands
+/// \return the equivalent if-expression, carrying expr's type and location
+inline if_exprt lower_gcc_conditional_expression(const side_effect_exprt &expr)
+{
+  PRECONDITION(expr.get_statement() == ID_gcc_conditional_expression);
+  const binary_exprt &binary = to_binary_expr(expr);
+  if_exprt if_expr{
+    typecast_exprt::conditional_cast(binary.op0(), bool_typet{}),
+    binary.op0(),
+    binary.op1(),
+    expr.type()};
+  if_expr.add_source_location() = expr.source_location();
+  return if_expr;
+}
+
+/// Recursively rewrite every GCC `a ? : b` conditional-expression side effect
+/// in \p expr into `(a != 0) ? a : b` if-expressions.  Only valid in constant
+/// contexts, where the once-only evaluation of `a` is immaterial (there are
+/// no side effects), so that the simplifier can fold the result.
+inline void lower_gcc_conditional_expressions(exprt &expr)
+{
+  for(auto &op : expr.operands())
+    lower_gcc_conditional_expressions(op);
+
+  if(
+    expr.id() == ID_side_effect &&
+    to_side_effect_expr(expr).get_statement() ==
+      ID_gcc_conditional_expression &&
+    expr.operands().size() == 2)
+  {
+    if_exprt if_expr =
+      lower_gcc_conditional_expression(to_side_effect_expr(expr));
+    expr.swap(if_expr);
+  }
+}
+
+#endif // CPROVER_ANSI_C_GCC_CONDITIONAL_EXPRESSION_H

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol.h>
 
 #include <analyses/natural_loops.h>
+#include <ansi-c/gcc_conditional_expression.h>
 
 #include "destructor.h"
 
@@ -834,18 +835,12 @@ goto_convertt::remove_gcc_conditional_expression(
   clean_expr_resultt side_effects;
 
   {
-    auto &binary_expr = to_binary_expr(expr);
-
     // first remove side-effects from condition
     side_effects = clean_expr(to_binary_expr(expr).op0(), mode);
 
     // now we can copy op0 safely
-    if_exprt if_expr(
-      typecast_exprt::conditional_cast(binary_expr.op0(), bool_typet()),
-      binary_expr.op0(),
-      binary_expr.op1(),
-      expr.type());
-    if_expr.add_source_location() = expr.source_location();
+    if_exprt if_expr =
+      lower_gcc_conditional_expression(to_side_effect_expr(expr));
 
     expr.swap(if_expr);
   }


### PR DESCRIPTION
GCC's conditional with omitted middle operand (`a ? : b`) is kept as a side-effect expression (a is evaluated once) for goto-conversion, so the simplifier did not fold it and make_constant rejected it with "expected constant expression". This blocked compiling real kernel objects with goto-cc: __cacheline_group_begin_aligned expands to
  __attribute__((aligned((__VA_ARGS__ + 0) ? : SMP_CACHE_BYTES)))
i.e. an aligned attribute whose value is `0 ? : 64`.

In a constant context there are no side effects, so `a ? : b` is exactly `(a != 0) ? a : b`.  make_constant now lowers any
gcc_conditional_expression side effect to an if-expression before simplifying, letting the existing folding handle it.

Regression test gcc_conditional_expr_constant covers the aligned-attribute constant context for both zero and non-zero conditions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
