### PR TITLE
util: move IEEE float value conversions to ieee_float_valuet

### DIFF
--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -1253,7 +1253,7 @@ void ieee_float_valuet::from_expr(const constant_exprt &expr)
   unpack(bvrep2integer(expr.get_value(), spec.width(), false));
 }
 
-mp_integer ieee_floatt::to_integer() const
+mp_integer ieee_float_valuet::to_integer() const
 {
   if(NaN_flag || infinity_flag || is_zero())
     return 0;

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -270,14 +270,45 @@ public:
 
   // performs conversions from IEEE float-point format
   // to something else
+
+  /// Reinterpret this value as a native \c double. This is a bit-exact
+  /// reinterpretation of the packed IEEE 754 representation, not a rounding
+  /// conversion, and therefore does not depend on any rounding mode.
+  /// \pre the value is in IEEE 754 double (binary64) format, i.e.
+  ///   \ref is_double returns true.
+  /// \return the corresponding \c double
   double to_double() const;
+
+  /// Reinterpret this value as a native \c float. This is a bit-exact
+  /// reinterpretation of the packed IEEE 754 representation, not a rounding
+  /// conversion, and therefore does not depend on any rounding mode.
+  /// \note from_float() followed by to_float() may return a different bit
+  ///   pattern for NaN.
+  /// \pre the value is in IEEE 754 single (binary32) format, i.e.
+  ///   \ref is_float returns true.
+  /// \return the corresponding \c float
   float to_float() const;
+
+  /// \return true iff this value is in IEEE 754 double (binary64) format
   bool is_double() const;
+  /// \return true iff this value is in IEEE 754 single (binary32) format
   bool is_float() const;
   mp_integer pack() const;
   void extract_base2(mp_integer &_exponent, mp_integer &_fraction) const;
   void extract_base10(mp_integer &_exponent, mp_integer &_fraction) const;
-  mp_integer to_integer() const; // this always rounds to zero
+
+  /// Convert to an integer, always rounding towards zero (truncation), i.e.
+  /// modelling a C cast such as `(int)f`. NaN, infinities and zero map to 0.
+  ///
+  /// Because the rounding is fixed (truncation), this conversion does not
+  /// depend on any rounding mode and so belongs on \ref ieee_float_valuet
+  /// rather than \ref ieee_floatt. A rounding-mode-respecting float-to-integer
+  /// conversion (the analogue of `lrint`) would instead belong on
+  /// \ref ieee_floatt; see also \ref ieee_floatt::round_to_integral, which
+  /// rounds to an integral *floating-point* value according to the configured
+  /// rounding mode.
+  /// \return the truncated integer value
+  mp_integer to_integer() const;
 
   // output
   void print(std::ostream &out) const;
@@ -396,12 +427,6 @@ public:
   void from_integer(const mp_integer &i);
   void from_base10(const mp_integer &exp, const mp_integer &frac);
   void build(const mp_integer &exp, const mp_integer &frac);
-
-  // performs conversions from IEEE float-point format
-  // to something else
-  double to_double() const;
-  float to_float() const;
-  mp_integer to_integer() const; // this always rounds to zero
 
   // conversions
   void change_spec(const ieee_float_spect &dest_spec);

--- a/unit/util/ieee_float.cpp
+++ b/unit/util/ieee_float.cpp
@@ -129,3 +129,88 @@ TEST_CASE("round_to_integral", "[unit][util][ieee_float]")
   REQUIRE(round_to_integral(from_double(0x1.0p+52), away) == 0x1.0p+52);
   REQUIRE(round_to_integral(from_double(dmax), away) == dmax);
 }
+
+TEST_CASE(
+  "ieee_float_valuet to_double / to_float round-trip",
+  "[core][util][ieee_float]")
+{
+  auto from_double = [](double d) -> ieee_float_valuet
+  {
+    ieee_float_valuet v;
+    v.from_double(d);
+    return v;
+  };
+  auto from_float = [](float f) -> ieee_float_valuet
+  {
+    ieee_float_valuet v;
+    v.from_float(f);
+    return v;
+  };
+
+  SECTION("to_double is a bit-exact reinterpretation")
+  {
+    REQUIRE(from_double(0.0).to_double() == 0.0);
+    REQUIRE(from_double(1.0).to_double() == 1.0);
+    REQUIRE(from_double(-2.5).to_double() == -2.5);
+    REQUIRE(from_double(3.14159).to_double() == 3.14159);
+    REQUIRE(
+      from_double(std::numeric_limits<double>::infinity()).to_double() ==
+      std::numeric_limits<double>::infinity());
+    REQUIRE(
+      from_double(std::numeric_limits<double>::max()).to_double() ==
+      std::numeric_limits<double>::max());
+  }
+
+  SECTION("to_float is a bit-exact reinterpretation")
+  {
+    REQUIRE(from_float(0.0f).to_float() == 0.0f);
+    REQUIRE(from_float(1.0f).to_float() == 1.0f);
+    REQUIRE(from_float(-2.5f).to_float() == -2.5f);
+    REQUIRE(
+      from_float(std::numeric_limits<float>::infinity()).to_float() ==
+      std::numeric_limits<float>::infinity());
+  }
+}
+
+TEST_CASE(
+  "ieee_float_valuet to_integer truncates towards zero",
+  "[core][util][ieee_float]")
+{
+  auto from_double = [](double d) -> ieee_float_valuet
+  {
+    ieee_float_valuet v;
+    v.from_double(d);
+    return v;
+  };
+
+  // to_integer always rounds towards zero (truncation), independent of any
+  // rounding mode -- this is the caveat that justifies it living on
+  // ieee_float_valuet rather than ieee_floatt.
+  SECTION("positive values truncate down")
+  {
+    REQUIRE(from_double(0.0).to_integer() == 0);
+    REQUIRE(from_double(0.9).to_integer() == 0);
+    REQUIRE(from_double(1.0).to_integer() == 1);
+    REQUIRE(from_double(3.9).to_integer() == 3);
+    REQUIRE(from_double(1e10).to_integer() == 10000000000);
+  }
+
+  SECTION("negative values truncate towards zero, not down")
+  {
+    REQUIRE(from_double(-0.0).to_integer() == 0);
+    REQUIRE(from_double(-0.9).to_integer() == 0);
+    REQUIRE(from_double(-1.0).to_integer() == -1);
+    // truncation towards zero gives -3, not -4 (which round-to-minus-infinity
+    // would give)
+    REQUIRE(from_double(-3.9).to_integer() == -3);
+    REQUIRE(from_double(-1e10).to_integer() == -10000000000);
+  }
+
+  SECTION("NaN and infinities map to zero")
+  {
+    const auto dp = ieee_float_spect::double_precision();
+    REQUIRE(ieee_float_valuet::NaN(dp).to_integer() == 0);
+    REQUIRE(ieee_float_valuet::plus_infinity(dp).to_integer() == 0);
+    REQUIRE(ieee_float_valuet::minus_infinity(dp).to_integer() == 0);
+  }
+}


### PR DESCRIPTION
ieee_floatt redundantly re-declared to_double()/to_float()/to_integer(). These are value conversions that do not depend on the rounding mode and so belong on ieee_float_valuet:

- to_double()/to_float() were already implemented on ieee_float_valuet; the ieee_floatt declarations were dead (unimplemented) and merely shadowed the base ones.
- to_integer() (which always rounds to zero) was implemented on ieee_floatt while its ieee_float_valuet declaration was dead.

Drop the dead ieee_floatt declarations and move the to_integer() implementation down to ieee_float_valuet. The conversions remain callable with identical behaviour on ieee_floatt (now inherited) and additionally become usable on a plain ieee_float_valuet.

Document the conversions with Doxygen, in particular noting that to_double() and to_float() are bit-exact reinterpretations with a format precondition, and that to_integer() always truncates towards zero independently of any rounding mode (a rounding-mode-respecting variant would belong on ieee_floatt, cf. round_to_integral). Add unit tests covering the to_double/to_float round-trip and the to_integer truncation behaviour (including negative values, NaN and infinities).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
