### PR TITLE
use `std::string_view` in edit_distance

### DIFF
--- a/src/util/edit_distance.cpp
+++ b/src/util/edit_distance.cpp
@@ -6,7 +6,7 @@
 #include "edit_distance.h"
 
 levenshtein_automatont::levenshtein_automatont(
-  const std::string &string,
+  std::string_view string,
   std::size_t allowed_errors)
 {
   const std::size_t layer_offset = string.size() + 1;
@@ -49,13 +49,13 @@ levenshtein_automatont::levenshtein_automatont(
   }
 }
 
-bool levenshtein_automatont::matches(const std::string &string) const
+bool levenshtein_automatont::matches(std::string_view string) const
 {
   return get_edit_distance(string).has_value();
 }
 
 std::optional<std::size_t>
-levenshtein_automatont::get_edit_distance(const std::string &string) const
+levenshtein_automatont::get_edit_distance(std::string_view string) const
 {
   auto current = nfa.initial_state(0);
   for(const auto c : string)

--- a/src/util/edit_distance.h
+++ b/src/util/edit_distance.h
@@ -16,7 +16,7 @@
 
 #include <cstddef>
 #include <optional>
-#include <string>
+#include <string_view>
 
 /// Simple automaton that can detect whether a string can be transformed into
 /// another with a limited number of deletions, insertions or substitutions.
@@ -30,11 +30,11 @@ private:
 
 public:
   levenshtein_automatont(
-    const std::string &string,
+    std::string_view string,
     std::size_t allowed_errors = 2);
 
-  bool matches(const std::string &string) const;
-  std::optional<std::size_t> get_edit_distance(const std::string &string) const;
+  bool matches(std::string_view string) const;
+  std::optional<std::size_t> get_edit_distance(std::string_view string) const;
 
   void dump_automaton_dot_to(std::ostream &out)
   {


### PR DESCRIPTION
The strings given as arguments to the methods in `levenshtein_automatont` are not copied, and their address is not taken.  Hence, a `std::string_view` suffices.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
