### PR TITLE
goto-programs: name_mangler — also rename child symbols of mangled functions

### DIFF
--- a/regression/goto-cc-file-local/child-symbols-mangled/file1.c
+++ b/regression/goto-cc-file-local/child-symbols-mangled/file1.c
@@ -1,0 +1,5 @@
+#include "lib.h"
+int caller1(int a)
+{
+  return helper(a);
+}

--- a/regression/goto-cc-file-local/child-symbols-mangled/file2.c
+++ b/regression/goto-cc-file-local/child-symbols-mangled/file2.c
@@ -1,0 +1,5 @@
+#include "lib.h"
+int caller2(int b)
+{
+  return helper(b);
+}

--- a/regression/goto-cc-file-local/child-symbols-mangled/lib.h
+++ b/regression/goto-cc-file-local/child-symbols-mangled/lib.h
@@ -1,0 +1,12 @@
+// A file-local function defined in a shared header: when two translation
+// units include it and are compiled with --export-file-local-symbols, both
+// mangle `helper` to the same __CPROVER_file_local_lib_h_helper name.  Its
+// parameter symbol (helper::x) must be mangled in lockstep, otherwise the
+// two TUs carry identically-named parameter symbols that clash at link time.
+static int helper(int x)
+{
+  // A body-local variable exercises the function-local scope chain
+  // (helper::...::t), which must be mangled in lockstep with the parameter.
+  int t = x + 1;
+  return t;
+}

--- a/regression/goto-cc-file-local/child-symbols-mangled/main.c
+++ b/regression/goto-cc-file-local/child-symbols-mangled/main.c
@@ -1,0 +1,13 @@
+// A third TU including the same header, providing an entry point so the
+// assertion-check variant can run cbmc on the linked model.  This verifies the
+// linked model is usable -- i.e. the mangled child symbols and the symbol_expr
+// references inside instruction bodies are consistent, not just the
+// symbol-table keys.
+#include "lib.h"
+
+#include <assert.h>
+int main(void)
+{
+  assert(helper(41) == 42);
+  return 0;
+}

--- a/regression/goto-cc-file-local/child-symbols-mangled/test-assertion.desc
+++ b/regression/goto-cc-file-local/child-symbols-mangled/test-assertion.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+final-link assertion-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Companion to test.desc: after linking three TUs that each include the same
+header (so `helper` and its child symbols mangle to the same name and unify),
+run cbmc on the linked model.  This checks the model is actually usable -- the
+mangled symbol_expr references inside instruction bodies and the function's
+parameter_identifiers must be consistent -- which a symbol-table grep alone
+would not catch.

--- a/regression/goto-cc-file-local/child-symbols-mangled/test.desc
+++ b/regression/goto-cc-file-local/child-symbols-mangled/test.desc
@@ -1,0 +1,9 @@
+CORE
+file1.c
+final-link show-symbol-table
+^EXIT=0$
+^SIGNAL=0$
+__CPROVER_file_local_lib_h_helper::x
+__CPROVER_file_local_lib_h_helper::1::t
+--
+^warning: ignoring

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -7,6 +7,7 @@
 
 #include <util/message.h>
 #include <util/rename_symbol.h>
+#include <util/std_types.h>
 
 #include "goto_model.h"
 
@@ -51,7 +52,7 @@ public:
     rename_symbolt rename;
     std::map<irep_idt, irep_idt> renamed_funs;
     std::vector<symbolt> new_syms;
-    std::vector<symbol_tablet::symbolst::const_iterator> old_syms;
+    std::vector<irep_idt> old_syms;
 
     for(auto sym_it = model.symbol_table.symbols.begin();
         sym_it != model.symbol_table.symbols.end();
@@ -75,7 +76,7 @@ public:
       new_sym.is_file_local = false;
 
       new_syms.push_back(new_sym);
-      old_syms.push_back(sym_it);
+      old_syms.push_back(sym.name);
 
       rename.insert(sym.symbol_expr(), new_sym.symbol_expr());
       renamed_funs.insert(std::make_pair(sym.name, mangled));
@@ -83,10 +84,72 @@ public:
       log.debug() << "Mangling: " << sym.name << " -> " << mangled << log.eom;
     }
 
+    // Second pass: rename scoped child symbols of renamed
+    // functions.  Parameter symbols and function-local
+    // variables are stored in the symbol table under names of
+    // the form `<function_name>::<base_name>` (and longer
+    // scope chains for nested locals).  Without renaming
+    // these, two translation units that include the same
+    // kernel header end up with identically-named parameter
+    // symbols (e.g. `security_netlink_send::sk` from both
+    // TUs); the linker then either accepts them with a
+    // `$link1` suffix on one (unifying the function symbol
+    // under its external name) or rejects them as
+    // 'conflicting function declarations' depending on
+    // whether the parameter types match exactly.  The fix is
+    // to rename child symbols in lockstep with the parent
+    // function so the per-TU mangling is complete.
+    std::vector<symbolt> new_child_syms;
+    std::vector<irep_idt> old_child_syms;
+    for(const auto &sym_pair : model.symbol_table.symbols)
+    {
+      const std::string sym_name = id2string(sym_pair.first);
+      // Child symbols are scoped as `<function>::<rest>`.  Renamed file-local
+      // function names never contain "::" themselves (plain C file-local names
+      // and the __CPROVER_file_local_<file>_<sym> mangling are "::"-free), so
+      // the leading scope up to the first "::" is the owning function's name.
+      // A single lookup then decides whether this symbol belongs to a renamed
+      // function; this also subsumes skipping the function symbols themselves,
+      // since those have no "::".
+      const std::size_t sep = sym_name.find("::");
+      if(sep == std::string::npos)
+        continue;
+      auto renamed = renamed_funs.find(sym_name.substr(0, sep));
+      if(renamed == renamed_funs.end())
+        continue;
+
+      const irep_idt new_name =
+        id2string(renamed->second) + sym_name.substr(sep);
+      symbolt new_child = sym_pair.second;
+      new_child.name = new_name;
+      // Clear file_local on the child symbols too: the parent
+      // function has just transitioned from file-local to
+      // globally-mangled and unifiable, and the linker's
+      // file-local renaming rule (RENAME_NEW for any
+      // file_local symbol it sees on the new side of a link)
+      // would otherwise force `$link1` suffixes on each
+      // duplicate child symbol — defeating the unification we
+      // just set up.  The new mangled name is unique across
+      // TUs that share the header but should unify cleanly
+      // when two TUs include the SAME header (because both
+      // ends of the link produce identical mangled names).
+      new_child.is_file_local = false;
+      new_child_syms.push_back(new_child);
+      old_child_syms.push_back(sym_pair.first);
+      rename.insert(sym_pair.second.symbol_expr(), new_child.symbol_expr());
+    }
+
     for(const auto &sym : new_syms)
       model.symbol_table.insert(sym);
-    for(const auto &sym : old_syms)
-      model.symbol_table.erase(sym);
+    // Erase the originals by name (not by stored iterator): the inserts above
+    // may have rehashed symbol_table.symbols, which would invalidate any held
+    // iterators.  symbol_tablet::remove re-finds the entry, so it is safe.
+    for(const auto &name : old_syms)
+      model.symbol_table.remove(name);
+    for(const auto &sym : new_child_syms)
+      model.symbol_table.insert(sym);
+    for(const auto &name : old_child_syms)
+      model.symbol_table.remove(name);
 
     for(auto it = model.symbol_table.begin(); it != model.symbol_table.end();
         ++it)
@@ -130,6 +193,17 @@ public:
       if(!inserted.second)
         log.debug() << "Found a mangled name that already exists: "
                     << std::string(pair.second.c_str()) << log.eom;
+
+      // The moved goto_functiont still carries parameter_identifiers scoped
+      // under the old function name; the rename above only updated the
+      // identifiers embedded in the symbol's code_typet.  Re-derive the vector
+      // from that (now renamed) code_typet so the in-memory model is
+      // self-consistent -- otherwise goto_functionst::validate() and any
+      // in-memory consumer would look up the stale `<old_func>::param` names.
+      const symbolt &fun_sym = model.symbol_table.lookup_ref(pair.second);
+      if(fun_sym.type.id() == ID_code)
+        inserted.first->second.set_parameter_identifiers(
+          to_code_type(fun_sym.type));
 
       model.goto_functions.function_map.erase(found);
     }


### PR DESCRIPTION
The function_name_manglert renames file-local function symbols (when --export-file-local-symbols is in use) to a mangled form __CPROVER_file_local_<file>_<sym> so the same function from multiple TUs ends up under a unique unifiable name.

Bug: the mangle pass renames the function symbol but does not rename the parameter and local-variable symbols whose names are scoped under the function's name (e.g. <function>::param_name). After mangling, the function symbol becomes
__CPROVER_file_local_<header>_<func> but the parameter symbol is still <func>::param.  At link time, two TUs that include the same header end up with identical parameter symbol names; CBMC's linker then either applies a  suffix to disambiguate them (breaking parameter-name agreement in the function type) or reports 'conflicting function declarations' depending on what else differs.

Fix: in mangle(), after identifying the file-local functions to rename, do a second pass to rename child symbols whose names start with .  Each child gets its name
prefix updated to the mangled function name and its is_file_local flag cleared (the parent function transitioned to globally-mangled-and-unifiable, and the linker's RENAME_NEW rule for file-local symbols would otherwise force per-TU divergence on each duplicate child).  The rename map covers function-type parameter identifiers too, so symbol_expr references inside the function body's goto-instructions are updated consistently.

Practical effect: kernel TUs compiled with
--export-file-local-symbols can now be linked together with synthesised harness TUs that pull in the same kernel headers, without spurious 'conflicting function declarations' on parameter symbols of static-inline kernel header functions.

Limitation surfaced during validation: even with the parameter mangling fixed, linking real kernel TUs against harness TUs that include extensive kernel headers still surfaces a separate class of conflict where one TU has a forward-declared struct () and the other has the full struct definition
inlined into the function type irep.  CBMC's irep equality is naive byte-comparison and rejects this even though both refer to the same C type.  That is a deeper issue (type-completeness agreement between TUs) requiring further investigation; this commit does not address it.  The fix here is still a prerequisite for any solution to the deeper issue.

Validated: all 98 CORE ctest entries pass.  All
integration/linux regressions pass:
  - scan/run.sh cases 1-9
  - test-per-file.sh
  - test-per-file-mode.sh cases 1-4
  - smoke-all-lts.sh (4/4)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
