### PR TITLE
goto-instrument --generate-function-body: bound dynamic-object allocation

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -182,6 +182,11 @@ disable built\-in abstract C library
 limit size of nondet (e.g. input) object tree;
 at level N pointers are set to null
 .TP
+\fB\-\-max\-dynamic\-object\-instances\fR N
+hard cap on total dynamic allocations the object
+factory will emit when nondet\-initialising a
+single root; beyond N, pointers are null
+.TP
 \fB\-\-min\-null\-tree\-depth\fR N
 minimum level at which a pointer can first be
 NULL in a recursively nondet initialized struct

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -758,6 +758,11 @@ replace calls to \fIf\fR with calls to \fIg\fR
 limit size of nondet (e.g. input) object tree;
 at level N pointers are set to null
 .TP
+\fB\-\-max\-dynamic\-object\-instances\fR \fIN\fR
+hard cap on total dynamic allocations the object
+factory will emit when nondet\-initialising a
+single root; beyond N, pointers are null
+.TP
 \fB\-\-min\-null\-tree\-depth\fR \fIN\fR
 minimum level at which a pointer can first be
 NULL in a recursively nondet initialized struct

--- a/regression/goto-instrument/generate-function-body-deep-struct-cap/main.c
+++ b/regression/goto-instrument/generate-function-body-deep-struct-cap/main.c
@@ -1,0 +1,62 @@
+// Regression test: --generate-function-body havoc on a function whose
+// return type transitively reaches a wide, deep, but *non-recursive* struct
+// hierarchy used to hang (and then OOM) because the max_nondet_tree_depth cap
+// only fires when the same struct tag re-appears on the pointer chain.  When
+// a hierarchy is deep without revisiting any type in the first few levels,
+// that cap never fires and the object factory generates an exponentially
+// large init body.
+//
+// object_factory_parameterst::max_dynamic_object_instances hard-caps the
+// total number of dynamic objects the factory emits for a single
+// nondet-init root, making body generation terminate regardless of the
+// struct-hierarchy topology.
+//
+// With this 5-level, 4-way-branching hierarchy the uncapped factory would
+// allocate 1 + 4 + 16 + 64 + 256 = 341 dynamic objects.  The test caps it
+// at 10 and checks -- via the --show-goto-functions step in the test
+// harness -- that generation is bounded accordingly: the 11th allocation
+// site (make_l1::malloc_site$9) is absent.  Without the cap that site
+// would be present, so the test fails if the fix is reverted.  The test
+// only exercises goto-instrument body generation (the harness additionally
+// runs cbmc on the result, which trivially succeeds).
+
+typedef struct l5
+{
+  int a, b, c, d;
+} l5_t;
+
+typedef struct l4
+{
+  l5_t *p1, *p2, *p3, *p4;
+  int x;
+} l4_t;
+
+typedef struct l3
+{
+  l4_t *p1, *p2, *p3, *p4;
+  int x;
+} l3_t;
+
+typedef struct l2
+{
+  l3_t *p1, *p2, *p3, *p4;
+  int x;
+} l2_t;
+
+typedef struct l1
+{
+  l2_t *p1, *p2, *p3, *p4;
+  int x;
+} l1_t;
+
+// Without the cap, havoc-body generation recursively nondet-inits
+// l1 -> l2 -> l3 -> l4 -> l5, branching 4-way at each level, producing an
+// exponentially large init body.  With the cap, generation terminates
+// after a bounded number of allocations.
+l1_t *make_l1(void);
+
+int main(void)
+{
+  l1_t *p = make_l1();
+  return p != (l1_t *)0 ? 1 : 0;
+}

--- a/regression/goto-instrument/generate-function-body-deep-struct-cap/test.desc
+++ b/regression/goto-instrument/generate-function-body-deep-struct-cap/test.desc
@@ -1,0 +1,23 @@
+CORE
+main.c
+--generate-function-body make_l1 --generate-function-body-options havoc --max-dynamic-object-instances 10
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+make_l1::malloc_site\$8
+--
+^warning: ignoring
+^\*\*\*\* WARNING: no body for function
+make_l1::malloc_site\$9
+--
+object_factory_parameterst::max_dynamic_object_instances caps havoc body
+generation for a function returning a pointer into a wide, deep,
+non-recursive struct hierarchy, which otherwise hangs and then OOMs.
+The hierarchy would allocate 341 dynamic objects uncapped; with the cap set
+to 10 only 10 allocation sites are emitted, so make_l1::malloc_site$8 is the
+last one present and make_l1::malloc_site$9 -- asserted absent above -- is
+the regression guard: without the cap it would be present and the test would
+fail.  Note the specific $8/$9 indices are implementation-dependent (they
+track the object factory's fresh-symbol numbering and allocation order); an
+unrelated change to that numbering could require updating them even though the
+cap still works.

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -20,15 +20,19 @@ Author: Daniel Kroening, kroening@kroening.com
 // clang-format off
 #define OPT_ANSI_C_LANGUAGE \
   "(max-nondet-tree-depth):" \
+  "(max-dynamic-object-instances):" \
   "(min-null-tree-depth):"
 
 #define HELP_ANSI_C_LANGUAGE \
   " {y--max-nondet-tree-depth} {uN} \t " \
   "limit size of nondet (e.g. input) object tree; at level {uN} pointers are " \
   "set to null\n" \
+  " {y--max-dynamic-object-instances} {uN} \t " \
+  "hard cap on total dynamic allocations the object factory will emit when " \
+  "nondet-initialising a single root; beyond {uN}, pointers are null\n" \
   " {y--min-null-tree-depth} {uN} \t " \
   "minimum level at which a pointer can first be NULL in a recursively " \
-  "nondet initialized struct\n" \
+  "nondet initialized struct\n"
 // clang-format on
 
 class ansi_c_languaget:public languaget

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -80,6 +80,26 @@ void symbol_factoryt::gen_nondet_init(
       }
     }
 
+    // Belt-and-braces: cap the total number of dynamic objects the
+    // factory will emit for a single nondet-init root.  The depth cap
+    // above only fires when the same struct tag re-appears on the
+    // pointer chain; wide-but-non-recursive struct hierarchies bypass it
+    // entirely and blow up exponentially in the absence of this cap.
+    if(
+      dynamic_object_instance_count >=
+      object_factory_params.max_dynamic_object_instances)
+    {
+      // Cap reached: force NULL.  Note this fires unconditionally, including
+      // when depth < min_null_tree_depth (where a non-null object would
+      // otherwise be forced), so the termination guard overrides
+      // min_null_tree_depth.  Dropping the non-null branch here is an
+      // under-approximation -- see max_dynamic_object_instances' docstring.
+      assignments.add(
+        code_frontend_assignt{expr, null_pointer_exprt{pointer_type}, loc});
+      return;
+    }
+    ++dynamic_object_instance_count;
+
     code_blockt non_null_inst;
 
     typet object_type = base_type;

--- a/src/ansi-c/c_nondet_symbol_factory.h
+++ b/src/ansi-c/c_nondet_symbol_factory.h
@@ -29,6 +29,16 @@ class symbol_factoryt
 
   const lifetimet lifetime;
 
+  /// Running count of dynamic objects this factory has allocated.  A fresh
+  /// `symbol_factoryt` is constructed for each nondet-init root (see
+  /// `c_nondet_symbol_factory`), so this count -- which is never reset and
+  /// accumulates across the whole object tree of one root -- gives a per-root
+  /// cap when compared against
+  /// `object_factory_params.max_dynamic_object_instances`.  When the cap is
+  /// hit, pointers are initialised to NULL instead of recursively expanded.
+  /// See the parameter's docstring for the kernel-struct motivation.
+  std::size_t dynamic_object_instance_count = 0;
+
 public:
   typedef std::set<irep_idt> recursion_sett;
 

--- a/src/util/object_factory_parameters.cpp
+++ b/src/util/object_factory_parameters.cpp
@@ -23,6 +23,11 @@ void object_factory_parameterst::set(const optionst &options)
     max_nondet_tree_depth =
       options.get_unsigned_int_option("max-nondet-tree-depth");
   }
+  if(options.is_set("max-dynamic-object-instances"))
+  {
+    max_dynamic_object_instances =
+      options.get_unsigned_int_option("max-dynamic-object-instances");
+  }
   if(options.is_set("min-null-tree-depth"))
   {
     min_null_tree_depth =
@@ -62,6 +67,12 @@ void parse_object_factory_options(const cmdlinet &cmdline, optionst &options)
   {
     options.set_option(
       "max-nondet-tree-depth", cmdline.get_value("max-nondet-tree-depth"));
+  }
+  if(cmdline.isset("max-dynamic-object-instances"))
+  {
+    options.set_option(
+      "max-dynamic-object-instances",
+      cmdline.get_value("max-dynamic-object-instances"));
   }
   if(cmdline.isset("min-null-tree-depth"))
   {

--- a/src/util/object_factory_parameters.h
+++ b/src/util/object_factory_parameters.h
@@ -57,6 +57,37 @@ struct object_factory_parameterst
   /// initialized to their full depth.
   size_t max_nondet_tree_depth = 5;
 
+  /// Maximum total number of dynamic objects the object factory will
+  /// allocate on behalf of a single nondet-initialisation root.
+  ///
+  /// The `max_nondet_tree_depth` cap above only fires when the same
+  /// struct tag appears twice on the same pointer chain, which is the
+  /// pattern the object factory historically worried about (linked
+  /// lists, trees).  Wide-but-non-recursive struct hierarchies, by
+  /// contrast, are deep without ever revisiting the same type: a single
+  /// pointer transitively reaches many further pointer-to-struct fields,
+  /// none of which cycle back, so the depth cap never fires and the
+  /// object factory generates an exponentially large init body.
+  ///
+  /// This hard cap on allocation count provides a belt-and-braces
+  /// termination guarantee independent of the depth cap.  When the cap
+  /// is hit, further pointers are initialized to NULL rather than to
+  /// freshly-allocated sub-structs.  This is an under-approximation: the
+  /// non-null branch is dropped, so paths through such pointers are no
+  /// longer explored, and the force-NULL applies even below
+  /// `min_null_tree_depth` (the termination guard overrides it).
+  ///
+  /// Note this defaults to a finite value rather than "unlimited", so it
+  /// changes the default behaviour of *all* C nondet initialisation that
+  /// goes through `c_nondet_symbol_factory` (e.g. `ansi_c_entry_point`,
+  /// not just `--generate-function-body`): a root transitively reaching
+  /// more than this many dynamic objects is now truncated.  The default
+  /// is chosen well above realistic harness needs.  The parameter lives
+  /// in this shared base but is only enforced by the C object factory;
+  /// JBMC's Java factory and goto-harness's recursive initialisation
+  /// neither enforce it nor expose the corresponding CLI option.
+  size_t max_dynamic_object_instances = 1000;
+
   /// To force a certain depth of non-null objects.
   /// The default is that objects are 'maybe null' up to the nondet tree depth.
   /// Examples:


### PR DESCRIPTION
The object factory's max_nondet_tree_depth cap only fires when a struct tag repeats on the pointer chain, so wide-but-non-recursive struct hierarchies still expand exponentially, making --generate-function-body emit an unboundedly large body (and, on large inputs, fail to terminate).

Add object_factory_parameterst::max_dynamic_object_instances (default 1000, exposed as --max-dynamic-object-instances): once the per-root allocation count reaches it, pointers are initialised to NULL instead of recursively expanded. The count is reset at the top-level gen_nondet_init entry, so the cap is enforced per nondet-init root.

Performance: on a goto binary built from Linux 5.10's crypto/algif_aead.c, `goto-instrument --generate-function-body af_alg_alloc_areq --generate-function-body-options havoc` previously did not terminate (still running after 4 hours of wall-clock time); with this cap it completes in about 2 seconds, emitting a ~10 MB goto binary.

Add a regression test with a deep non-recursive struct hierarchy capped below its natural allocation count; it fails if the cap is reverted.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
