### PR TITLE
SMT2: tolerate non-constant array indices when parsing array models

### DIFF
--- a/regression/cbmc/extern6/test.desc
+++ b/regression/cbmc/extern6/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend no-new-smt
+CORE no-new-smt
 main.c
 
 ^EXIT=10$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -639,6 +639,12 @@ void smt2_convt::walk_array_tree(
     // Recurse
     walk_array_tree(operands_map, src.get_sub()[1], type);
     const auto index_expr = parse_rec(src.get_sub()[2], type.size().type());
+    if(!index_expr.is_constant())
+      // The index in a (store array index value) term is not necessarily a
+      // constant: models for unbounded or non-integer-keyed arrays can carry
+      // a symbolic/non-constant index. Such an entry cannot be placed in the
+      // index-keyed operands map, so skip it during model reconstruction.
+      return;
     const constant_exprt index_constant = to_constant_expr(index_expr);
     mp_integer tempint;
     bool failure = to_integer(index_constant, tempint);

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -8,6 +8,7 @@
 #include <util/bitvector_types.h>
 #include <util/c_types.h>
 #include <util/ieee_float.h>
+#include <util/invariant.h>
 #include <util/mathematical_expr.h>
 #include <util/mathematical_types.h>
 #include <util/message.h>
@@ -540,4 +541,77 @@ TEST_CASE(
     string_builtin_app(ID_cprover_string_in_regex_func, {s, re}, bool_typet{});
   conv.set_to(in, true);
   REQUIRE(out.str().find("RegLan") != std::string::npos);
+}
+
+/// Subclass exposing the protected \ref smt2_convt::walk_array_tree method so
+/// the array-model parse direction can be exercised directly.
+class array_tree_smt2_convt : public smt2_convt
+{
+public:
+  using smt2_convt::smt2_convt;
+  using smt2_convt::walk_array_tree;
+};
+
+/// Helper: build an irept node carrying just an id.
+static irept smt_node(const irep_idt &id)
+{
+  irept node;
+  node.id(id);
+  return node;
+}
+
+TEST_CASE(
+  "smt2_convt::walk_array_tree skips non-constant store indices",
+  "[core][solvers][smt2]")
+{
+  // A solver may return an array model whose store term carries a
+  // non-constant index (e.g. for unbounded or non-integer-keyed arrays).
+  // walk_array_tree must skip such an entry rather than abort in
+  // to_constant_expr, while still collecting the well-formed entries.
+  //
+  // Put invariants into throwing mode: without the is_constant() guard,
+  // to_constant_expr fails via an INVARIANT that aborts the unit binary by
+  // default; throwing mode turns that into an exception REQUIRE_NOTHROW can
+  // report as a clean test failure.
+  const cbmc_invariants_should_throwt invariants_throw;
+
+  // The index is parsed against type.size().type(); a bool-typed size makes
+  // a plain symbol index parse to a non-constant (nil) expression, which is
+  // the case the guard handles. (parse_rec coerces arithmetic index types to
+  // constants, so a non-constant index can only arise from a non-arithmetic
+  // index type.)
+  const signedbv_typet element_type{32};
+  const array_typet array_type{element_type, symbol_exprt{"n", bool_typet{}}};
+
+  // (as const <type> 0): a well-formed default entry, collected at index -1
+  // without going through index parsing.
+  irept as_const_header;
+  as_const_header.get_sub().push_back(smt_node("as"));
+  as_const_header.get_sub().push_back(smt_node("const"));
+  as_const_header.get_sub().push_back(irept{}); // type info, unused here
+  irept as_const_node;
+  as_const_node.get_sub().push_back(as_const_header);
+  as_const_node.get_sub().push_back(smt_node("0")); // default value 0
+
+  // (store (as const <type> 0) x 7): the index "x" is a plain symbol, so it
+  // parses to a non-constant under the bool-typed index type and must be
+  // dropped.
+  irept store_node;
+  store_node.get_sub().push_back(smt_node("store"));
+  store_node.get_sub().push_back(as_const_node);
+  store_node.get_sub().push_back(smt_node("x")); // non-constant index
+  store_node.get_sub().push_back(smt_node("7")); // value, must not survive
+
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  std::ostringstream out;
+  array_tree_smt2_convt conv{
+    ns, "test", "", "QF_BV", smt2_convt::solvert::GENERIC, out};
+
+  std::unordered_map<int64_t, exprt> operands_map;
+  REQUIRE_NOTHROW(conv.walk_array_tree(&operands_map, store_node, array_type));
+
+  // The non-constant store was dropped; only the well-formed default remains.
+  REQUIRE(operands_map.size() == 1);
+  REQUIRE(operands_map.count(-1) == 1);
 }


### PR DESCRIPTION
smt2_convt::walk_array_tree assumes every (store array index value) term in a solver-returned array model has a constant index, calling to_constant_expr on it unconditionally. Models for unbounded or non-integer-keyed arrays can contain a non-constant index, which trips the to_constant_expr precondition. Skip such store entries during model reconstruction instead of aborting.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
