### PR TITLE
SMT2: skip element enumeration for non-integer-keyed array literals

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5893,12 +5893,29 @@ void smt2_convt::find_symbols(const exprt &expr)
       convert_type(array_type);
       out << ")" << "\n";
 
-      if(!is_zero_width(array_type.element_type(), ns))
+      // Per-element constraints enumerate indices via from_integer(i,
+      // index_type), so the index type must be one from_integer can build a
+      // constant for: an integer/bitvector type or a C enum. A c_enum_tag is
+      // followed to its underlying c_enum type (from_integer has no c_enum_tag
+      // branch). Arrays keyed by some other domain (e.g. Strata's `Map Ref _`,
+      // a struct or pointer key) are left unconstrained -- a sound
+      // over-approximation.
+      const typet &idx_t = array_type.index_type();
+      const typet &index_constant_type =
+        idx_t.id() == ID_c_enum_tag
+          ? static_cast<const typet &>(ns.follow_tag(to_c_enum_tag_type(idx_t)))
+          : idx_t;
+      const bool enumerable_index =
+        can_cast_type<integer_bitvector_typet>(index_constant_type) ||
+        index_constant_type.id() == ID_bv ||
+        index_constant_type.id() == ID_integer ||
+        index_constant_type.id() == ID_c_enum;
+      if(!is_zero_width(array_type.element_type(), ns) && enumerable_index)
       {
         for(std::size_t i = 0; i < expr.operands().size(); i++)
         {
           out << "(assert (= (select " << id << " ";
-          convert_expr(from_integer(i, array_type.index_type()));
+          convert_expr(from_integer(i, index_constant_type));
           out << ") "; // select
           if(array_type.element_type().id() == ID_bool && !use_array_of_bool)
           {

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -615,3 +615,86 @@ TEST_CASE(
   REQUIRE(operands_map.size() == 1);
   REQUIRE(operands_map.count(-1) == 1);
 }
+
+/// Helper: the full SMT2 text emitted by set_to for \p expr (used to inspect
+/// the array-constructor substitute produced by find_symbols).
+static std::string set_to_output(const namespacet &ns, const exprt &expr)
+{
+  std::ostringstream out;
+  smt2_convt conv(
+    ns, "test", "", "QF_AUFBV", smt2_convt::solvert::GENERIC, out);
+  conv.set_to(expr, true);
+  return out.str();
+}
+
+TEST_CASE(
+  "smt2_convt array literal with an integer index is enumerated",
+  "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const unsignedbv_typet element_type{8};
+  const array_typet array_type{element_type, from_integer(2, size_type())};
+  const array_exprt array_literal{
+    {from_integer(1, element_type), from_integer(2, element_type)}, array_type};
+  const symbol_exprt array_symbol{"arr", array_type};
+
+  const std::string output =
+    set_to_output(ns, equal_exprt{array_symbol, array_literal});
+
+  // an integer index type is enumerable: per-element select constraints emitted
+  REQUIRE(output.find("(select array.") != std::string::npos);
+}
+
+TEST_CASE(
+  "smt2_convt array literal with a c_enum_tag index is enumerated",
+  "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  const c_enum_typet enum_type{unsignedbv_typet{32}};
+  const type_symbolt enum_symbol{"my_enum", enum_type, ID_C};
+  symbol_table.insert(enum_symbol);
+  const namespacet ns{symbol_table};
+  const c_enum_tag_typet enum_tag{enum_symbol.name};
+
+  const unsignedbv_typet element_type{8};
+  array_typet array_type{element_type, from_integer(2, size_type())};
+  array_type.index_type_nonconst() = enum_tag;
+  const array_exprt array_literal{
+    {from_integer(1, element_type), from_integer(2, element_type)}, array_type};
+  const symbol_exprt array_symbol{"arr", array_type};
+
+  const std::string output =
+    set_to_output(ns, equal_exprt{array_symbol, array_literal});
+
+  // a c_enum_tag index is followed to its underlying c_enum and enumerated;
+  // before the fix from_integer aborts on c_enum_tag
+  REQUIRE(output.find("(select array.") != std::string::npos);
+}
+
+TEST_CASE(
+  "smt2_convt array literal with a non-scalar index is left unconstrained",
+  "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+
+  const unsignedbv_typet element_type{8};
+  array_typet array_type{element_type, from_integer(2, size_type())};
+  // a struct (non-scalar) index type, as in Strata's `Map Ref _`
+  array_type.index_type_nonconst() = struct_typet{{{"x", unsignedbv_typet{8}}}};
+  const array_exprt array_literal{
+    {from_integer(1, element_type), from_integer(2, element_type)}, array_type};
+  const symbol_exprt array_symbol{"arr", array_type};
+
+  const std::string output =
+    set_to_output(ns, equal_exprt{array_symbol, array_literal});
+
+  // the array is still declared, but no per-element constraints are emitted:
+  // from_integer cannot build a constant of a struct index type, so the array
+  // is left unconstrained (a sound over-approximation)
+  REQUIRE(
+    output.find("substitute for an array constructor") != std::string::npos);
+  REQUIRE(output.find("(select array.") == std::string::npos);
+}


### PR DESCRIPTION
The array-constructor substitute in find_symbols enumerates element indices via from_integer(i, index_type), which is only valid for integer/bitvector index types. For arrays keyed by a non-scalar type, leave the array unconstrained (a sound over-approximation) rather than constructing an integer constant of a non-integer index type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
