### PR TITLE
Shard the long-running CORE runs of contracts-dfcc and jbmc-strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ regression/solver-hardness/solver-hardness-simple/solver_hardness.json
 regression/goto-instrument-wmm-core/*/*.txt
 regression/goto-instrument-wmm-core/*/*.dot
 jbmc/regression/**/tests.log
-jbmc/regression/**/tests-symex-driven-loading*.log
+jbmc/regression/**/tests-*.log
 unit/memory-analyzer/input.inc
 unit/memory-analyzer/test.inc
 unit/gdb.txt

--- a/jbmc/regression/jbmc-strings/CMakeLists.txt
+++ b/jbmc/regression/jbmc-strings/CMakeLists.txt
@@ -1,6 +1,13 @@
-add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
-)
+set(jbmc_strings_cmdline
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation")
+set(jbmc_strings_shards 4)
+
+# The plain (non-symex-driven) CORE run of this suite is one of the slowest
+# non-sharded CORE ctests; shard it (keeping its 30-minute per-shard timeout)
+# so it runs as several parallel ctest entries on the macOS runners. See
+# add_sharded_test_pl_tests.
+add_sharded_test_pl_tests(
+  "${jbmc_strings_cmdline}" "core" ${jbmc_strings_shards} 1800)
 
 # The symex-driven-lazy-loading run of this suite is the single largest CORE
 # ctest on the macOS runners (~1-1.5h), and a single ctest test runs serially
@@ -9,11 +16,10 @@ add_test_pl_tests(
 # dominating the job's wall-clock.
 add_sharded_test_pl_profile(
   "jbmc-strings-symex-driven-lazy-loading"
-  "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
+  "${jbmc_strings_cmdline} --symex-driven-lazy-loading"
   "-C;-X;symex-driven-lazy-loading-expected-failure"
   "CORE"
   "symex-driven-loading"
-  4
+  ${jbmc_strings_shards}
   10800
 )
-set_tests_properties("jbmc-strings-CORE" PROPERTIES TIMEOUT 1800)

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -53,6 +53,28 @@ macro(add_test_pl_tests cmdline)
     add_test_pl_profile("${TEST_DIR_NAME}" "${cmdline}" -K KNOWNBUG ${ARGN})
 endmacro(add_test_pl_tests)
 
+# Like add_test_pl_tests, but split the CORE profile into <shard_count>
+# parallel shards (see add_sharded_test_pl_profile) so a long-running CORE
+# suite runs as several parallel ctest entries instead of one indivisible test
+# -- e.g. to keep the slowest suites from dominating the macOS runners'
+# wall-clock or approaching the per-test timeout. THOROUGH/FUTURE/KNOWNBUG
+# remain single tests. <log_suffix> names the per-shard CORE logs and each CORE
+# shard is given <timeout>. Any extra arguments (e.g. -X exclusions) are
+# forwarded to every profile.
+macro(add_sharded_test_pl_tests cmdline log_suffix shard_count timeout)
+    get_filename_component(TEST_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+    message(STATUS "Adding sharded tests in directory: ${TEST_DIR_NAME}")
+    # Build the CORE flags as a list so an empty ARGN collapses to just -C (no
+    # spurious empty argument reaching test.pl).
+    set(_core_flags "-C" ${ARGN})
+    add_sharded_test_pl_profile(
+        "${TEST_DIR_NAME}" "${cmdline}" "${_core_flags}" "CORE"
+        "${log_suffix}" ${shard_count} ${timeout})
+    add_test_pl_profile("${TEST_DIR_NAME}" "${cmdline}" -T THOROUGH ${ARGN})
+    add_test_pl_profile("${TEST_DIR_NAME}" "${cmdline}" -F FUTURE ${ARGN})
+    add_test_pl_profile("${TEST_DIR_NAME}" "${cmdline}" -K KNOWNBUG ${ARGN})
+endmacro(add_sharded_test_pl_tests)
+
 # For the best possible utilisation of multiple cores when
 # running tests in parallel, it is important that these directories are
 # listed with decreasing runtimes (i.e. longest running at the top)

--- a/regression/contracts-dfcc/CMakeLists.txt
+++ b/regression/contracts-dfcc/CMakeLists.txt
@@ -13,9 +13,15 @@ else()
 endif()
 
 
-add_test_pl_tests(
-    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows} true" ${gcc_only}
-)
+set(dfcc_cmd
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows} true")
+set(dfcc_core_shards 4)
+
+# The CORE run of this suite is one of the slowest non-sharded CORE ctests;
+# shard it (and keep its 30-minute per-shard timeout) so it runs as several
+# parallel ctest entries on the macOS runners. See add_sharded_test_pl_tests.
+add_sharded_test_pl_tests(
+    "${dfcc_cmd}" "dfcc-core" ${dfcc_core_shards} 1800 ${gcc_only})
 
 add_test_pl_profile(
     "contracts-non-dfcc"
@@ -42,15 +48,16 @@ add_test_pl_profile(
 
 # solver appears on the PATH in Windows already
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set_property(
-    TEST "contracts-dfcc-CORE"
-    PROPERTY ENVIRONMENT
-      "PATH=$ENV{PATH}:$<TARGET_FILE_DIR:smt2_solver>"
-  )
+  foreach(shard RANGE 1 ${dfcc_core_shards})
+    set_property(
+      TEST "contracts-dfcc-${shard}-CORE"
+      PROPERTY ENVIRONMENT
+        "PATH=$ENV{PATH}:$<TARGET_FILE_DIR:smt2_solver>"
+    )
+  endforeach()
   set_property(
     TEST "contracts-non-dfcc-CORE"
     PROPERTY ENVIRONMENT
       "PATH=$ENV{PATH}:$<TARGET_FILE_DIR:smt2_solver>"
   )
 endif()
-set_tests_properties("contracts-dfcc-CORE" PROPERTIES TIMEOUT 1800)


### PR DESCRIPTION
These two suites are the slowest non-sharded CORE ctest entries and, at a single 30-minute-capped test each, intermittently time out on the slower and highly variable macOS-14 runners (their per-run time there swings roughly 2-3x). Their timeouts (1800s) are already above the 1200s default, so the right remedy is sharding rather than a further timeout bump.

Split each suite's CORE profile into 4 parallel shards via test.pl's --shard option, reusing the add_sharded_test_pl_profile helper already used for the jbmc-strings symex-driven-lazy-loading profile. The smaller pieces run in parallel as separate ctest entries instead of one indivisible test, so they no longer dominate the job wall-clock or approach the per-test timeout. Each shard keeps the suite's previous 30-minute cap, which is now ample headroom.

The contracts-dfcc smt2_solver PATH environment is applied to each shard, and the THOROUGH/FUTURE/KNOWNBUG levels remain single tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
