### PR TITLE
cprover: state-encoding for uninterpreted functions and member/index lvalues

### DIFF
--- a/regression/cprover/enter_scope_mathematical_size/main.c
+++ b/regression/cprover/enter_scope_mathematical_size/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  // A variable of a mathematical type (here: an unbounded integer) has no
+  // statically computable byte size. The enter-scope-state term for it falls
+  // back to a unit size rather than aborting; this is sound because such
+  // objects are not byte-addressed. See state_encoding_smt2_convt::
+  // add_converters (ID_enter_scope_state).
+  __CPROVER_integer x;
+
+  __CPROVER_assert(1, "reachable");
+  return 0;
+}

--- a/regression/cprover/enter_scope_mathematical_size/test.desc
+++ b/regression/cprover/enter_scope_mathematical_size/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--smt2 --inline
+^EXIT=0$
+^SIGNAL=0$
+\(enter-scope-state-p\d+ \|ς\| \(object-address "main::1::x"\) \(_ bv1 \d+\)\)
+--

--- a/regression/cprover/struct_assignment_if/main.c
+++ b/regression/cprover/struct_assignment_if/main.c
@@ -1,0 +1,20 @@
+struct S
+{
+  int x, y;
+};
+
+int nondet_int(void);
+
+int main()
+{
+  struct S a, b, t;
+  int c = nondet_int();
+
+  // A whole-struct value computed by an if-then-else must be assigned to t in
+  // one go, rather than split into per-field assignments. See
+  // assignment_constraint_rec / is_whole_struct_value.
+  t = c ? a : b;
+
+  __CPROVER_assert(c == c, "reachable");
+  return 0;
+}

--- a/regression/cprover/struct_assignment_if/test.desc
+++ b/regression/cprover/struct_assignment_if/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--text --solve --inline
+^EXIT=0$
+^SIGNAL=0$
+❝main::1::t❞:=\(ς\(❝main::1::c❞\) ≠ 0 \?
+^\[main\.assertion\.1\] line \d+ reachable: SUCCESS$
+--
+❝main::1::t❞\.❝x❞:=

--- a/regression/cprover/struct_datatypes/main.c
+++ b/regression/cprover/struct_datatypes/main.c
@@ -1,0 +1,15 @@
+struct S
+{
+  int x, y;
+};
+
+int main()
+{
+  // Struct values are emitted using SMT datatypes (use_datatypes is enabled
+  // for this encoder so that whole-struct values can be expressed). The SMT2
+  // output therefore declares a datatype for struct S.
+  struct S s;
+  s.x = 1;
+  __CPROVER_assert(s.x == 1, "property 1");
+  return 0;
+}

--- a/regression/cprover/struct_datatypes/test.desc
+++ b/regression/cprover/struct_datatypes/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--smt2 --inline
+^EXIT=0$
+^SIGNAL=0$
+^\(declare-datatypes 
+--

--- a/regression/cprover/struct_ternary_field_read/main.c
+++ b/regression/cprover/struct_ternary_field_read/main.c
@@ -1,0 +1,23 @@
+struct S
+{
+  int x, y;
+};
+
+int nondet_int(void);
+
+int main()
+{
+  struct S a, b, t;
+  int c = nondet_int();
+
+  // Whole-struct if-assignment: t is stored as a single (datatype) value.
+  t = c ? a : b;
+
+  // Reading individual fields of t via their addresses must agree with the
+  // per-branch field values. This exercises the bridge between the whole
+  // struct value stored for t and the field-address reads of t.x / t.y.
+  __CPROVER_assert(t.x == (c ? a.x : b.x), "field x after ternary");
+  __CPROVER_assert(t.y == (c ? a.y : b.y), "field y after ternary");
+
+  return 0;
+}

--- a/regression/cprover/struct_ternary_field_read/test.desc
+++ b/regression/cprover/struct_ternary_field_read/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--text --solve --inline
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line \d+ field x after ternary: SUCCESS$
+^\[main\.assertion\.2\] line \d+ field y after ternary: SUCCESS$
+--

--- a/src/cprover/simplify_state_expr.cpp
+++ b/src/cprover/simplify_state_expr.cpp
@@ -52,6 +52,46 @@ exprt simplify_evaluate_update(
 
   const auto &update_state_expr = to_update_state_expr(evaluate_expr.state());
 
+  // Reading a field or element of an object that was updated with a whole
+  // (struct or array) value:
+  //   (ς[A := V])(field_address(A, f))   --> member(V, f)
+  //   (ς[A := V])(element_address(A, i)) --> V[i]
+  // The may-alias dispatch below compares the sub-component address against
+  // the whole-object update address, finds them to be different addresses,
+  // and would therefore incorrectly skip the update. Handle this overlap
+  // explicitly first. This only fires when the update wrote exactly the
+  // object whose component is being read (single level of nesting).
+  if(evaluate_expr.address().id() == ID_field_address)
+  {
+    const auto &field_address = to_field_address_expr(evaluate_expr.address());
+    auto base_alias = ::may_alias(
+      field_address.base(), update_state_expr.address(), address_taken, ns);
+    if(base_alias.has_value() && base_alias->is_true())
+    {
+      const member_exprt member{
+        update_state_expr.new_value(),
+        field_address.component_name(),
+        evaluate_expr.type()};
+      return simplify_state_expr_node(member, address_taken, ns);
+    }
+  }
+  else if(evaluate_expr.address().id() == ID_element_address)
+  {
+    const auto &element_address =
+      to_element_address_expr(evaluate_expr.address());
+    auto base_alias = ::may_alias(
+      element_address.base(), update_state_expr.address(), address_taken, ns);
+    if(base_alias.has_value() && base_alias->is_true())
+    {
+      const index_exprt index{
+        update_state_expr.new_value(), element_address.index()};
+      return simplify_state_expr_node(
+        typecast_exprt::conditional_cast(index, evaluate_expr.type()),
+        address_taken,
+        ns);
+    }
+  }
+
 #if 0
   std::cout << "U: " << format(update_state_expr) << "\n";
   std::cout << "u: " << format(update_state_expr.address()) << "\n";
@@ -1078,6 +1118,75 @@ exprt simplify_state_expr_node(
         else
           return false_exprt();
       }
+    }
+  }
+  else if(src.id() == ID_member)
+  {
+    const auto &member_expr = to_member_expr(src);
+    const exprt &compound = member_expr.struct_op();
+    const irep_idt &component = member_expr.get_component_name();
+    if(compound.id() == ID_evaluate)
+    {
+      // Bridge the datatype view of a whole-object read and the field-address
+      // scalar view, so both representations of a struct field agree:
+      //   member(evaluate(s, A), f) --> evaluate(s, field_address(A, f))
+      const auto &evaluate_expr = to_evaluate_expr(compound);
+      field_address_exprt field_address{
+        evaluate_expr.address(), component, pointer_type(member_expr.type())};
+      return simplify_state_expr_node(
+        evaluate_exprt{
+          evaluate_expr.state(), std::move(field_address), member_expr.type()},
+        address_taken,
+        ns);
+    }
+    else if(compound.id() == ID_if)
+    {
+      // distribute member over if, so the bridge above applies to each arm
+      const auto &if_expr = to_if_expr(compound);
+      return if_exprt{
+        if_expr.cond(),
+        simplify_state_expr_node(
+          member_exprt{if_expr.true_case(), component, member_expr.type()},
+          address_taken,
+          ns),
+        simplify_state_expr_node(
+          member_exprt{if_expr.false_case(), component, member_expr.type()},
+          address_taken,
+          ns)};
+    }
+  }
+  else if(src.id() == ID_index)
+  {
+    const auto &index_expr = to_index_expr(src);
+    const exprt &array = index_expr.array();
+    if(array.id() == ID_evaluate)
+    {
+      // as for member: index(evaluate(s, A), i) -->
+      //   evaluate(s, element_address(A, i))
+      const auto &evaluate_expr = to_evaluate_expr(array);
+      element_address_exprt element_address{
+        evaluate_expr.address(),
+        index_expr.index(),
+        pointer_type(index_expr.type())};
+      return simplify_state_expr_node(
+        evaluate_exprt{
+          evaluate_expr.state(), std::move(element_address), index_expr.type()},
+        address_taken,
+        ns);
+    }
+    else if(array.id() == ID_if)
+    {
+      const auto &if_expr = to_if_expr(array);
+      return if_exprt{
+        if_expr.cond(),
+        simplify_state_expr_node(
+          index_exprt{if_expr.true_case(), index_expr.index()},
+          address_taken,
+          ns),
+        simplify_state_expr_node(
+          index_exprt{if_expr.false_case(), index_expr.index()},
+          address_taken,
+          ns)};
     }
   }
 

--- a/src/cprover/state_encoding.cpp
+++ b/src/cprover/state_encoding.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/expr_util.h>
 #include <util/mathematical_expr.h>
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
@@ -204,6 +205,31 @@ exprt state_encodingt::replace_nondet_rec(
   }
 }
 
+/// Returns the base expression of a (possibly nested) member/index access
+/// chain, i.e. the first operand that is neither a member nor an index
+/// expression.
+static const exprt &member_index_base(const exprt &expr)
+{
+  const exprt *e = &expr;
+  while(e->id() == ID_member || e->id() == ID_index)
+  {
+    e = e->id() == ID_member ? &to_member_expr(*e).struct_op()
+                             : &to_index_expr(*e).array();
+  }
+  return *e;
+}
+
+/// True if a struct-typed assignment RHS denotes a complete computed value (a
+/// function application or if-then-else, possibly behind typecasts) that must
+/// be assigned as a whole. Splitting such an RHS into per-field assignments
+/// would re-evaluate the computed value (e.g. re-apply the function) once per
+/// field.
+static bool is_whole_struct_value(const exprt &rhs)
+{
+  const exprt &skipped = skip_typecast(rhs);
+  return skipped.id() == ID_function_application || skipped.id() == ID_if;
+}
+
 exprt state_encodingt::evaluate_expr_rec(
   loct loc,
   const exprt &state,
@@ -222,6 +248,12 @@ exprt state_encodingt::evaluate_expr_rec(
       return evaluate_exprt(
         state, address_rec(loc, state, new_symbol), what.type());
     }
+    else if(symbol_expr.type().id() == ID_mathematical_function)
+    {
+      // Pure function symbols (uninterpreted functions) are not state
+      // variables — leave them as-is.
+      return what;
+    }
     else if(bound_symbols.find(symbol_expr) == bound_symbols.end())
     {
       return evaluate_exprt(state, address_rec(loc, state, what), what.type());
@@ -229,11 +261,32 @@ exprt state_encodingt::evaluate_expr_rec(
     else
       return what; // leave as is
   }
-  else if(
-    what.id() == ID_dereference || what.id() == ID_member ||
-    what.id() == ID_index)
+  else if(what.id() == ID_dereference)
   {
     return evaluate_exprt(state, address_rec(loc, state, what), what.type());
+  }
+  else if(what.id() == ID_member || what.id() == ID_index)
+  {
+    // Find the base of the member/index access chain. If the base is an
+    // addressable lvalue (symbol, dereference, or string constant -- all of
+    // which address_rec handles), use the address-based evaluation path.
+    // Otherwise (e.g. a function_application returning a struct), evaluate the
+    // operands directly.
+    const exprt &base = member_index_base(what);
+
+    if(
+      base.id() == ID_symbol || base.id() == ID_dereference ||
+      base.id() == ID_string_constant)
+    {
+      return evaluate_exprt(state, address_rec(loc, state, what), what.type());
+    }
+    else
+    {
+      exprt tmp = what;
+      for(auto &op : tmp.operands())
+        op = evaluate_expr_rec(loc, state, op, bound_symbols);
+      return tmp;
+    }
   }
   else if(what.id() == ID_forall || what.id() == ID_exists)
   {
@@ -506,9 +559,11 @@ exprt state_encodingt::assignment_constraint_rec(
   exprt rhs,
   std::vector<symbol_exprt> &nondet_symbols) const
 {
-  if(lhs.type().id() == ID_struct_tag)
+  if(lhs.type().id() == ID_struct_tag && !is_whole_struct_value(rhs))
   {
     // split up into fields, recursively
+    // (but not when the RHS is a computed whole-struct value such as a
+    // function_application or if-then-else -- see is_whole_struct_value)
     const namespacet ns(goto_model.symbol_table);
     const auto &struct_type = ns.follow_tag(to_struct_tag_type(lhs.type()));
     exprt new_state = state;

--- a/src/cprover/state_encoding_targets.cpp
+++ b/src/cprover/state_encoding_targets.cpp
@@ -8,6 +8,9 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "state_encoding_targets.h"
 
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/exception_utils.h>
 #include <util/format_expr.h>
 #include <util/pointer_offset_size.h>
 
@@ -77,10 +80,26 @@ void state_encoding_smt2_convt::add_converters()
     out << ' ';
     convert_expr(to_binary_expr(expr).op1());
     out << ' ';
-    auto size_opt = size_of_expr(
-      to_pointer_type(to_binary_expr(expr).op1().type()).base_type(), ns);
-    CHECK_RETURN(size_opt.has_value());
-    convert_expr(*size_opt);
+    const auto &base_type =
+      to_pointer_type(to_binary_expr(expr).op1().type()).base_type();
+    auto size_opt = size_of_expr(base_type, ns);
+    if(size_opt.has_value())
+      convert_expr(*size_opt);
+    else if(
+      base_type.id() == ID_integer || base_type.id() == ID_natural ||
+      base_type.id() == ID_rational || base_type.id() == ID_real)
+    {
+      // Mathematical types (as used by the Strata encoding) have no byte
+      // size. Such objects are not byte-addressed, so the enter-scope size is
+      // immaterial and a unit size is sound. Any other type without a size is
+      // unexpected (e.g. a function or incomplete type) and fails loudly
+      // below.
+      convert_expr(from_integer(1, size_type()));
+    }
+    else
+      throw incorrect_goto_program_exceptiont(
+        "enter-scope-state for an object whose type has no byte size: " +
+        base_type.id_string());
     out << ')';
   });
 

--- a/src/cprover/state_encoding_targets.h
+++ b/src/cprover/state_encoding_targets.h
@@ -79,6 +79,10 @@ public:
   {
     use_array_of_bool = true;
     use_as_const = true;
+    // Struct (tuple) values returned by functions and other computed
+    // whole-struct values are emitted using SMT datatypes; the solvers this
+    // cprover pipeline targets all support declare-datatypes.
+    use_datatypes = true;
     add_converters();
   }
 


### PR DESCRIPTION
Leave mathematical-function (uninterpreted function) symbols unencoded as state variables, and follow member/index chains to the addressable base expression when state-encoding lvalues.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
