### PR TITLE
cmdlinet: add set(char, string) for single-char options

### DIFF
--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -89,6 +89,22 @@ void cmdlinet::set(const std::string &option, const std::string &value)
   }
 }
 
+void cmdlinet::set(char option, const std::string &value)
+{
+  auto i = getoptnr(option);
+
+  if(i.has_value())
+  {
+    options[*i].isset = true;
+    options[*i].values.push_back(value);
+  }
+  else
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "unknown command line option", std::string(1, option));
+  }
+}
+
 static std::list<std::string> immutable_empty_list;
 
 const std::list<std::string> &cmdlinet::get_values(char option) const

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -95,6 +95,7 @@ public:
   {
     set(option, std::string{value});
   }
+  virtual void set(char option, const std::string &value);
 
   virtual void clear();
 

--- a/unit/util/cmdline.cpp
+++ b/unit/util/cmdline.cpp
@@ -19,6 +19,29 @@ TEST_CASE("cmdlinet::has_option", "[core][util][cmdline]")
   REQUIRE(!cmdline.has_option("c"));
 }
 
+TEST_CASE("cmdlinet::set char option", "[core][util][cmdline]")
+{
+  cmdlinet cmdline;
+  REQUIRE(!cmdline.parse(0, nullptr, "I:D:f:"));
+
+  cmdline.set('I', "/some/path");
+  cmdline.set('I', "/another/path");
+  cmdline.set('D', "FOO=1");
+
+  REQUIRE(cmdline.isset('I'));
+  REQUIRE(cmdline.isset('D'));
+  REQUIRE(!cmdline.isset('f'));
+
+  auto &i_values = cmdline.get_values('I');
+  REQUIRE(i_values.size() == 2);
+  REQUIRE(i_values.front() == "/some/path");
+  REQUIRE(i_values.back() == "/another/path");
+
+  auto &d_values = cmdline.get_values('D');
+  REQUIRE(d_values.size() == 1);
+  REQUIRE(d_values.front() == "FOO=1");
+}
+
 TEST_CASE("cmdline::option_names", "[core][util][cmdline]")
 {
   cmdlinet cmdline;


### PR DESCRIPTION
## Summary
- Adds a `set()` overload that takes a `char` option identifier and a `string` value
- Complements the existing `set(string, string)` that only works for long options registered via `(name)` in the optstring
- Enables programmatic addition of values to single-char options like `-I` and `-D`

Needed by diffblue/hw-cbmc#1961 to support `.f` command files that contain `-I` include paths.

## Test plan
- [x] Builds cleanly with `-Werror`
- [x] Existing tests pass (no behavior change for existing code)