### PR TITLE
pointer_expr: object-address of struct members with non-constant width

### DIFF
--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -61,7 +61,18 @@ static void build_object_descriptor_rec(
     build_object_descriptor_rec(ns, struct_op, dest);
 
     auto offset = member_offset_expr(member, ns);
-    CHECK_RETURN(offset.has_value());
+    if(!offset.has_value())
+    {
+      // member_offset_expr cannot compute the offset when a preceding member
+      // has non-constant width. Use the member access itself as the (precise)
+      // object; the offset relative to it is then zero, so reset the offset
+      // accumulated while descending into struct_op above. (The ID_index
+      // branch instead keeps the root object and marks the offset unknown --
+      // here the member-as-object form is both consistent and more precise.)
+      dest.object() = member;
+      dest.offset() = from_integer(0, c_index_type());
+      return;
+    }
 
     dest.offset() = plus_exprt(
       dest.offset(),

--- a/unit/util/pointer_expr.cpp
+++ b/unit/util/pointer_expr.cpp
@@ -1,9 +1,15 @@
 // Author: Diffblue Ltd.
 
+#include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/cmdline.h>
+#include <util/config.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_predicates.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
 
+#include <testing-utils/empty_namespace.h>
 #include <testing-utils/invariant.h>
 #include <testing-utils/use_catch.h>
 
@@ -181,4 +187,42 @@ TEST_CASE("object_size_exprt", "[core][util]")
       }
     }
   }
+}
+
+TEST_CASE(
+  "object_descriptor_exprt::build with uncomputable member offset",
+  "[core][util]")
+{
+  // size_of_expr needs a configured architecture (char width, etc.).
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const signedbv_typet int_type{32};
+
+  // INNER { int a[]; int x; }: the leading member 'a' is an incomplete array,
+  // so size_of_expr(a) is empty and member_offset_expr(x) returns nullopt,
+  // which is what drives the fallback under test.
+  struct_typet inner_type;
+  inner_type.components().emplace_back("a", array_typet{int_type, nil_exprt{}});
+  inner_type.components().emplace_back("x", int_type);
+
+  // OUTER { int pad; INNER inner; }: the leading 'pad' means descending into
+  // o.inner accumulates a non-zero offset before the fallback fires, so this
+  // also guards against the offset being double-counted.
+  struct_typet outer_type;
+  outer_type.components().emplace_back("pad", int_type);
+  outer_type.components().emplace_back("inner", inner_type);
+
+  const symbol_exprt o{"o", outer_type};
+  const member_exprt inner_access{o, "inner", inner_type};
+  const member_exprt x_access{inner_access, "x", int_type};
+
+  object_descriptor_exprt odt;
+  odt.build(x_access, empty_namespace);
+
+  // The member access itself becomes the (precise) object, and the offset is
+  // reset to zero -- not left at the offset of 'inner' accumulated while
+  // descending into the struct operand.
+  CHECK(odt.object() == x_access);
+  CHECK(odt.offset() == from_integer(0, c_index_type()));
 }


### PR DESCRIPTION
When the byte offset of a struct member cannot be computed (struct with non-constant-width members), fall back to using the member expression itself as the object rather than asserting.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
