### PR TITLE
Use `std::string_view` in `cmdlinet`

### DIFF
--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -46,7 +46,7 @@ bool goto_cc_cmdlinet::in_list(const char *option, const char **list)
   return false;
 }
 
-std::size_t goto_cc_cmdlinet::get_optnr(const std::string &opt_string)
+std::size_t goto_cc_cmdlinet::get_optnr(std::string_view opt_string)
 {
   std::optional<std::size_t> optnr;
   cmdlinet::optiont option;

--- a/src/goto-cc/goto_cc_cmdline.h
+++ b/src/goto-cc/goto_cc_cmdline.h
@@ -27,22 +27,22 @@ public:
   static bool in_list(const char *option, const char **list);
 
   // never fails, will add if not found
-  std::size_t get_optnr(const std::string &option);
+  std::size_t get_optnr(std::string_view option);
 
   /// Set option \p option to \p value.
-  void set(const std::string &opt, const char *value) override
+  void set(std::string_view opt, const char *value) override
   {
     set(opt, std::string{value});
   }
 
-  void set(const std::string &opt, const std::string &value) override
+  void set(std::string_view opt, std::string value) override
   {
     std::size_t nr=get_optnr(opt);
     options[nr].isset=true;
-    options[nr].values.push_back(value);
+    options[nr].values.push_back(std::move(value));
   }
 
-  void set(const std::string &opt, bool value = true) override
+  void set(std::string_view opt, bool value = true) override
   {
     options[get_optnr(opt)].isset = value;
   }
@@ -55,7 +55,7 @@ public:
   {
   public:
     argt():is_infile_name(false) { }
-    explicit argt(const std::string &_arg):is_infile_name(false), arg(_arg) { }
+    explicit argt(std::string _arg):is_infile_name(false), arg(std::move(_arg)) { }
     bool is_infile_name;
     std::string arg;
   };
@@ -68,9 +68,9 @@ public:
   std::string stdin_file;
 
 protected:
-  void add_arg(const std::string &arg)
+  void add_arg(std::string arg)
   {
-    parsed_argv.push_back(argt(arg));
+    parsed_argv.push_back(argt{std::move(arg)});
   }
 
   void add_infile_arg(const std::string &arg);

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -36,7 +36,7 @@ bool cmdlinet::isset(char option) const
     return false;
 }
 
-bool cmdlinet::isset(const char *option) const
+bool cmdlinet::isset(std::string_view option) const
 {
   auto i=getoptnr(option);
   if(i.has_value())
@@ -60,7 +60,7 @@ std::optional<std::string> cmdlinet::value_opt(char option) const
     return {};
 }
 
-void cmdlinet::set(const std::string &option, bool value)
+void cmdlinet::set(std::string_view option, bool value)
 {
   auto i=getoptnr(option);
 
@@ -69,27 +69,27 @@ void cmdlinet::set(const std::string &option, bool value)
   else
   {
     throw invalid_command_line_argument_exceptiont(
-      "unknown command line option", option);
+      "unknown command line option", std::string{option});
   }
 }
 
-void cmdlinet::set(const std::string &option, const std::string &value)
+void cmdlinet::set(std::string_view option, std::string value)
 {
   auto i=getoptnr(option);
 
   if(i.has_value())
   {
     options[*i].isset=true;
-    options[*i].values.push_back(value);
+    options[*i].values.push_back(std::move(value));
   }
   else
   {
     throw invalid_command_line_argument_exceptiont(
-      "unknown command line option", option);
+      "unknown command line option", std::string(option));
   }
 }
 
-static std::list<std::string> immutable_empty_list;
+const static std::list<std::string> immutable_empty_list;
 
 const std::list<std::string> &cmdlinet::get_values(char option) const
 {
@@ -101,12 +101,12 @@ const std::list<std::string> &cmdlinet::get_values(char option) const
     return immutable_empty_list;
 }
 
-std::string cmdlinet::get_value(const char *option) const
+std::string cmdlinet::get_value(std::string_view option) const
 {
   return value_opt(option).value_or("");
 }
 
-std::optional<std::string> cmdlinet::value_opt(const char *option) const
+std::optional<std::string> cmdlinet::value_opt(std::string_view option) const
 {
   auto i=getoptnr(option);
 
@@ -116,8 +116,8 @@ std::optional<std::string> cmdlinet::value_opt(const char *option) const
     return {};
 }
 
-const std::list<std::string> &cmdlinet::get_values(
-  const std::string &option) const
+const std::list<std::string> &
+cmdlinet::get_values(std::string_view option) const
 {
   auto i=getoptnr(option);
 
@@ -128,7 +128,7 @@ const std::list<std::string> &cmdlinet::get_values(
 }
 
 std::list<std::string>
-cmdlinet::get_comma_separated_values(const char *option) const
+cmdlinet::get_comma_separated_values(std::string_view option) const
 {
   std::list<std::string> separated_values;
 
@@ -151,7 +151,7 @@ std::optional<std::size_t> cmdlinet::getoptnr(char option) const
   return std::optional<std::size_t>();
 }
 
-std::optional<std::size_t> cmdlinet::getoptnr(const std::string &option) const
+std::optional<std::size_t> cmdlinet::getoptnr(std::string_view option) const
 {
   for(std::size_t i=0; i<options.size(); i++)
     if(options[i].optstring==option)
@@ -172,6 +172,7 @@ cmdlinet::option_namest cmdlinet::option_names() const
 {
   return option_namest{*this};
 }
+
 void cmdlinet::parse_optstring(const char *optstring)
 {
   while(optstring[0] != 0)
@@ -217,7 +218,7 @@ void cmdlinet::parse_optstring(const char *optstring)
 }
 
 std::vector<std::string>
-cmdlinet::get_argument_suggestions(const std::string &unknown_argument)
+cmdlinet::get_argument_suggestions(std::string_view unknown_argument)
 {
   struct suggestiont
   {

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <list>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class cmdlinet
@@ -74,31 +75,36 @@ public:
   virtual bool parse(int argc, const char **argv, const char *optstring);
 
   std::string get_value(char option) const;
-  std::string get_value(const char *option) const;
+  std::string get_value(std::string_view option) const;
 
   std::optional<std::string> value_opt(char option) const;
-  std::optional<std::string> value_opt(const char *option) const;
+  std::optional<std::string> value_opt(std::string_view option) const;
 
-  const std::list<std::string> &get_values(const std::string &option) const;
+  const std::list<std::string> &get_values(std::string_view option) const;
   const std::list<std::string> &get_values(char option) const;
 
   /// Collect all occurrences of option \p option and split their values on each
   /// comma, merging them into a single list of values.
-  std::list<std::string> get_comma_separated_values(const char *option) const;
+  std::list<std::string>
+  get_comma_separated_values(std::string_view option) const;
 
   virtual bool isset(char option) const;
-  virtual bool isset(const char *option) const;
+  virtual bool isset(std::string_view option) const;
+
   /// Set option \p option to \p value, or \c true if the value is omitted.
-  virtual void set(const std::string &option, bool value = true);
-  virtual void set(const std::string &option, const std::string &value);
-  virtual void set(const std::string &option, const char *value)
+  virtual void set(std::string_view option, bool value = true);
+  virtual void set(std::string_view option, std::string value);
+
+  // This is required to match string literals, which otherwise
+  // are cast to bool
+  virtual void set(std::string_view option, const char *value)
   {
     set(option, std::string{value});
   }
 
   virtual void clear();
 
-  bool has_option(const std::string &option) const
+  bool has_option(std::string_view option) const
   {
     return getoptnr(option).has_value();
   }
@@ -158,7 +164,7 @@ public:
   virtual ~cmdlinet();
 
   std::vector<std::string>
-  get_argument_suggestions(const std::string &unknown_argument);
+  get_argument_suggestions(std::string_view unknown_argument);
 
 protected:
   struct optiont
@@ -193,7 +199,7 @@ protected:
   std::vector<optiont> options;
 
   std::optional<std::size_t> getoptnr(char option) const;
-  std::optional<std::size_t> getoptnr(const std::string &option) const;
+  std::optional<std::size_t> getoptnr(std::string_view option) const;
 };
 
 #endif // CPROVER_UTIL_CMDLINE_H

--- a/src/util/edit_distance.cpp
+++ b/src/util/edit_distance.cpp
@@ -6,7 +6,7 @@
 #include "edit_distance.h"
 
 levenshtein_automatont::levenshtein_automatont(
-  const std::string &string,
+  std::string_view string,
   std::size_t allowed_errors)
 {
   const std::size_t layer_offset = string.size() + 1;
@@ -49,13 +49,13 @@ levenshtein_automatont::levenshtein_automatont(
   }
 }
 
-bool levenshtein_automatont::matches(const std::string &string) const
+bool levenshtein_automatont::matches(std::string_view string) const
 {
   return get_edit_distance(string).has_value();
 }
 
 std::optional<std::size_t>
-levenshtein_automatont::get_edit_distance(const std::string &string) const
+levenshtein_automatont::get_edit_distance(std::string_view string) const
 {
   auto current = nfa.initial_state(0);
   for(const auto c : string)

--- a/src/util/edit_distance.h
+++ b/src/util/edit_distance.h
@@ -16,7 +16,7 @@
 
 #include <cstddef>
 #include <optional>
-#include <string>
+#include <string_view>
 
 /// Simple automaton that can detect whether a string can be transformed into
 /// another with a limited number of deletions, insertions or substitutions.
@@ -30,11 +30,11 @@ private:
 
 public:
   levenshtein_automatont(
-    const std::string &string,
+    std::string_view string,
     std::size_t allowed_errors = 2);
 
-  bool matches(const std::string &string) const;
-  std::optional<std::size_t> get_edit_distance(const std::string &string) const;
+  bool matches(std::string_view string) const;
+  std::optional<std::size_t> get_edit_distance(std::string_view string) const;
 
   void dump_automaton_dot_to(std::ostream &out)
   {


### PR DESCRIPTION
The strings passed as argument to the methods in `cmdlinet` are frequently not copied, and their address is not taken.  Hence, in those cases, use `std::string_view` instead of `std::string` to relieve the caller from the burden of constructing the `std::string` object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
