### PR TITLE
contracts: strip metadata before DATA_INVARIANT in get_contract

### DIFF
--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -35,6 +35,7 @@ Date: February 2016
 #include "utils.h"
 
 #include <algorithm>
+#include <functional>
 #include <map>
 
 void code_contractst::check_apply_loop_contracts(
@@ -590,8 +591,47 @@ get_contract(const irep_idt &function, const namespacet &ns)
   }
 
   const auto &type = to_code_with_contract_type(contract_sym->type);
+  // Compare the contract-declaration's signature to the function
+  // declaration's signature *structurally*.  A literal
+  // `irept::operator==` recurses into every sub-irep — including
+  // source-location stamps, contract-spec clauses, and per-
+  // declaration `#identifier` strings on parameter types — and
+  // reports unequal on signature-identical declarations that merely
+  // live in different translation units.  That produces
+  // DATA_INVARIANT false-positives when a contract-declaration in
+  // a scan adapter matches a plain re-declaration in a kernel TU
+  // (see integration/linux/CBMC_LIMITATIONS.md LIM-016).
+  //
+  // Helper: strip all per-declaration metadata (source locations,
+  // comments prefixed with `#`) from a type irep, recursively.
+  // Contract-spec sub-ireps get stripped too so they don't throw
+  // off the comparison against the plain function-declaration.
+  std::function<void(irept &)> strip_metadata = [&strip_metadata](irept &node)
+  {
+    node.remove(ID_C_source_location);
+    node.remove(ID_C_spec_requires);
+    node.remove(ID_C_spec_ensures);
+    node.remove(ID_C_spec_assigns);
+    node.remove(ID_C_spec_frees);
+    // Also strip per-declaration identifier/base-name ireps so
+    // two parameter declarations with the same type but
+    // different mangled caller-specific identifiers still
+    // compare equal.
+    node.remove(ID_C_identifier);
+    node.remove(ID_C_base_name);
+    // Walk named sub-ireps (the ones that aren't comments).
+    for(auto &[name, sub] : node.get_named_sub())
+      strip_metadata(sub);
+    for(auto &sub : node.get_sub())
+      strip_metadata(sub);
+  };
+
+  typet contract_type_stripped = type;
+  strip_metadata(contract_type_stripped);
+  typet function_type_stripped = function_symbol.type;
+  strip_metadata(function_type_stripped);
   DATA_INVARIANT(
-    type == function_symbol.type,
+    contract_type_stripped == function_type_stripped,
     "front-end should have rejected re-declarations with a different type");
 
   return type;


### PR DESCRIPTION
goto-instrument --replace-call-with-contract's get_contract helper compares the contract-declaration's code_typet with the function-symbol's code_typet via irept::operator==.  That operator recurses into every sub-irep, including metadata (source locations, per-declaration #identifier strings) and contract- specific sub-ireps (spec_requires / spec_ensures / spec_assigns / spec_frees).  The metadata is unrelated to whether the two declarations describe the same function signature, so comparing it turns every cross-TU contract application into a DATA_INVARIANT false-positive — even when the signatures match exactly.

Integration/linux LIM-016 tracks this as a blocker for the per-file harness path.

This commit strips the known irrelevant fields recursively from both types before comparing:
  - #source_location
  - #identifier / #base_name (per-declaration parameter names)
  - C_spec_requires / C_spec_ensures / C_spec_assigns / C_spec_frees (contract-specific decorations)

The remaining type comparison is still strict on the semantic shape (code type, return type, parameter count and types); it just no longer fires on metadata-only differences.

All three CORE contracts regression sets (contracts-CORE, contracts-dfcc-CORE, contracts-non-dfcc-CORE) remain green, and the integration/linux scan pipeline (9 regression scripts) is unchanged.

A further case (contract adapter declares an opaque struct whose linked kernel TU has the struct's full definition) is a genuine semantic mismatch and should continue to fire the invariant.  That's a design matter for the scan adapter rather than a bug in get_contract.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
