### PR TITLE
cprover: treat the __CPROVER_allocate side effect like malloc

### DIFF
--- a/regression/cprover/pointers/allocate1.c
+++ b/regression/cprover/pointers/allocate1.c
@@ -1,0 +1,16 @@
+// Regression test for cprover rewriting __CPROVER_allocate to a state-tied
+// allocation, which makes the allocate axioms (live_object, object_size, ...)
+// apply to the result. Before the fix the "pointer p safe" checks over the
+// allocated object were spuriously refuted; after the fix they are proved
+// like for malloc.
+void *__CPROVER_allocate(__CPROVER_size_t, int);
+
+int *p;
+
+int main()
+{
+  p = __CPROVER_allocate(sizeof(int) * 10, 0);
+  p[2] = 123;
+  __CPROVER_assert(p[2] == 123, "property 1");
+  return 0;
+}

--- a/regression/cprover/pointers/allocate1.desc
+++ b/regression/cprover/pointers/allocate1.desc
@@ -1,0 +1,10 @@
+CORE
+allocate1.c
+--text --solve --inline
+^EXIT=0$
+^SIGNAL=0$
+^\(\d+\) ∀ ς : state \. S\d+\(ς\) ⇒ S\d+\(ς\[❝main::\$tmp::malloc_value❞:=allocate\(ς, 4 \* cast\(10, unsignedbv\[\d+\]\)\)\]\)$
+^\[main\.pointer\.1\] line \d+ pointer .* safe: SUCCESS$
+^\[main\.pointer\.2\] line \d+ pointer .* safe: SUCCESS$
+^\[main\.assertion\.1\] line \d+ property 1: SUCCESS$
+--

--- a/regression/cprover/pointers/allocate2.c
+++ b/regression/cprover/pointers/allocate2.c
@@ -1,0 +1,13 @@
+// Soundness companion: an out-of-bounds access to an __CPROVER_allocate'd
+// object must still be refuted (the allocate rewrite must not mask it).
+void *__CPROVER_allocate(__CPROVER_size_t, int);
+
+int *p;
+
+int main()
+{
+  p = __CPROVER_allocate(sizeof(int), 0);
+  p[5] = 123;
+  __CPROVER_assert(p[5] == 123, "property 1");
+  return 0;
+}

--- a/regression/cprover/pointers/allocate2.desc
+++ b/regression/cprover/pointers/allocate2.desc
@@ -1,0 +1,8 @@
+CORE
+allocate2.c
+--text --solve --inline
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.pointer\.1\] line \d+ pointer .* safe: REFUTED$
+^\[main\.assertion\.1\] line \d+ property 1: SUCCESS$
+--

--- a/regression/cprover/pointers/allocate3.c
+++ b/regression/cprover/pointers/allocate3.c
@@ -1,0 +1,15 @@
+// Known limitation: __CPROVER_allocate(size, 1) is the calloc lowering and
+// requests zero-initialised memory, but the cprover state encoder drops the
+// zero-init operand and models nondeterministic contents (like malloc), so a
+// read of the freshly-allocated memory cannot be proven to be 0.  Documented
+// as a KNOWNBUG; promote to CORE if/when zeroing is modelled.
+void *__CPROVER_allocate(__CPROVER_size_t, int);
+
+int *p;
+
+int main()
+{
+  p = __CPROVER_allocate(sizeof(int), 1); // calloc-style: zero-initialised
+  __CPROVER_assert(p[0] == 0, "property 1");
+  return 0;
+}

--- a/regression/cprover/pointers/allocate3.desc
+++ b/regression/cprover/pointers/allocate3.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+allocate3.c
+--text --solve --inline
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line \d+ property 1: SUCCESS$
+--
+--
+The calloc lowering __CPROVER_allocate(size, 1) requests zero-initialised
+memory, but the cprover state encoder drops the zero-init operand and models
+nondeterministic contents (matching malloc/posix_memalign/realloc), so
+`p[0] == 0` is currently REFUTED rather than SUCCESS.  Marked KNOWNBUG to
+document the limitation; promote to CORE if/when zeroing is modelled.

--- a/src/cprover/state_encoding.cpp
+++ b/src/cprover/state_encoding.cpp
@@ -338,6 +338,33 @@ exprt state_encodingt::evaluate_expr_rec(
   }
   else if(what.id() == ID_side_effect)
   {
+    const auto &side_effect = to_side_effect_expr(what);
+    if(
+      side_effect.get_statement() == ID_allocate &&
+      side_effect.operands().size() == 2 &&
+      side_effect.type().id() == ID_pointer)
+    {
+      // __CPROVER_allocate is handled like the malloc call (see the malloc
+      // handling in function_call_symbol below): tie the allocation to the
+      // current state so that the live_object, writeable_object and
+      // object_size axioms apply to the result. Without this, the generic
+      // allocate side effect is left uninterpreted, and "pointer safe"
+      // properties over the allocated object are spuriously refuted.
+      // c_typecheck_expr rejects an ID_allocate without exactly two
+      // operands (size, zero-init flag), so the size() == 2 check documents
+      // that invariant rather than building an allocation from a partial
+      // operand list; the side effect's type is always void *, so the
+      // ID_pointer conjunct is defensive only.
+      //
+      // NOTE: operands()[1] is the zero-initialisation flag (calloc lowers to
+      // __CPROVER_allocate(size, 1)); like the malloc/posix_memalign/realloc
+      // cases this backend does not model zeroing, so the allocated contents
+      // are left nondeterministic.  TODO: model zeroing.
+      auto size_evaluated = evaluate_expr_rec(
+        loc, state, side_effect.operands().front(), bound_symbols);
+      return allocate_exprt{
+        state, size_evaluated, to_pointer_type(side_effect.type())};
+    }
     // leave as is
     return what;
   }


### PR DESCRIPTION
The state encoder special-cases calls to `malloc`/`posix_memalign`/`realloc` by tying the allocation to the current state (`update_state(state, lhs, allocate_exprt(state, size, type))`), which makes the allocate axioms (`live_object`, `writeable_object`, `object_size`, `pointer_offset`) apply to the result. The generic `__CPROVER_allocate` side effect, however, was left as-is during expression evaluation, so an assignment `p = __CPROVER_allocate(...)` never connected the allocated object to the state. As a result, "pointer safe" properties over a freshly allocated object were spuriously refuted, even though cprover has axioms for `ID_allocate`. A function merely named `malloc` (even bodyless) was handled correctly while the same `__CPROVER_allocate` under any other name was not -- the behavior keyed on the C library name rather than the GOTO primitive.

Handle the `__CPROVER_allocate` side effect uniformly in `evaluate_expr_rec` by rewriting it to an `allocate_exprt` tied to the current state, mirroring the malloc special case. This makes cprover treat the GOTO allocation primitive directly, independent of any C-level allocator name.

Soundness is preserved: safe allocations verify (pointer safe), while out-of-bounds accesses and functional bugs over allocated objects are still refuted.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
