### PR TITLE
use `std::string_view` for `unicode.h` functions

### DIFF
--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -61,7 +61,7 @@ std::wstring widen(const char *s)
 #endif
 }
 
-std::string narrow(const std::wstring &s)
+std::string narrow(std::wstring_view s)
 {
 #ifdef _WIN32
 
@@ -84,7 +84,7 @@ std::string narrow(const std::wstring &s)
 #endif
 }
 
-std::wstring widen(const std::string &s)
+std::wstring widen(std::string_view s)
 {
 #ifdef _WIN32
 
@@ -188,7 +188,7 @@ static void utf16_append_code(unsigned int code, std::wstring &result)
 /// \par parameters: String in UTF-8 format
 /// \return String in UTF-16 format. The encoding follows the endianness of the
 ///   architecture iff swap_bytes is true.
-std::wstring utf8_to_utf16_native_endian(const std::string &in)
+std::wstring utf8_to_utf16_native_endian(std::string_view in)
 {
   std::wstring result;
   result.reserve(in.size());
@@ -202,7 +202,7 @@ std::wstring utf8_to_utf16_native_endian(const std::string &in)
 /// Convert UTF8-encoded string to UTF-32 with architecture-native endianness.
 /// \par parameters: String in UTF-8 format
 /// \return String in UTF-32 format.
-std::u32string utf8_to_utf32(const std::string &utf8_str)
+std::u32string utf8_to_utf32(std::string_view utf8_str)
 {
   std::u32string result;
   result.reserve(utf8_str.size());
@@ -347,7 +347,7 @@ std::string utf16_native_endian_to_java(const char16_t ch)
 /// \param in: String in UTF-16 (native endianness) format
 /// \return Valid Java string literal in US-ASCII format, with \\uxxxx escapes
 /// for other characters
-std::string utf16_native_endian_to_java_string(const std::wstring &in)
+std::string utf16_native_endian_to_java_string(std::wstring_view in)
 {
   std::ostringstream result;
   const std::locale loc;

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -11,15 +11,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // we follow the ideas suggested at
 // http://www.utf8everywhere.org/
 
-std::string narrow(const wchar_t *s);
-std::wstring widen(const char *s);
-std::string narrow(const std::wstring &s);
-std::wstring widen(const std::string &s);
+std::string narrow(const wchar_t *);
+std::wstring widen(const char *);
+std::string narrow(std::wstring_view);
+std::wstring widen(std::string_view);
 
 // This removes the need to have a #ifdef whenever using std::fstream.
 #ifdef _WIN32
@@ -28,16 +29,16 @@ std::wstring widen(const std::string &s);
 #  define widen_if_needed(s) (s)
 #endif
 
-std::string utf32_native_endian_to_utf8(const std::basic_string<char32_t> &s);
+std::string utf32_native_endian_to_utf8(const std::basic_string<char32_t> &);
 
 /// \param utf8_str: UTF-8 string
 /// \return UTF-32 encoding of the string
-std::u32string utf8_to_utf32(const std::string &utf8_str);
+std::u32string utf8_to_utf32(std::string_view utf8_str);
 
-std::wstring utf8_to_utf16_native_endian(const std::string &in);
-std::string utf16_native_endian_to_java(const char16_t ch);
-std::string utf16_native_endian_to_java(const std::wstring &in);
-std::string utf16_native_endian_to_java_string(const std::wstring &in);
+std::wstring utf8_to_utf16_native_endian(std::string_view);
+std::string utf16_native_endian_to_java(const char16_t);
+std::string utf16_native_endian_to_java(std::wstring_view);
+std::string utf16_native_endian_to_java_string(std::wstring_view);
 
 std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide);
 


### PR DESCRIPTION
Many of the functions only 'view' the string given, and hence, it the use of `std::string_view` may relieve the caller of the burden of constructing the `std::string` object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
