### PR TITLE
goto-cc: fix dead -fsingle-precision-constant query

### DIFF
--- a/regression/goto-gcc/CMakeLists.txt
+++ b/regression/goto-gcc/CMakeLists.txt
@@ -1,5 +1,7 @@
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  set(not_gnu_ld -X gnu-ld-only)
+  # On macOS goto-gcc wraps clang, which does not support gcc-only compiler
+  # flags (e.g. -fsingle-precision-constant), so exclude gcc-only tests too.
+  set(not_gnu_ld -X gnu-ld-only -X gcc-only)
 else()
   set(not_gnu_ld "")
 endif()

--- a/regression/goto-gcc/Makefile
+++ b/regression/goto-gcc/Makefile
@@ -10,7 +10,9 @@ tests.log: ../test.pl
 
 else
 ifeq ($(BUILD_ENV_),OSX)
-  not_gnu_ld = -X gnu-ld-only
+  # On macOS goto-gcc wraps clang, which does not support gcc-only compiler
+  # flags (e.g. -fsingle-precision-constant), so exclude gcc-only tests too.
+  not_gnu_ld = -X gnu-ld-only -X gcc-only
 endif
 test: ../../src/goto-cc/goto-gcc
 	@PATH=../../../scripts:$$PATH \

--- a/regression/goto-gcc/fsingle_precision_constant/main.c
+++ b/regression/goto-gcc/fsingle_precision_constant/main.c
@@ -1,0 +1,21 @@
+// -fsingle-precision-constant makes an unsuffixed floating-point constant
+// `float` instead of the default `double`.  The type of such a constant is
+// therefore sizeof(float) rather than sizeof(double); both sizes are
+// fixed-width, so this holds on 32-bit and 64-bit targets.  The checks are
+// _Static_asserts evaluated at conversion time, so if the flag is silently
+// ignored (as it was before the dead-query fix in gcc_mode) the unsuffixed
+// constant stays `double`, the assertions fail and conversion errors out.
+_Static_assert(sizeof(1.0) == sizeof(float), "unsuffixed constant is float");
+_Static_assert(
+  sizeof(3.14159) == sizeof(float),
+  "unsuffixed constant is float");
+
+// An explicitly suffixed constant keeps its suffix-determined type and is
+// unaffected by the flag.
+_Static_assert(
+  sizeof(1.0L) == sizeof(long double), "long double suffix unaffected");
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/goto-gcc/fsingle_precision_constant/test.desc
+++ b/regression/goto-gcc/fsingle_precision_constant/test.desc
@@ -1,0 +1,13 @@
+CORE gcc-only
+main.c
+-fsingle-precision-constant -c -o main.gb
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$
+--
+With -fsingle-precision-constant an unsuffixed floating-point constant is
+`float` rather than `double`; the _Static_asserts in main.c check this at
+conversion time.  Before the dead-query fix in gcc_mode the flag was
+silently ignored, the constant stayed `double`, and conversion failed --
+so this test fails (CONVERSION ERROR) without the fix.

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -590,7 +590,7 @@ int gcc_modet::doit()
 
   // -fsingle-precision-constant makes floating-point constants "float"
   // instead of double
-  if(cmdline.isset("-fsingle-precision-constant"))
+  if(cmdline.isset("fsingle-precision-constant"))
     config.ansi_c.single_precision_constant=true;
 
   // -fshort-double makes double the same as float


### PR DESCRIPTION
goto_cc_cmdlinet stores long options with a single leading '-' stripped, so the existing isset("-fsingle-precision-constant") (with the dash) never matched and the option was silently dead. Query it as "fsingle-precision-constant", consistent with the other -f options.

Add regression/goto-gcc/fsingle_precision_constant, which compiles with -fsingle-precision-constant and checks via _Static_assert that an unsuffixed floating-point constant is `float` rather than `double`. Before this fix the flag was ignored, the constant stayed `double`, and the assertion (hence conversion) failed -- so the test fails without the fix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
