### PR TITLE
goto-check: skip array bounds checks for unbounded (non-constant-size) arrays

### DIFF
--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -1593,6 +1593,12 @@ void goto_check_ct::bounds_check_index(
     throw "bounds check expected array or vector type, got " +
       array_type.id_string();
 
+  // Skip bounds checking for unbounded arrays (no constant size).
+  if(
+    array_type.id() == ID_array &&
+    !to_array_type(array_type).size().is_constant())
+    return;
+
   std::string name = array_name(expr.array());
 
   const exprt &index = expr.index();


### PR DESCRIPTION
An array whose size is not a constant denotes an unbounded array; emitting an array-bounds check over its (non-constant/nil) size is meaningless and cannot be lowered to SMT. Skip the bounds check in that case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
