### PR TITLE
boolbv_index: handle incomplete extern array types in symbol registration

### DIFF
--- a/regression/cbmc/incomplete_extern_array1/main.c
+++ b/regression/cbmc/incomplete_extern_array1/main.c
@@ -1,0 +1,30 @@
+// Regression test for the fix to:
+//   src/solvers/flattening/boolbv_index.cpp
+// where indexing into an `extern T arr[]` (incomplete array)
+// at multiple indices used to register the symbol with width
+// 0 in boolbv_mapt, then trip the size-equals-width invariant
+// in get_literals.
+//
+// The Linux kernel hits this via <linux/ctype.h>'s
+// `extern const unsigned char _ctype[]` declaration combined
+// with the `__ismask(c)` macro that expands to `_ctype[c]`.
+
+extern const unsigned char _ctype[];
+
+int nondet_int(void);
+
+int main(void)
+{
+  int c = nondet_int();
+  if(c >= 0 && c < 128)
+  {
+    unsigned char m1 = _ctype[c];
+    unsigned char m2 = _ctype[c + 1];
+    // Reading the same index again must yield the same value: this confirms
+    // the flattened array symbol is encoded consistently, rather than merely
+    // that CBMC no longer aborts.
+    __CPROVER_assert(_ctype[c] == m1, "same index yields the same value");
+    return m1 + m2;
+  }
+  return 0;
+}

--- a/regression/cbmc/incomplete_extern_array1/test.desc
+++ b/regression/cbmc/incomplete_extern_array1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--bounds-check
+^\[main\.assertion\.\d+\] .* same index yields the same value: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^Invariant check failed

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -157,6 +157,16 @@ protected:
 
   virtual bvt convert_index(const exprt &array, const mp_integer &index);
   virtual bvt convert_index(const index_exprt &expr);
+  /// Record the type of an array symbol in \ref map so that subsequent lookups
+  /// share a consistent bitvector encoding. The width is unknown (taken as 0)
+  /// for an incomplete array such as `extern T arr[]`; registration is skipped
+  /// only when the symbol is already registered at a different width, which
+  /// would otherwise trip the size-equals-width invariant in
+  /// \ref boolbv_mapt::get_literals against an entry created via the
+  /// element-typed access path.
+  void register_array_symbol(
+    const irep_idt &identifier,
+    const array_typet &array_type);
   virtual bvt convert_bswap(const bswap_exprt &expr);
   virtual bvt convert_byte_extract(const byte_extract_exprt &expr);
   virtual bvt convert_byte_update(const byte_update_exprt &expr);

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -18,6 +18,27 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 
+void boolbvt::register_array_symbol(
+  const irep_idt &identifier,
+  const array_typet &array_type)
+{
+  const std::size_t array_width =
+    bv_width.get_width_opt(array_type).value_or(0);
+  // Register the array symbol's type, but skip when the symbol is already
+  // registered at a *different* width.  An incomplete extern array (e.g.
+  // `extern T arr[]`, width 0 here) may already be registered at a non-zero
+  // width via its element-typed access path (e.g. `T arr[i]` yields a T-width
+  // value), and re-registering at width 0 would trip get_literals'
+  // size-equals-width invariant.  We must *not* simply skip all unknown-width
+  // (width 0) registrations: a first-time width-0 registration is what makes
+  // unbounded-array counterexample traces and string-refinement arrays display
+  // their element values (see regression/cbmc/trace-values/unbounded_array),
+  // so only a genuine width mismatch is skipped.
+  const auto existing = map.get_map_entry(identifier);
+  if(!existing.has_value() || existing->get().literal_map.size() == array_width)
+    (void)map.get_literals(identifier, array_type, array_width);
+}
+
 bvt boolbvt::convert_index(const index_exprt &expr)
 {
   const exprt &array=expr.array();
@@ -50,11 +71,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         if(
           final_array.id() == ID_symbol || final_array.id() == ID_nondet_symbol)
         {
-          const auto &array_width_opt = bv_width.get_width_opt(array_type);
-          (void)map.get_literals(
-            final_array.get(ID_identifier),
-            array_type,
-            array_width_opt.value_or(0));
+          register_array_symbol(final_array.get(ID_identifier), array_type);
         }
 
         // make sure we have the index in the cache
@@ -70,9 +87,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         // record type if array is a symbol
         if(array.id() == ID_symbol || array.id() == ID_nondet_symbol)
         {
-          const auto &array_width_opt = bv_width.get_width_opt(array_type);
-          (void)map.get_literals(
-            array.get(ID_identifier), array_type, array_width_opt.value_or(0));
+          register_array_symbol(array.get(ID_identifier), array_type);
         }
 
         // make sure we have the index in the cache

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -171,6 +171,27 @@ void send_function_definition(
     &expression_identifiers,
   std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
+  // The same SSA identifier can be reached via two expressions that differ
+  // only in their (sort-equivalent) type irep -- e.g. an incomplete
+  // `extern T arr[]` whose array type is represented differently at
+  // different access sites.  Such expressions are distinct keys in
+  // expression_identifiers, so both reach this point, but they denote the
+  // same symbol and must be declared to the solver only once.  Map any
+  // later expression to the already-declared identifier.
+  const auto existing = identifier_table.find(symbol_identifier);
+  if(existing != identifier_table.end())
+  {
+    // The two type ireps are assumed to be sort-equivalent; check this so a
+    // violated assumption fails loudly here rather than as an opaque solver
+    // error downstream. smt_identifier_termt hides get_sort with a
+    // bit-vector-only overload, so compare via the smt_termt base.
+    INVARIANT(
+      static_cast<const smt_termt &>(existing->second).get_sort() ==
+        convert_type_to_smt_sort(expr.type()),
+      "expressions sharing an SSA identifier must have sort-equivalent types");
+    expression_identifiers.emplace(expr, existing->second);
+    return;
+  }
   const smt_declare_function_commandt function{
     smt_identifier_termt(
       symbol_identifier, convert_type_to_smt_sort(expr.type())),


### PR DESCRIPTION
When boolbv flattens an array index expression where the array is a symbol of unbounded `array_typet` (e.g. an incomplete declaration like `extern T arr[]`), it registered that symbol with `boolbv_mapt::get_literals` using a width of `array_width_opt.value_or(0)`. Passing 0 created a zero-width entry that tripped the size-equals-width invariant in `get_literals` when the same symbol was — or had been — registered at a non-zero width via its element-typed access path (e.g. `T arr[i]` returns a T-width value).

This was first surfaced by `integration/linux` scans of kernel sources that include `<linux/ctype.h>`, which declares `extern const unsigned char _ctype[]` — an incomplete extern array referenced by the `is*()` classifier macros that expand to `_ctype[c]`. CBMC aborted at `boolbv_map.cpp:68` on every such TU.

The fix spans both back-ends, hence two commits:

* **`boolbv_index`** — Skip the registration only when the symbol is already registered at a *different* width. The width-0 registration itself must be preserved: it is what lets unbounded-array counterexample traces and string-refinement arrays display their element values (e.g. `regression/cbmc/trace-values/unbounded_array`); only the conflicting re-registration that trips the invariant is dropped. The shared guard is factored into `boolbvt::register_array_symbol` so the two index branches cannot drift apart.

* **`smt2_incremental`** — The incremental SMT2 back-end needs the same symbol handled once. It keyed its set of already-declared functions on the full expression irep, so the same SSA symbol reached via two sort-equivalent array-type ireps (e.g. `_ctype[c]` and `_ctype[c + 1]`) was emitted as two `declare-fun`s, which z3 rejects (`constant '_ctype#1' ... already declared`). `send_function_definition` now deduplicates by SSA identifier, with a defensive invariant that the later expression's type is sort-equivalent to the existing declaration.

**Regression test:** `regression/cbmc/incomplete_extern_array1/` indexes such an array at two distinct indices (forcing the symbol to be reached twice) under `--bounds-check`, and asserts that re-reading the same index yields the same value — so it guards against unsound flattening as well as the original invariant abort. As a `CORE` test it is additionally run by the `cbmc-new-smt-backend` CTest profile (`--incremental-smt2-solver`) when z3 is on `PATH`, which exercises the second commit.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
