### PR TITLE
loop_ids: wrap JSON_UI case body in a block

### DIFF
--- a/src/goto-programs/loop_ids.cpp
+++ b/src/goto-programs/loop_ids.cpp
@@ -105,6 +105,7 @@ void show_loop_ids(
       break;
 
     case ui_message_handlert::uit::JSON_UI:
+    {
       json_objectt json_result;
       json_arrayt &loops=json_result["loops"].make_array();
 
@@ -113,5 +114,6 @@ void show_loop_ids(
 
       std::cout << ",\n" << json_result;
       break;
+    }
   }
 }


### PR DESCRIPTION
The JSON_UI case of show_loop_ids declares local variables; wrap its body in an explicit block so the declarations are scoped to the case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
