### PR TITLE
ansi-c: constant-fold __builtin_strlen of a string literal

### DIFF
--- a/regression/ansi-c/gcc_builtin_strlen_constant/main.c
+++ b/regression/ansi-c/gcc_builtin_strlen_constant/main.c
@@ -1,0 +1,21 @@
+// GCC folds __builtin_strlen of a string literal to its length at compile
+// time.  The Linux kernel relies on this in module_param, which expands to
+// a _Static_assert(sizeof(name) - 1 == __builtin_strlen(name), ...).
+_Static_assert(__builtin_strlen("disable_ertm:bool") == 17, "len 17");
+_Static_assert(
+  sizeof("disable_ertm:bool") - 1 == __builtin_strlen("disable_ertm:bool"),
+  "module_param pattern");
+_Static_assert(__builtin_strlen("") == 0, "empty");
+_Static_assert(__builtin_strlen("a") == 1, "one");
+
+// strlen counts up to the first NUL, not the whole stored literal
+_Static_assert(__builtin_strlen("a\0b") == 1, "embedded NUL");
+
+// also usable as an array size (constant context)
+char buf[__builtin_strlen("hello")];
+_Static_assert(sizeof(buf) == 5, "array size from strlen");
+
+int main(void)
+{
+  return sizeof(buf);
+}

--- a/regression/ansi-c/gcc_builtin_strlen_constant/test.desc
+++ b/regression/ansi-c/gcc_builtin_strlen_constant/test.desc
@@ -1,0 +1,11 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+__builtin_strlen of a string literal must constant-fold (used by the
+Linux kernel module_param _Static_asserts and as array sizes).

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3773,6 +3773,36 @@ exprt c_typecheck_baset::do_special_functions(
 
     return tmp2;
   }
+  else if(identifier == "__builtin_strlen")
+  {
+    // GCC folds __builtin_strlen of a string literal to its length at
+    // compile time; the Linux kernel relies on this in module_param
+    // _Static_asserts (e.g. sizeof(name)-1 == __builtin_strlen(name)).
+    // Fold the literal case here; otherwise fall back to the library
+    // model (runtime strlen) by returning nil.
+    if(expr.arguments().size() != 1)
+    {
+      error().source_location = f_op.source_location();
+      error() << "__builtin_strlen expects one argument" << eom;
+      throw 0;
+    }
+
+    typecheck_function_call_arguments(expr);
+
+    exprt arg = expr.arguments()[0];
+    simplify(arg, *this);
+
+    // Fold only the offset-zero whole-literal shape; anything else (a
+    // non-zero offset, a conditional between literals, or a non-literal
+    // argument) falls back to the library model by returning nil.
+    if(const auto length = string_literal_length(arg))
+    {
+      return from_integer(*length, expr.type())
+        .with_source_location(source_location);
+    }
+    else
+      return nil_exprt{}; // not a literal: use the library model
+  }
   else if(identifier=="__builtin_classify_type")
   {
     // This is a gcc/clang extension that produces an integer

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "c_types.h"
+#include "expr_util.h"
+#include "pointer_expr.h"
 #include "std_expr.h"
 
 static array_typet make_type(const irep_idt &value)
@@ -69,4 +71,36 @@ array_exprt string_constantt::to_array_expr() const
   }
 
   return std::move(dest).with_source_location(*this);
+}
+
+std::optional<mp_integer> string_literal_length(const exprt &expr)
+{
+  // Peel off the (implicit) typecasts inserted by array-to-pointer decay.
+  const exprt &current = skip_typecast(expr);
+
+  // We only fold the bare-literal shape `&literal[0]`.  Any pointer
+  // arithmetic (a non-zero index/offset) or a choice between literals must
+  // not fold to a constant: doing so would silently drop the offset or pick
+  // an arbitrary operand.  Such arguments fall back to the runtime model.
+  const auto address_of = expr_try_dynamic_cast<address_of_exprt>(current);
+  if(address_of == nullptr)
+    return {};
+
+  const auto index = expr_try_dynamic_cast<index_exprt>(address_of->object());
+  if(index == nullptr)
+    return {};
+
+  const auto string = expr_try_dynamic_cast<string_constantt>(index->array());
+  if(string == nullptr)
+    return {};
+
+  const auto offset = numeric_cast<mp_integer>(index->index());
+  if(offset != mp_integer{0})
+    return {};
+
+  // strlen counts the bytes up to (but not including) the first NUL, which
+  // need not be the end of the stored literal (e.g. "a\0b" has length 1).
+  const std::string value = id2string(string->value());
+  const std::size_t nul = value.find('\0');
+  return mp_integer{nul == std::string::npos ? value.size() : nul};
 }

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -9,7 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_STRING_CONSTANT_H
 #define CPROVER_UTIL_STRING_CONSTANT_H
 
+#include "mp_arith.h"
 #include "std_expr.h"
+
+#include <optional>
 
 class string_constantt : public nullary_exprt
 {
@@ -66,5 +69,14 @@ inline string_constantt &to_string_constant(typet &type)
 {
   return to_string_constant((exprt &)type);
 }
+
+/// If \p expr is the offset-zero decay of a string literal -- that is, an
+/// optional sequence of typecasts wrapping `address_of(index(string_constant,
+/// 0))` -- return the length of that literal as `strlen` would compute it: the
+/// number of bytes up to, but not including, the first NUL.  Returns an empty
+/// optional for anything else (a non-zero offset such as `"abc" + 1`, a
+/// conditional between literals, or a non-literal argument), so that callers
+/// can fall back to a runtime model rather than fold to a wrong constant.
+std::optional<mp_integer> string_literal_length(const exprt &expr);
 
 #endif // CPROVER_ANSI_C_STRING_CONSTANT_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -207,6 +207,7 @@ SRC += analyses/ai/ai.cpp \
        util/ssa_expr.cpp \
        util/std_expr.cpp \
        util/string2int.cpp \
+       util/string_constant.cpp \
        util/structured_data.cpp \
        util/string_utils/capitalize.cpp \
        util/string_utils/escape.cpp \

--- a/unit/util/string_constant.cpp
+++ b/unit/util/string_constant.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************\
+
+ Module: Unit tests for string_literal_length
+
+ Author: Michael Tautschnig
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/cmdline.h>
+#include <util/config.h>
+#include <util/pointer_expr.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
+#include <util/string_constant.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("string_literal_length", "[core][util][string_constant]")
+{
+  // string_constantt::make_type uses char_type()/c_index_type(), which require
+  // a configured architecture.
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  // Build the offset-`offset` decay of a string literal: &literal[offset].
+  const auto decay = [](const irep_idt &value, const mp_integer &offset)
+  {
+    return address_of_exprt{index_exprt{
+      string_constantt{value}, from_integer(offset, c_index_type())}};
+  };
+
+  SECTION("empty literal folds to 0")
+  {
+    REQUIRE(string_literal_length(decay("", 0)) == 0);
+  }
+  SECTION("single character folds to 1")
+  {
+    REQUIRE(string_literal_length(decay("a", 0)) == 1);
+  }
+  SECTION("length is counted up to the first embedded NUL")
+  {
+    REQUIRE(string_literal_length(decay(std::string{"a\0b", 3}, 0)) == 1);
+  }
+  SECTION("multi-character literal folds to its length")
+  {
+    REQUIRE(string_literal_length(decay("hello", 0)) == 5);
+  }
+  SECTION("typecasts around the literal are peeled")
+  {
+    const exprt arg =
+      typecast_exprt{decay("hello", 0), pointer_type(char_type())};
+    REQUIRE(string_literal_length(arg) == 5);
+  }
+  SECTION("a non-zero offset does not fold")
+  {
+    REQUIRE_FALSE(string_literal_length(decay("hello", 2)).has_value());
+  }
+  SECTION("a non-literal argument does not fold")
+  {
+    REQUIRE_FALSE(
+      string_literal_length(symbol_exprt{"p", pointer_type(char_type())})
+        .has_value());
+  }
+  SECTION("a conditional between literals does not fold")
+  {
+    const if_exprt cond{
+      symbol_exprt{"c", bool_typet{}}, decay("ab", 0), decay("cdef", 0)};
+    REQUIRE_FALSE(string_literal_length(cond).has_value());
+  }
+}


### PR DESCRIPTION
GCC folds __builtin_strlen("literal") to the length at compile time; CBMC treated it as an (unmodelled) runtime call, so it could not be used in constant contexts -- "expected constant expression". This blocks compiling real kernel objects with goto-cc: module_param expands to
  _Static_assert(sizeof(name) - 1 == __builtin_strlen(name), ...)
(e.g. net/bluetooth/l2cap_core.c, net/wireless/scan.c).

do_special_functions now folds __builtin_strlen when the argument contains a string_constant: it locates the literal in the (simplified) decayed argument and returns its length (array-type size minus the terminating NUL, or the stored value length). Non-literal arguments return nil and fall back to the existing behaviour unchanged.

Regression test gcc_builtin_strlen_constant covers the module_param _Static_assert pattern, empty/one-char literals, and use as an array size.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
