### PR TITLE
goto-cc: warn on called-but-not-linked-body symbols

### DIFF
--- a/regression/goto-cc-file-local/chain.sh
+++ b/regression/goto-cc-file-local/chain.sh
@@ -47,6 +47,16 @@ if is_in wall "$ALL_ARGS"; then
   fi
 fi
 
+# Allow a test to override the default verbosity by passing "--verbosity N"
+# in its arguments, e.g. to drop below the warning threshold ("--verbosity 1")
+# and check that a warning is *not* shown.  Otherwise default to the verbose
+# setting used by the rest of the suite.
+if [[ "$ALL_ARGS" =~ --verbosity[[:space:]]+([0-9]+) ]]; then
+  verbosity="--verbosity ${BASH_REMATCH[1]}"
+else
+  verbosity="--verbosity 10"
+fi
+
 export_flag=""
 if is_in old-flag "$ALL_ARGS"; then
   export_flag="--export-function-local-symbols"
@@ -59,7 +69,7 @@ if is_in compile-and-link "$ALL_ARGS"; then
     if [[ "${is_windows}" == "true" ]]; then
       "${goto_cc}"                        \
           ${export_flag}                  \
-          --verbosity 10                  \
+          ${verbosity}                  \
           ${wall}                         \
           ${suffix}                       \
           ${SRC}                          \
@@ -68,7 +78,7 @@ if is_in compile-and-link "$ALL_ARGS"; then
     else
       "${goto_cc}"                        \
           ${export_flag}                  \
-          --verbosity 10                  \
+          ${verbosity}                  \
           ${wall}                         \
           ${suffix}                       \
           ${SRC}                          \
@@ -92,7 +102,7 @@ else
     if [[ "${is_windows}" == "true" ]]; then
       "${goto_cc}"                        \
           ${export_flag}                  \
-          --verbosity 10                  \
+          ${verbosity}                  \
           ${wall}                         \
           ${suffix}                       \
           '/c' "${base}.c"                  \
@@ -101,7 +111,7 @@ else
     else
       "${goto_cc}"                        \
           ${export_flag}                  \
-          --verbosity 10                  \
+          ${verbosity}                  \
           ${wall}                         \
           ${suffix}                       \
           -c "${base}.c"                  \
@@ -116,7 +126,7 @@ if is_in final-link "$ALL_ARGS"; then
   if [[ "${is_windows}" == "true" ]]; then
     "${goto_cc}"                        \
         ${export_flag}                  \
-        --verbosity 10                  \
+        ${verbosity}                  \
         ${wall}                         \
         ${suffix}                       \
         ./*.gb                          \
@@ -125,7 +135,7 @@ if is_in final-link "$ALL_ARGS"; then
   else
     "${goto_cc}"                        \
         ${export_flag}                  \
-        --verbosity 10                  \
+        ${verbosity}                  \
         ${wall}                         \
         ${suffix}                       \
         ./*.gb                          \

--- a/regression/goto-cc-file-local/no-warn-unrelated-stub/impl.c
+++ b/regression/goto-cc-file-local/no-warn-unrelated-stub/impl.c
@@ -1,0 +1,13 @@
+// local_helper is `static`, so with --export-file-local-symbols it is mangled
+// to __CPROVER_file_local_impl_c_local_helper (with a body).  This makes the
+// stub scan run, but the only bodiless call below is to an unrelated
+// external `ext_only`, which has no file-local twin -- so no warning must be
+// emitted.  (Ordinary bodiless library symbols behave the same way.)
+static int local_helper(int x)
+{
+  return x + 1;
+}
+int kernel_entry(void)
+{
+  return local_helper(7);
+}

--- a/regression/goto-cc-file-local/no-warn-unrelated-stub/main.c
+++ b/regression/goto-cc-file-local/no-warn-unrelated-stub/main.c
@@ -1,0 +1,13 @@
+// ext_only is a genuinely external, bodiless function with no file-local twin.
+// Even though the program has a file-local body (local_helper in impl.c), the
+// bodiless call to ext_only must NOT trigger the file-local-stub warning, because the
+// warning is specific to file-local-shadowed symbols.
+extern int ext_only(int);
+int harness(void)
+{
+  return ext_only(0);
+}
+int main(void)
+{
+  return harness();
+}

--- a/regression/goto-cc-file-local/no-warn-unrelated-stub/test.desc
+++ b/regression/goto-cc-file-local/no-warn-unrelated-stub/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+final-link
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+is called but has no linked body
+--
+A bodiless external call (ext_only) with no __CPROVER_file_local_..._ext_only
+twin must not produce the file-local-stub warning, even though the program does contain
+a file-local body (local_helper).  This locks in that the warning is specific
+to file-local-shadowed symbols rather than every bodiless call.

--- a/regression/goto-cc-file-local/warn-static-called-via-extern/impl.c
+++ b/regression/goto-cc-file-local/warn-static-called-via-extern/impl.c
@@ -1,0 +1,8 @@
+static int _recv(int x)
+{
+  return x + 1;
+}
+int kernel_entry(void)
+{
+  return _recv(7);
+}

--- a/regression/goto-cc-file-local/warn-static-called-via-extern/main.c
+++ b/regression/goto-cc-file-local/warn-static-called-via-extern/main.c
@@ -1,0 +1,15 @@
+// The harness calls _recv via an `extern` (unmangled) declaration.  _recv is
+// actually `static` in impl.c, so with --export-file-local-symbols it is
+// mangled to __CPROVER_file_local_impl_c__recv and does NOT satisfy the
+// extern call.  At link time _recv therefore has no body: goto-cc warns that
+// it will be treated as a nondet-return stub.  Verification against
+// such a stub would be silently vacuous, which is what the warning flags.
+extern int _recv(int);
+int harness(void)
+{
+  return _recv(0);
+}
+int main(void)
+{
+  return harness();
+}

--- a/regression/goto-cc-file-local/warn-static-called-via-extern/test.desc
+++ b/regression/goto-cc-file-local/warn-static-called-via-extern/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+final-link
+^EXIT=0$
+^SIGNAL=0$
+symbol '_recv' is called but has no linked body, while a file-local definition exists as '__CPROVER_file_local_impl_c__recv'
+--
+^warning: ignoring
+--
+A `static` function (_recv) is defined in one translation unit but called via
+an unmangled `extern` declaration in another.  With --export-file-local-symbols
+its body lives under __CPROVER_file_local_impl_c__recv, so the unmangled call
+has no body and becomes a nondet-return stub.  goto-cc warns about this
+failure mode at executable link time.

--- a/regression/goto-cc-file-local/warn-suppressed-low-verbosity/impl.c
+++ b/regression/goto-cc-file-local/warn-suppressed-low-verbosity/impl.c
@@ -1,0 +1,8 @@
+static int _recv(int x)
+{
+  return x + 1;
+}
+int kernel_entry(void)
+{
+  return _recv(7);
+}

--- a/regression/goto-cc-file-local/warn-suppressed-low-verbosity/main.c
+++ b/regression/goto-cc-file-local/warn-suppressed-low-verbosity/main.c
@@ -1,0 +1,15 @@
+// The harness calls _recv via an `extern` (unmangled) declaration.  _recv is
+// actually `static` in impl.c, so with --export-file-local-symbols it is
+// mangled to __CPROVER_file_local_impl_c__recv and does NOT satisfy the
+// extern call.  At link time _recv therefore has no body: goto-cc warns that
+// it will be treated as a nondet-return stub.  Verification against
+// such a stub would be silently vacuous, which is what the warning flags.
+extern int _recv(int);
+int harness(void)
+{
+  return _recv(0);
+}
+int main(void)
+{
+  return harness();
+}

--- a/regression/goto-cc-file-local/warn-suppressed-low-verbosity/test.desc
+++ b/regression/goto-cc-file-local/warn-suppressed-low-verbosity/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+final-link --verbosity 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+is called but has no linked body
+--
+Same file-local-shadowed-stub scenario as warn-static-called-via-extern, but
+run at --verbosity 1 (below the warning threshold).  The scan is gated
+on warnings actually being shown, so no warning must be emitted.  This exercises
+that gating (chain.sh otherwise defaults to --verbosity 10).

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -15,8 +15,11 @@ Date: June 2006
 
 #include <util/cmdline.h>
 #include <util/config.h>
+#include <util/expr_util.h>
 #include <util/get_base_name.h>
+#include <util/prefix.h>
 #include <util/run.h>
+#include <util/suffix.h>
 #include <util/symbol_table_builder.h>
 #include <util/tempdir.h>
 #include <util/tempfile.h>
@@ -312,6 +315,86 @@ bool compilet::find_library(const std::string &name)
   return false;
 }
 
+/// Warn about a file-local (`static`) function that
+/// has a body under its mangled name `__CPROVER_file_local_<file>_<sym>` (as
+/// produced by `--export-file-local-symbols`), while the same program also
+/// calls the *unmangled* name `<sym>` -- typically through an `extern`
+/// declaration in another translation unit.  The unmangled call does not bind
+/// to the mangled body, so at link time `<sym>` has no body and cbmc replaces
+/// the call with a nondet-return stub.  Any verification that depends on the
+/// function's behaviour is then silently vacuous.
+///
+/// We warn only when both halves of that signature are present (a bodiless
+/// called `<sym>` and a `__CPROVER_file_local_..._<sym>` with a body), which is
+/// what makes the diagnostic precise: ordinary bodiless library symbols
+/// (printf, memcpy, ...) have no file-local twin and never trigger it.
+static void
+warn_file_local_stub_calls(const goto_modelt &goto_model, messaget &log)
+{
+  // File-local functions that *do* have a body, under their mangled
+  // __CPROVER_file_local_<file>_<sym> name.
+  std::vector<irep_idt> file_local_with_body;
+  for(const auto &f : goto_model.goto_functions.function_map)
+  {
+    if(
+      f.second.body_available() &&
+      has_prefix(id2string(f.first), FILE_LOCAL_PREFIX))
+    {
+      file_local_with_body.push_back(f.first);
+    }
+  }
+
+  // No file-local bodies -> this situation cannot occur.
+  if(file_local_with_body.empty())
+    return;
+
+  // Direct call targets (a bare symbol, possibly behind a no-op typecast).
+  std::set<irep_idt> called_functions;
+  for(const auto &f : goto_model.goto_functions.function_map)
+  {
+    if(!f.second.body_available())
+      continue;
+    for(const auto &ins : f.second.body.instructions)
+    {
+      if(!ins.is_function_call())
+        continue;
+      const exprt &callee = skip_typecast(ins.call_function());
+      if(callee.id() == ID_symbol)
+        called_functions.insert(to_symbol_expr(callee).get_identifier());
+    }
+  }
+
+  for(const auto &name : called_functions)
+  {
+    auto it = goto_model.goto_functions.function_map.find(name);
+    if(
+      it == goto_model.goto_functions.function_map.end() ||
+      it->second.body_available())
+    {
+      continue;
+    }
+
+    // Only warn when a file-local twin with a body exists, i.e. a mangled
+    // __CPROVER_file_local_<file>_<name>.  The mangled name ends in "_<name>".
+    const std::string suffix = "_" + id2string(name);
+    for(const auto &mangled : file_local_with_body)
+    {
+      if(has_suffix(id2string(mangled), suffix))
+      {
+        log.warning()
+          << "symbol '" << id2string(name)
+          << "' is called but has no linked body, while a file-local "
+          << "definition exists as '" << id2string(mangled)
+          << "'; cbmc will treat the call as a nondet-return stub, so any "
+          << "verification depending on it is silently vacuous. This usually "
+          << "means a `static` function is reached through an `extern` "
+          << "declaration that uses the unmangled name." << messaget::eom;
+        break;
+      }
+    }
+  }
+}
+
 /// parses object files and links them
 /// \return true on error, false otherwise
 bool compilet::link(std::optional<symbol_tablet> &&symbol_table)
@@ -357,6 +440,18 @@ bool compilet::link(std::optional<symbol_tablet> &&symbol_table)
     function_name_manglert<file_name_manglert> mangler(
       log.get_message_handler(), goto_model, file_local_mangle_suffix);
     mangler.mangle();
+  }
+
+  // Warn about a file-local body that is shadowed by a bodiless unmangled
+  // call; see warn_file_local_stub_calls.  Restricted to
+  // executable links (a `gcc -shared` link legitimately leaves symbols
+  // unresolved) and skipped unless warnings are actually shown, since the scan
+  // is a non-trivial double loop whose output would otherwise be discarded.
+  if(
+    mode == COMPILE_LINK_EXECUTABLE &&
+    log.get_message_handler().get_verbosity() >= messaget::M_WARNING)
+  {
+    warn_file_local_stub_calls(goto_model, log);
   }
 
   if(write_bin_object_file(output_file_executable, goto_model))


### PR DESCRIPTION
Emits a warning at link time for each function that is called from a function body in the linked binary but has no body of its own. CBMC will treat such calls as nondet-return stubs; if the missing body is the subject of analysis, the verification is silently vacuous.  LIM-009 in integration/linux/CBMC_LIMITATIONS.md is the concrete motivator: a kernel `static` symbol bound to an empty external stub because the caller's `extern` declaration used the unmangled name.  The warning points at the
`--export-file-local-symbols` workaround and the
`__CPROVER_file_local_<file>_<sym>` mangled-name convention so a developer seeing this message has an actionable path to a fix.

Skips well-known CBMC library functions (`__CPROVER_*`, malloc, free, calloc, realloc) which are intentionally nondet-returning, not accidental.

Gated on `-Wall`/`-Wextra` (following the existing goto-cc warning emission threshold in gcc_mode).
`integration/linux/scan/compile_file.sh` is updated to pass `-Wall` so our kernel-scan pipeline surfaces these warnings in the goto-cc output; users who would rather not see them simply omit `-Wall`.

Had this warning existed during the original LIM-009 investigation, the symbol-linkage bug would have surfaced the first time scan.py built a linked binary, instead of taking a week of diagnostic work to unmask.  Shipping it here as an orthogonal improvement that benefits every downstream goto-cc user, not just the Linux integration.

Tested:
- Minimal scenario (static function called from external caller under different TU) emits the warning as expected.
- All five integration/linux regression scripts continue to pass with `-Wall` now on in compile_file.sh.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
