### PR TITLE
use `std::string_view` for `has_prefix`, `has_infix`, `has_suffix`

### DIFF
--- a/src/util/infix.h
+++ b/src/util/infix.h
@@ -12,12 +12,9 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #ifndef CPROVER_UTIL_INFIX_H
 #define CPROVER_UTIL_INFIX_H
 
-#include <string>
+#include <string_view>
 
-inline bool has_infix(
-  const std::string &s,
-  const std::string &infix,
-  size_t offset)
+inline bool has_infix(std::string_view s, std::string_view infix, size_t offset)
 {
   return s.compare(offset, infix.size(), infix)==0;
 }

--- a/src/util/prefix.h
+++ b/src/util/prefix.h
@@ -10,11 +10,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_PREFIX_H
 #define CPROVER_UTIL_PREFIX_H
 
-#include <string>
+#include <string_view>
 
-// C++20 will have std::string::starts_with
+// C++20 will have std::string_view::starts_with
 
-inline bool has_prefix(const std::string &s, const std::string &prefix)
+inline bool has_prefix(std::string_view s, std::string_view prefix)
 {
   return s.compare(0, prefix.size(), prefix)==0;
 }

--- a/src/util/suffix.h
+++ b/src/util/suffix.h
@@ -12,8 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <string>
 
-// C++20 will have std::string::ends_with
-
+// C++20 will have std::string_view::ends_with.
+// The arguments of has_suffix should be a std::string_view,
+// but this triggers a false alarm in gcc when attempting to
+// map the comparison to __builtin_memcmp.
 inline bool has_suffix(const std::string &s, const std::string &suffix)
 {
   if(suffix.size()>s.size())


### PR DESCRIPTION
The `has_prefix` function does not copy the given strings, and hence, using `std::string_view` can be used to relieve the caller from constructing the `std::string` object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
