### PR TITLE
Release CBMC 6.10.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,72 @@
+# CBMC 6.10.0
+
+This release includes a workaround for a Z3 unsoundness in prior releases of Z3
+(via #9011), fixes SMT encoding problems (via #9012), improves support for
+floating-point processing in the in-tree SMT2 solver (via #8889, among others),
+but also removes support for CVC 3 and CVC 4 (via #8967).
+
+## What's Changed
+* Remove support for CVC 3 and CVC 4 by @kroening in https://github.com/diffblue/cbmc/pull/8967
+* Add fp.isSubnormal, fp.isNegative, fp.isPositive to SMT2 parser by @tautschnig in https://github.com/diffblue/cbmc/pull/8889
+* Do not use `as const` with Z3 due to soundness issue by @tautschnig in https://github.com/diffblue/cbmc/pull/9011
+
+## Bug Fixes
+* push up `all_zeros_expr` and `all_ones_expr` helpers to `bitvector_typet` by @kroening in https://github.com/diffblue/cbmc/pull/8963
+* move `bitvector_typet` into bitvector_type.h by @kroening in https://github.com/diffblue/cbmc/pull/8962
+* move flag initialisation in `smt2_convt` by @kroening in https://github.com/diffblue/cbmc/pull/8965
+* Unit test: ensure simplifier flattens nested AND/OR expressions by @tautschnig in https://github.com/diffblue/cbmc/pull/8970
+* Unit tests: verify complementary pair detection in AND/OR by @tautschnig in https://github.com/diffblue/cbmc/pull/8982
+* CODEOWNERS: consistency and redundancy by @tautschnig in https://github.com/diffblue/cbmc/pull/8994
+* Fixup for #8829: add bit-vector case by @kroening in https://github.com/diffblue/cbmc/pull/8966
+* fix SMT-LIB2 `nor` by @kroening in https://github.com/diffblue/cbmc/pull/8832
+* `symbol_exprt` C++-style API by @kroening in https://github.com/diffblue/cbmc/pull/8824
+* Make namespacet references const where possible by @tautschnig in https://github.com/diffblue/cbmc/pull/8995
+* float_utils: normalization shift for very short fractions by @kroening in https://github.com/diffblue/cbmc/pull/8968
+* SMT2 backend: reduction operators by @kroening in https://github.com/diffblue/cbmc/pull/8964
+* SMT2: avoid emitting unary bitvector concat by @kroening in https://github.com/diffblue/cbmc/pull/8997
+* Support 1-bit signed bitvectors in `bv_utilst::lt_or_le` by @kroening in https://github.com/diffblue/cbmc/pull/8998
+* Compile Java regression test sources (5/n) by @peterschrammel in https://github.com/diffblue/cbmc/pull/8556
+* move `range_typet` to `mathematical_types.h` by @kroening in https://github.com/diffblue/cbmc/pull/9000
+* rename `range_typet` to `integer_range_typet` by @kroening in https://github.com/diffblue/cbmc/pull/9001
+* SMT2: fix for encoding of range-typed symbols by @kroening in https://github.com/diffblue/cbmc/pull/8969
+* Use cmake for cleaning in cmake job by @peterschrammel in https://github.com/diffblue/cbmc/pull/8547
+* disallow flexible array members in unions by @kroening in https://github.com/diffblue/cbmc/pull/7296
+* Use `std::from_chars` instead of `stoll`/`stoull` in string2int.h by @kroening in https://github.com/diffblue/cbmc/pull/9007
+* Fix typing of array expressions within an C ternary ? : operator by @rod-chapman in https://github.com/diffblue/cbmc/pull/9012
+* Fix profiling: use --verbosity 8 instead of 10 by @tautschnig in https://github.com/diffblue/cbmc/pull/8977
+* Upgrade cvc5 from 1.2.1 to 1.3.4 by @tautschnig in https://github.com/diffblue/cbmc/pull/8886
+* introduce `reduction_*_exprt` classes by @kroening in https://github.com/diffblue/cbmc/pull/9010
+* use `std::string_view` for `safe_string2int` by @kroening in https://github.com/diffblue/cbmc/pull/9009
+* Message handler: add quote_begin, quote_end commands by @tautschnig in https://github.com/diffblue/cbmc/pull/5696
+* SMT2 tokenizer now has full `tokent` class by @kroening in https://github.com/diffblue/cbmc/pull/9003
+* use `std::string_view` in string_utils by @kroening in https://github.com/diffblue/cbmc/pull/9005
+* Replace deprecated save-always with cache/restore + cache/save by @tautschnig in https://github.com/diffblue/cbmc/pull/8891
+* boolbv: fix fixedbv-type check in convert_rest for ID_isfinite by @tautschnig in https://github.com/diffblue/cbmc/pull/9021
+* Remove dead #if 0 block in boolbv_mod.cpp by @tautschnig in https://github.com/diffblue/cbmc/pull/9026
+* Incremental SMT2: Remove unnecessary #if 0 for floating-point modulo by @tautschnig in https://github.com/diffblue/cbmc/pull/9027
+* Bump codecov/codecov-action from 6 to 7 by @dependabot[bot] in https://github.com/diffblue/cbmc/pull/9029
+* smt2: support bit-pattern reinterpretation overload of to_fp by @tautschnig in https://github.com/diffblue/cbmc/pull/9032
+* Drop unused functions before property instrumentation by @tautschnig in https://github.com/diffblue/cbmc/pull/8975
+* Avoid host C library headers in cbmc-cover built-ins/location tests by @tautschnig in https://github.com/diffblue/cbmc/pull/9033
+* Add empty_namespacet for unit tests by @tautschnig in https://github.com/diffblue/cbmc/pull/8996
+* Constant-fold unsigned division/remainder in bv_utils by @tautschnig in https://github.com/diffblue/cbmc/pull/9025
+* Fix ROUND_TO_AWAY rounding decision in float_bvt by @tautschnig in https://github.com/diffblue/cbmc/pull/8983
+* smt2: flatten FPA-encoded floats to their IEEE bit pattern by @tautschnig in https://github.com/diffblue/cbmc/pull/9031
+* regression/cbmc/array-constraint/test_json: un-KNOWNBUG, fix expectations by @tautschnig in https://github.com/diffblue/cbmc/pull/9018
+* boolbv_let: pass lowered value to record_array_let_binding by @tautschnig in https://github.com/diffblue/cbmc/pull/9017
+* Fix float-to-integer conversion for wide destination types by @tautschnig in https://github.com/diffblue/cbmc/pull/8986
+* Shard the long-running JBMC symex-driven-lazy-loading test suites by @tautschnig in https://github.com/diffblue/cbmc/pull/9036
+* util: expose is_zero_width via util/pointer_offset_size by @tautschnig in https://github.com/diffblue/cbmc/pull/9016
+* use `std::string_view` in dstring by @kroening in https://github.com/diffblue/cbmc/pull/9006
+* clang_builtins.py: parse the TableGen builtin databases by @tautschnig in https://github.com/diffblue/cbmc/pull/9037
+* string_container: use std::string_view as the interning map key by @tautschnig in https://github.com/diffblue/cbmc/pull/9042
+* Fix fp.isZero to handle -0 correctly by @tautschnig in https://github.com/diffblue/cbmc/pull/8887
+* build(deps): bump actions/checkout from 6 to 7 by @dependabot[bot] in https://github.com/diffblue/cbmc/pull/9076
+* ansi-c: support __builtin_has_attribute (parse + model as constant) by @tautschnig in https://github.com/diffblue/cbmc/pull/9046
+* Ignore x86 __seg_fs/__seg_gs named-address-space qualifiers by @tautschnig in https://github.com/diffblue/cbmc/pull/9054
+
+**Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.9.0...cbmc-6.10.0
+
 # CBMC 6.9.0
 
 This release ensures cross-platform determinism of formulae created by CBMC (for

--- a/src/config.inc
+++ b/src/config.inc
@@ -47,7 +47,7 @@ endif
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
 
 # Detailed version information
-CBMC_VERSION = 6.9.0
+CBMC_VERSION = 6.10.0
 
 # Use the CUDD library for BDDs, can be installed using `make -C src cudd-download`
 # CUDD = ../../cudd-3.0.0

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcprover_rust"
-version = "6.9.0"
+version = "6.10.0"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
 repository = "https://github.com/diffblue/cbmc"


### PR DESCRIPTION
This release includes a workaround for a Z3 unsoundness in prior releases of Z3 (via #9011), fixes SMT encoding problems (via #9012), improves support for floating-point processing in the in-tree SMT2 solver (via #8889, among others), but also removes support for CVC 3 and CVC 4 (via #8967).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
