### PR TITLE
ansi-c: fix self-referential enum from __attribute__((mode)) fallback

### DIFF
--- a/regression/ansi-c/gcc_enum_mode_attribute/main.c
+++ b/regression/ansi-c/gcc_enum_mode_attribute/main.c
@@ -1,0 +1,61 @@
+// gcc allows __attribute__((mode(...))) on enums (clang doesn't).  A mode name
+// may be spelled with or without a surrounding pair of underscores, so "byte"
+// is the same as "__byte__".  For a mode we don't recognise at all we fall
+// back to the enum's underlying bitvector -- crucially NOT the c_enum_tag,
+// which used to make the enum's underlying type its own tag (a cycle) and
+// crashed pointer_offset_bits / alignment.  Seen in kernel/crypto headers
+// (net/rxrpc, crypto/krb5).
+
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
+
+#ifdef __GNUC__
+
+// special-cased, underscored spelling -> 8 bits
+enum E
+{
+  A,
+  B,
+  C
+} __attribute__((mode(__QI__)));
+STATIC_ASSERT(sizeof(enum E) == 1);
+
+// un-underscored spelling of the same mode -> also 8 bits, matching gcc
+// (this is the genuinely new coverage; __QI__ above is already in
+// gcc_attributes6)
+enum F
+{
+  X,
+  Y
+} __attribute__((mode(byte)));
+STATIC_ASSERT(sizeof(enum F) == 1);
+
+// a mode we do not special-case at all: must fall back without crashing the
+// layout computation below.  The width is best-effort -- real gcc would use
+// 32 bytes for OI, whereas CBMC keeps the enum's natural underlying width.
+enum G
+{
+  P,
+  Q
+} __attribute__((mode(OI)));
+STATIC_ASSERT(sizeof(enum G) == sizeof(int));
+
+// force layout/alignment computation across all three enums -- this is the
+// path that used to crash on the self-referential fallback type
+struct s
+{
+  enum E e;
+  enum F f;
+  enum G g;
+  int tail;
+};
+STATIC_ASSERT(sizeof(struct s) >= sizeof(int));
+
+#endif
+
+int main()
+{
+}

--- a/regression/ansi-c/gcc_enum_mode_attribute/test.desc
+++ b/regression/ansi-c/gcc_enum_mode_attribute/test.desc
@@ -1,0 +1,15 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+An enum with __attribute__((mode(...))) must not produce a self-referential
+underlying type (an enum whose underlying type is its own c_enum_tag), which
+crashed pointer_offset_bits/alignment.  Covers a special-cased underscored
+mode (__QI__), the equivalent un-underscored spelling (byte, now honoured as
+8 bits like gcc), and a genuinely unrecognised mode (OI) exercising the
+best-effort fallback.

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -17,7 +17,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mathematical_types.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
+#include <util/suffix.h>
 #include <util/symbol_table_base.h>
 
 #include "ansi_c_convert_type.h"
@@ -122,8 +124,16 @@ void c_typecheck_baset::typecheck_type(typet &type)
   }
   else if(type.id()==ID_gcc_attribute_mode)
   {
-    // get that mode
-    const irep_idt gcc_attr_mode = type.get(ID_size);
+    // get that mode, and normalise it the way GCC does: a mode name may
+    // be spelled with or without a surrounding pair of underscores, so
+    // "QI"/"byte" are accepted spellings of "__QI__"/"__byte__".  Strip a
+    // surrounding "__" once so the comparisons below honour both spellings.
+    std::string gcc_attr_mode_str = id2string(type.get(ID_size));
+    if(has_prefix(gcc_attr_mode_str, "__"))
+      gcc_attr_mode_str.erase(0, 2);
+    if(has_suffix(gcc_attr_mode_str, "__"))
+      gcc_attr_mode_str.erase(gcc_attr_mode_str.size() - 2);
+    const irep_idt gcc_attr_mode = gcc_attr_mode_str;
 
     // A list of all modes is at
     // http://www.delorie.com/gnu/docs/gcc/gccint_53.html
@@ -151,49 +161,49 @@ void c_typecheck_baset::typecheck_type(typet &type)
 
       typet result;
 
-      if(gcc_attr_mode == "__QI__") // 8 bits
+      if(gcc_attr_mode == "QI") // 8 bits
       {
         if(is_signed)
           result=signed_char_type();
         else
           result=unsigned_char_type();
       }
-      else if(gcc_attr_mode == "__byte__") // 8 bits
+      else if(gcc_attr_mode == "byte") // 8 bits
       {
         if(is_signed)
           result=signed_char_type();
         else
           result=unsigned_char_type();
       }
-      else if(gcc_attr_mode == "__HI__") // 16 bits
+      else if(gcc_attr_mode == "HI") // 16 bits
       {
         if(is_signed)
           result=signed_short_int_type();
         else
           result=unsigned_short_int_type();
       }
-      else if(gcc_attr_mode == "__SI__") // 32 bits
+      else if(gcc_attr_mode == "SI") // 32 bits
       {
         if(is_signed)
           result=signed_int_type();
         else
           result=unsigned_int_type();
       }
-      else if(gcc_attr_mode == "__word__") // long int, we think
+      else if(gcc_attr_mode == "word") // long int, we think
       {
         if(is_signed)
           result=signed_long_int_type();
         else
           result=unsigned_long_int_type();
       }
-      else if(gcc_attr_mode == "__pointer__") // size_t/ssize_t, we think
+      else if(gcc_attr_mode == "pointer") // size_t/ssize_t, we think
       {
         if(is_signed)
           result=signed_size_type();
         else
           result=size_type();
       }
-      else if(gcc_attr_mode == "__DI__") // 64 bits
+      else if(gcc_attr_mode == "DI") // 64 bits
       {
         if(config.ansi_c.long_int_width==64)
         {
@@ -212,14 +222,14 @@ void c_typecheck_baset::typecheck_type(typet &type)
             result=unsigned_long_long_int_type();
         }
       }
-      else if(gcc_attr_mode == "__TI__") // 128 bits
+      else if(gcc_attr_mode == "TI") // 128 bits
       {
         if(is_signed)
           result=gcc_signed_int128_type();
         else
           result=gcc_unsigned_int128_type();
       }
-      else if(gcc_attr_mode == "__V2SI__") // vector of 2 ints, deprecated
+      else if(gcc_attr_mode == "V2SI") // vector of 2 ints, deprecated
       {
         if(is_signed)
         {
@@ -232,7 +242,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
             c_index_type(), unsigned_int_type(), from_integer(2, size_type()));
         }
       }
-      else if(gcc_attr_mode == "__V4SI__") // vector of 4 ints, deprecated
+      else if(gcc_attr_mode == "V4SI") // vector of 4 ints, deprecated
       {
         if(is_signed)
         {
@@ -245,8 +255,14 @@ void c_typecheck_baset::typecheck_type(typet &type)
             c_index_type(), unsigned_int_type(), from_integer(4, size_type()));
         }
       }
-      else // give up, just use subtype
-        result = to_type_with_subtype(type).subtype();
+      else // give up, just use the (resolved) underlying type.  We only
+           // reach this for mode names we don't recognise at all; the width
+           // is then best-effort and may not match GCC.  For an enum subtype
+           // the resolved underlying type is the enum's underlying bitvector,
+           // NOT the c_enum_tag -- using the tag would make the enum's
+           // underlying type its own tag (a cycle), which later crashes
+           // pointer_offset_bits/alignment.
+        result = underlying_type;
 
       // save the location
       result.add_source_location()=type.source_location();
@@ -266,26 +282,26 @@ void c_typecheck_baset::typecheck_type(typet &type)
     {
       typet result;
 
-      if(gcc_attr_mode == "__SF__") // 32 bits
+      if(gcc_attr_mode == "SF") // 32 bits
         result=float_type();
-      else if(gcc_attr_mode == "__DF__") // 64 bits
+      else if(gcc_attr_mode == "DF") // 64 bits
         result=double_type();
-      else if(gcc_attr_mode == "__TF__") // 128 bits
+      else if(gcc_attr_mode == "TF") // 128 bits
         result=gcc_float128_type();
-      else if(gcc_attr_mode == "__V2SF__") // deprecated vector of 2 floats
+      else if(gcc_attr_mode == "V2SF") // deprecated vector of 2 floats
         result = vector_typet(
           c_index_type(), float_type(), from_integer(2, size_type()));
-      else if(gcc_attr_mode == "__V2DF__") // deprecated vector of 2 doubles
+      else if(gcc_attr_mode == "V2DF") // deprecated vector of 2 doubles
         result = vector_typet(
           c_index_type(), double_type(), from_integer(2, size_type()));
-      else if(gcc_attr_mode == "__V4SF__") // deprecated vector of 4 floats
+      else if(gcc_attr_mode == "V4SF") // deprecated vector of 4 floats
         result = vector_typet(
           c_index_type(), float_type(), from_integer(4, size_type()));
-      else if(gcc_attr_mode == "__V4DF__") // deprecated vector of 4 doubles
+      else if(gcc_attr_mode == "V4DF") // deprecated vector of 4 doubles
         result = vector_typet(
           c_index_type(), double_type(), from_integer(4, size_type()));
-      else // give up, just use subtype
-        result = to_type_with_subtype(type).subtype();
+      else // give up, best-effort: use the (resolved) underlying type
+        result = underlying_type;
 
       // preserve the location
       type = result.with_source_location(type);
@@ -295,14 +311,14 @@ void c_typecheck_baset::typecheck_type(typet &type)
       // gcc allows this, but clang doesn't -- see enums above
       typet result;
 
-      if(gcc_attr_mode == "__SC__") // 32 bits
+      if(gcc_attr_mode == "SC") // 32 bits
         result=float_type();
-      else if(gcc_attr_mode == "__DC__") // 64 bits
+      else if(gcc_attr_mode == "DC") // 64 bits
         result=double_type();
-      else if(gcc_attr_mode == "__TC__") // 128 bits
+      else if(gcc_attr_mode == "TC") // 128 bits
         result=gcc_float128_type();
-      else // give up, just use subtype
-        result = to_type_with_subtype(type).subtype();
+      else // give up, best-effort: use the (resolved) underlying type
+        result = underlying_type;
 
       // save the location
       type = complex_typet(result).with_source_location(type);


### PR DESCRIPTION
For an enum with __attribute__((mode(M))), when M is not one of the special-cased mode names (e.g. plain "byte" rather than "__byte__"), the handler fell back to `result = subtype`, where the subtype is the c_enum_tag.  It then wrote that back as the enum symbol's underlying type, making the enum's underlying type its own tag -- a cyclic, malformed type.  This later caused infinite recursion in alignment() (a stack-overflow segfault) and a to_bitvector_type precondition abort in pointer_offset_bits(), crashing goto-cc on real kernel objects (net/rxrpc/rxgk, rxkad, af_rxrpc via crypto/krb5 headers).

Fall back to the already-resolved underlying bitvector type instead of the c_enum_tag subtype.  For a non-enum bitvector subtype this is unchanged (underlying_type == subtype); for an enum subtype it uses the enum's underlying integer type, so no cycle is created.

Regression test gcc_enum_mode_attribute covers a special-cased mode (__QI__) and a fall-back mode name (byte).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
