### PR TITLE
ansi-c: support qualified __auto_type

### DIFF
--- a/regression/ansi-c/gcc___auto_type1/main.c
+++ b/regression/ansi-c/gcc___auto_type1/main.c
@@ -5,12 +5,33 @@ int main()
   #if defined(__GNUC__)
   // accepted by GCC, but not Clang
   #ifndef __clang__
+  // unqualified __auto_type
   __auto_type s=1;
   __auto_type u=1U;
 
   static_assert(__builtin_types_compatible_p(typeof(s), int));
   static_assert(__builtin_types_compatible_p(typeof(u), unsigned));
-  #endif
-  #endif
+
+  // qualified __auto_type: 'const __auto_type c = s;' is equivalent to
+  // 'const typeof(s) c = s;'. The deduced type is int, and the const must be
+  // applied. __builtin_types_compatible_p ignores *top-level* qualifiers, so
+  // the qualifier is observed via typeof(&...), where the pointee qualifier is
+  // significant: the address of a const int is a 'const int *'.
+  const __auto_type c = s;
+  static_assert(__builtin_types_compatible_p(typeof(c), int));
+  static_assert(__builtin_types_compatible_p(typeof(&c), const int *));
+  static_assert(!__builtin_types_compatible_p(typeof(&c), int *));
+
+  // a single non-const qualifier
+  volatile __auto_type v = s;
+  static_assert(__builtin_types_compatible_p(typeof(&v), volatile int *));
+  static_assert(!__builtin_types_compatible_p(typeof(&v), int *));
+
+  // a multi-qualifier list, to confirm the whole type_qualifier_list is merged
+  const volatile __auto_type cv = s;
+  static_assert(
+    __builtin_types_compatible_p(typeof(&cv), const volatile int *));
+#  endif
+#endif
   return 0;
 }

--- a/regression/ansi-c/gcc___auto_type1/test.desc
+++ b/regression/ansi-c/gcc___auto_type1/test.desc
@@ -6,3 +6,11 @@ main.c
 --
 ^warning: ignoring
 ^CONVERSION ERROR$
+^syntax error
+--
+__auto_type, both unqualified and with type qualifiers (const/volatile/const
+volatile), must parse and deduce the initializer's type, mirroring GCC.  For
+the qualified forms the qualifier's effect is checked at compile time via
+typeof(&x), since __builtin_types_compatible_p ignores top-level qualifiers; a
+dropped qualifier turns a static_assert into a negative-width bit-field, i.e. a
+CONVERSION ERROR.

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1121,18 +1121,21 @@ declaring_list:
         | TOK_GCC_AUTO_TYPE declarator
           post_declarator_attributes_opt '=' initializer
         {
-          // handled as typeof(initializer)
-          parser_stack($1).id(ID_typeof);
-          parser_stack($1).copy_to_operands(parser_stack($5));
-
-          $2=merge($3, $2);
-
-          // the symbol has to be visible during initialization
-          init($$, ID_declaration);
-          parser_stack($$).type().swap(parser_stack($1));
-          PARSER.add_declarator(parser_stack($$), parser_stack($2));
-          // add the initializer
-          to_ansi_c_declaration(parser_stack($$)).add_initializer(parser_stack($5));
+          // __auto_type var = init; handled as typeof(init) var = init;
+          // Shared logic with the qualified production below lives in
+          // new_auto_type_declaration(); keep the two in sync.
+          new_auto_type_declaration($$, $1, $2, $3, $5, nullptr);
+        }
+        | type_qualifier_list TOK_GCC_AUTO_TYPE declarator
+          post_declarator_attributes_opt '=' initializer
+        {
+          // Qualified __auto_type: 'const/volatile/... __auto_type
+          // var = initializer;' is equivalent to
+          // '<qualifiers> typeof(initializer) var = initializer;'.
+          // Shared logic with the unqualified production above lives in
+          // new_auto_type_declaration(); the qualifier list is merged into
+          // the typeof type there.
+          new_auto_type_declaration($$, $2, $3, $4, $6, &$1);
         }
         | declaring_list ',' gcc_type_attribute_opt declarator
           post_declarator_attributes_opt

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -435,3 +435,52 @@ static void adjust_KnR_parameters(
     }
   }
 }
+
+/*******************************************************************\
+
+Function: new_auto_type_declaration
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: Build a declaration for a GCC `__auto_type` declarator.
+
+   `[<qualifiers>] __auto_type <declarator> <attributes> = <initializer>;`
+
+ is handled as
+
+   `[<qualifiers>] typeof(<initializer>) <declarator> = <initializer>;`
+
+ Shared by the unqualified and qualified `TOK_GCC_AUTO_TYPE` productions
+ in parser.y; keep those two productions in sync via this helper.
+
+\*******************************************************************/
+
+static void new_auto_type_declaration(
+  YYSTYPE &result,
+  YYSTYPE auto_type_node,
+  YYSTYPE declarator,
+  YYSTYPE attributes,
+  YYSTYPE initializer,
+  const YYSTYPE *qualifier_list)
+{
+  // turn the __auto_type node into typeof(initializer)
+  parser_stack(auto_type_node).id(ID_typeof);
+  parser_stack(auto_type_node).copy_to_operands(parser_stack(initializer));
+
+  // merge any qualifier list (const/volatile/...) into the typeof type
+  const YYSTYPE type_node = qualifier_list != nullptr
+                              ? merge(*qualifier_list, auto_type_node)
+                              : auto_type_node;
+
+  declarator = merge(attributes, declarator);
+
+  // the symbol has to be visible during initialization
+  init(result, ID_declaration);
+  parser_stack(result).type().swap(parser_stack(type_node));
+  PARSER.add_declarator(parser_stack(result), parser_stack(declarator));
+  // add the initializer
+  to_ansi_c_declaration(parser_stack(result))
+    .add_initializer(parser_stack(initializer));
+}


### PR DESCRIPTION
GCC allows __auto_type with type qualifiers, e.g.
  const __auto_type x = init;
which is equivalent to
  const typeof(init) x = init;
The parser only had a production for the unqualified '__auto_type var = init;' form, so a qualified __auto_type -- as used by the Linux 6.12 kernel in arch/x86/include/asm/string_64.h -- failed with a syntax error.

Add a declaring_list production for
  type_qualifier_list TOK_GCC_AUTO_TYPE declarator
    post_declarator_attributes_opt '=' initializer
whose semantic action builds the typeof-of-initializer node and merges the qualifier list into it, mirroring GCC's documented semantics.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
