### PR TITLE
Simplify member access into a compound literal

### DIFF
--- a/regression/ansi-c/compound_literal_member_static/main.c
+++ b/regression/ansi-c/compound_literal_member_static/main.c
@@ -1,0 +1,66 @@
+// A constant static initializer that nests a compound literal projected
+// through a union member -- the shape of the kernel's dynamic-debug
+// _ddebug descriptor whose .key union is initialised from the
+// STATIC_KEY_FALSE_INIT compound literal.  Before member-of-compound-
+// literal simplification, the typechecker rejected this with "expected
+// constant expression".
+typedef struct
+{
+  int counter;
+} atomic_t;
+
+struct static_key
+{
+  atomic_t enabled;
+  union
+  {
+    unsigned long type;
+    void *entries;
+  };
+};
+
+struct static_key_false
+{
+  struct static_key key;
+};
+struct static_key_true
+{
+  struct static_key key;
+};
+
+#define STATIC_KEY_INIT_FALSE                                                  \
+  {                                                                            \
+    .enabled = {0},                                                            \
+    {                                                                          \
+      .type = 0ul                                                              \
+    }                                                                          \
+  }
+#define STATIC_KEY_FALSE_INIT                                                  \
+  (struct static_key_false)                                                    \
+  {                                                                            \
+    .key = STATIC_KEY_INIT_FALSE,                                              \
+  }
+
+struct ddebug
+{
+  const char *function;
+  unsigned flags;
+  union
+  {
+    struct static_key_true dd_key_true;
+    struct static_key_false dd_key_false;
+  } key;
+};
+
+int main(void)
+{
+  static struct ddebug d = {
+    .function = __func__,
+    .flags = 0,
+    .key.dd_key_false = (STATIC_KEY_FALSE_INIT),
+  };
+  __CPROVER_assert(
+    d.key.dd_key_false.key.enabled.counter == 0,
+    "compound-literal member folds to its constant");
+  return 0;
+}

--- a/regression/ansi-c/compound_literal_member_static/test.desc
+++ b/regression/ansi-c/compound_literal_member_static/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+expected constant expression

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -125,6 +125,22 @@ simplify_exprt::simplify_member(const member_exprt &expr)
       return op.operands()[number];
     }
   }
+  else if(op.id() == ID_compound_literal)
+  {
+    // member(compound_literal(v), .m) -> member(v, .m)
+    // A compound literal `(TYPE){ ... }` wraps its initializer value (a
+    // struct/union/array expression) as its single operand; unwrap it so
+    // the struct/union member-extraction rules below can fold the access.
+    // This is needed for constant static initializers that nest a
+    // compound literal (e.g. the kernel's dynamic-debug _ddebug descriptor
+    // whose .key field is initialised from the STATIC_KEY_FALSE_INIT
+    // compound literal).
+    DATA_INVARIANT(
+      op.operands().size() == 1, "ID_compound_literal has a single operand");
+    auto new_expr = expr;
+    new_expr.struct_op() = to_unary_expr(op).op();
+    return changed(simplify_member(new_expr));
+  }
   else if(op.id()==ID_byte_extract_little_endian ||
           op.id()==ID_byte_extract_big_endian)
   {

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -710,3 +710,18 @@ TEST_CASE("Simplify complementary pair in nested OR", "[core][util]")
   const or_exprt expr{a, inner};
   REQUIRE(simplify_expr(expr, empty_namespace) == true_exprt{});
 }
+
+TEST_CASE("Simplify member of compound literal", "[core][util]")
+{
+  // member(compound_literal((struct){ .counter = 0 }), .counter) folds to 0.
+  // Without the simplify_member compound-literal rule this does not fold, so
+  // this pins that rule independently of the front-end.
+  const signedbv_typet int_type{32};
+  const struct_typet struct_type{{{"counter", int_type}}};
+  const struct_exprt struct_value{{from_integer(0, int_type)}, struct_type};
+  const unary_exprt compound_literal{
+    ID_compound_literal, struct_value, struct_type};
+  const member_exprt member{compound_literal, "counter", int_type};
+
+  REQUIRE(simplify_expr(member, empty_namespace) == from_integer(0, int_type));
+}


### PR DESCRIPTION
simplify_member now folds `member(compound_literal(v), .m)` by unwrapping the compound literal to its single initializer operand `v` and recursing, so the existing struct/union member-extraction rules apply.

This fixes a constant-folding gap that made the C front-end reject valid constant static initializers nesting a compound literal: the kernel's dynamic-debug `_ddebug` descriptor initialises its `.key` union from the `STATIC_KEY_FALSE_INIT` compound literal (under CONFIG_JUMP_LABEL), which projected to `member(compound_literal{...}, .key.enabled.counter)`.  That member-of-compound-literal was not simplified, so make_constant's is_compile_time_constantt rejected it with "expected constant expression" -- blocking goto-cc on every linux-6.12 translation unit that uses dynamic debug (sound/usb, fs/hfsplus, fs/jfs, ...).  With the fix sound/usb/format.c (and the rest) goto-cc cleanly.

regression/ansi-c/compound_literal_member_static reproduces the _ddebug shape (a static struct whose union field is initialised from a compound literal) and checks the projected member folds to its constant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
