### PR TITLE
Ignore x86 __seg_fs/__seg_gs named-address-space qualifiers

### DIFF
--- a/regression/cbmc/gcc_named_address_space/main.c
+++ b/regression/cbmc/gcc_named_address_space/main.c
@@ -1,0 +1,31 @@
+// The x86 named-address-space (segment) qualifiers __seg_fs / __seg_gs,
+// used by the Linux kernel's per-CPU accessors as BARE type qualifiers
+// when the compiler supports named address spaces
+// (CONFIG_CC_HAS_NAMED_ADDRESS_SPACES) -- e.g. `typeof(x) __seg_gs *`.
+// They denote %fs/%gs segment-relative addressing, irrelevant to
+// functional verification, so CBMC ignores the qualifier (the pointed-to
+// object is unchanged).
+struct s
+{
+  int x;
+};
+
+// plain non-pointer object carrying the qualifier (per-CPU object form)
+static int __seg_gs percpu;
+
+int main(void)
+{
+  struct s obj = {.x = 42};
+  struct s __seg_gs *p = (struct s __seg_gs *)&obj;
+  struct s __seg_fs *q = (struct s __seg_fs *)&obj;
+  __typeof__(struct s __seg_gs) *r = &obj;
+  // qualifier *before* the type
+  __seg_gs int *s = (__seg_gs int *)&obj.x;
+  __CPROVER_assert(p->x == 42, "seg-gs-qualified pointer reads the object");
+  __CPROVER_assert(q->x == 42, "seg-fs-qualified pointer reads the object");
+  __CPROVER_assert(r->x == 42, "typeof with seg qualifier");
+  __CPROVER_assert(*s == 42, "seg qualifier before the type");
+  percpu = 7;
+  __CPROVER_assert(percpu == 7, "non-pointer seg-qualified object");
+  return 0;
+}

--- a/regression/cbmc/gcc_named_address_space/test.desc
+++ b/regression/cbmc/gcc_named_address_space/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1023,6 +1023,17 @@ enable_or_disable ("enable"|"disable")
 
 "__extension__" { /* ignore */ }
 
+  /* x86 named-address-space (segment) qualifiers used by the kernel's
+     per-CPU accessors (arch/x86/include/asm/percpu.h) when the compiler
+     supports named address spaces (CONFIG_CC_HAS_NAMED_ADDRESS_SPACES).
+     They denote %fs/%gs segment-relative addressing, which is irrelevant
+     to functional verification, so we ignore the qualifier (the pointed-to
+     object is unchanged).  When the compiler lacks the feature these are
+     instead macros expanding to __attribute__((address_space(...))), which
+     the GCC_ATTRIBUTE states already discard. */
+"__seg_fs"      { /* ignore: segment address-space qualifier */ }
+"__seg_gs"      { /* ignore: segment address-space qualifier */ }
+
 "__restrict"    { loc(); return TOK_RESTRICT; }
 "__restrict__"  { loc(); return TOK_RESTRICT; }
 


### PR DESCRIPTION
The C scanner now ignores the bare type qualifiers __seg_fs and __seg_gs (like __extension__).  These are GCC/Clang x86 named-address-space qualifiers for %fs/%gs segment-relative addressing; the Linux kernel uses them directly in its per-CPU accessors (arch/x86/include/asm/percpu.h) when the compiler supports named address spaces
(CONFIG_CC_HAS_NAMED_ADDRESS_SPACES) -- e.g. `typeof(x) __seg_gs *` and `__typeof__(struct pcpu_hot __seg_gs)`.  Because the system preprocessor treats them as builtin keywords (not macros) in that configuration, they survive preprocessing as bare tokens and previously produced "syntax error before '__seg_gs'", blocking goto-cc on essentially every x86 kernel translation unit that touches `current` / preempt-count / per-CPU state.

Segment-relative addressing is irrelevant to functional verification (the pointed-to object is unchanged), so the qualifier is dropped.  When the compiler lacks the feature these identifiers are instead macros expanding to __attribute__((address_space(...))), which the GCC_ATTRIBUTE scanner states already discard, so both configurations are handled.

regression/cbmc/gcc_named_address_space exercises the bare-qualifier form both after and before the type, in pointer declarations, casts, __typeof__, and on a plain non-pointer object, and verifies that a seg-qualified pointer still reads the underlying object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

