### PR TITLE
Fix flatten2bv abort on non-constant FPA float (#9101)

### DIFF
--- a/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/main.c
+++ b/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/main.c
@@ -1,0 +1,24 @@
+// Reproducer for #9101: flatten2bv aborts on non-constant FPA-encoded float
+// when exporting to SMT2 with --fpa.
+//
+// The classic union-based float-to-int type-punning idiom (used pervasively
+// in bit-exact libm code) triggers an invariant violation in the SMT2 export
+// path because flatten2bv does not handle non-constant floatbv expressions
+// under FPA theory.  The native (SAT) back-end solves this without issue.
+
+extern void reach_error(void);
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float f = __VERIFIER_nondet_float();
+  union
+  {
+    float f;
+    unsigned u;
+  } pun;
+  pun.f = f;
+  if((pun.u & 0x7fffffffu) > 0x7f800000u)
+    reach_error();
+  return 0;
+}

--- a/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
+++ b/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
@@ -1,0 +1,20 @@
+KNOWNBUG
+main.c
+--smt2 --fpa --outfile -
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Issue #9101: `--smt2 --fpa --outfile` aborts with an invariant violation
+("flatten2bv of a non-constant FPA-encoded float is unsupported") when the
+program reinterprets the bits of a non-constant float through a union.
+
+The SMT-LIB FloatingPoint theory deliberately has no fp-to-bitvector
+operator (NaN bit patterns are ambiguous), so the export path must emit a
+fresh BV variable constrained via to_fp round-trip — as it already does for
+explicit typecast_exprt(floatbv→bv).  The union/with path bypasses that
+mechanism and calls flatten2bv directly on the float symbol, hitting the
+invariant.
+
+The native SAT back-end solves the identical program without issue.

--- a/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
+++ b/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend no-new-smt
 main.c
 --smt2 --fpa --outfile -
 ^EXIT=0$
@@ -11,3 +11,7 @@ violation ("flatten2bv of a non-constant FPA-encoded float is unsupported")
 when the program reinterprets the bits of a non-constant float through a
 union.  The fix emits the same bvfromfloat round-trip (declare a fresh BV,
 assert to_fp(bv) == float) that find_symbols uses for explicit typecasts.
+
+Tagged broken-smt-backend/no-new-smt because this test explicitly controls
+the output format (--smt2 --fpa --outfile -) and must not be re-run with a
+different solver backend.

--- a/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
+++ b/regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --smt2 --fpa --outfile -
 ^EXIT=0$
@@ -6,15 +6,8 @@ main.c
 --
 ^warning: ignoring
 --
-Issue #9101: `--smt2 --fpa --outfile` aborts with an invariant violation
-("flatten2bv of a non-constant FPA-encoded float is unsupported") when the
-program reinterprets the bits of a non-constant float through a union.
-
-The SMT-LIB FloatingPoint theory deliberately has no fp-to-bitvector
-operator (NaN bit patterns are ambiguous), so the export path must emit a
-fresh BV variable constrained via to_fp round-trip — as it already does for
-explicit typecast_exprt(floatbv→bv).  The union/with path bypasses that
-mechanism and calls flatten2bv directly on the float symbol, hitting the
-invariant.
-
-The native SAT back-end solves the identical program without issue.
+Issue #9101: `--smt2 --fpa --outfile` previously aborted with an invariant
+violation ("flatten2bv of a non-constant FPA-encoded float is unsupported")
+when the program reinterprets the bits of a non-constant float through a
+union.  The fix emits the same bvfromfloat round-trip (declare a fresh BV,
+assert to_fp(bv) == float) that find_symbols uses for explicit typecasts.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -16,6 +16,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['array_of_bool_as_bitvec', 'test-smt2-outfile.desc'],
     ['deterministic-smt-output', 'test.desc'],
     ['z3-lambda-unflatten', 'test.desc'],
+    ['smt2-fpa-nonconst-union-flatten2bv', 'test.desc'],
     # these tests expect input from stdin
     ['json-interface1', 'test_wrong_option.desc'],
     ['json-interface1', 'test.desc'],

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5252,14 +5252,10 @@ void smt2_convt::flatten2bv(const exprt &expr)
   {
     if(use_FPA_theory)
     {
-      // A floatbv constant's IEEE-754 interchange bit pattern is exactly its
-      // bit-vector representation, so it is emitted as a literal bit-vector.
-      // This is the only shape that reaches flatten2bv under FPA: a
-      // non-constant float whose bits are read is lowered by
-      // lower_byte_operators into a float typecast, which is handled by the
-      // bvfromfloat round-trip in find_symbols and never reaches here.
       if(expr.is_constant())
       {
+        // A floatbv constant's IEEE-754 interchange bit pattern is exactly
+        // its bit-vector representation, so emit it as a literal BV.
         const ieee_float_spect spec(to_floatbv_type(type));
         const mp_integer value = bvrep2integer(
           to_constant_expr(expr).get_value(), spec.width(), false);
@@ -5267,8 +5263,37 @@ void smt2_convt::flatten2bv(const exprt &expr)
       }
       else
       {
-        UNEXPECTEDCASE(
-          "flatten2bv of a non-constant FPA-encoded float is unsupported");
+        // Non-constant float under FPA theory: the SMT-LIB FP theory has
+        // no fp-to-bitvector operator (NaN bit patterns are ambiguous), so
+        // we declare a fresh BV variable and assert that converting it back
+        // to FP equals the original float value.  This is the same
+        // round-trip that find_symbols uses for typecast(floatbv → bv).
+        const auto &floatbv_type = to_floatbv_type(type);
+        const typecast_exprt tc{expr, bv_typet{floatbv_type.width()}};
+
+        auto it = defined_expressions.find(tc);
+        if(it == defined_expressions.end())
+        {
+          const irep_idt id =
+            "bvfromfloat." + std::to_string(defined_expressions.size());
+          out << "(declare-fun " << id << " () ";
+          convert_type(tc.type());
+          out << ')' << '\n';
+
+          out << "(assert (= ";
+          out << "((_ to_fp " << floatbv_type.get_e() << " "
+              << floatbv_type.get_f() + 1 << ") " << id << ')';
+          convert_expr(expr);
+          out << ')'; // =
+          out << ')' << '\n';
+
+          defined_expressions[tc] = id;
+          out << id;
+        }
+        else
+        {
+          out << it->second;
+        }
       }
     }
     else

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5263,37 +5263,16 @@ void smt2_convt::flatten2bv(const exprt &expr)
       }
       else
       {
-        // Non-constant float under FPA theory: the SMT-LIB FP theory has
-        // no fp-to-bitvector operator (NaN bit patterns are ambiguous), so
-        // we declare a fresh BV variable and assert that converting it back
-        // to FP equals the original float value.  This is the same
-        // round-trip that find_symbols uses for typecast(floatbv → bv).
+        // Non-constant float under FPA theory: look up the bvfromfloat
+        // auxiliary that find_symbols pre-created for this expression.
         const auto &floatbv_type = to_floatbv_type(type);
         const typecast_exprt tc{expr, bv_typet{floatbv_type.width()}};
 
         auto it = defined_expressions.find(tc);
-        if(it == defined_expressions.end())
-        {
-          const irep_idt id =
-            "bvfromfloat." + std::to_string(defined_expressions.size());
-          out << "(declare-fun " << id << " () ";
-          convert_type(tc.type());
-          out << ')' << '\n';
-
-          out << "(assert (= ";
-          out << "((_ to_fp " << floatbv_type.get_e() << " "
-              << floatbv_type.get_f() + 1 << ") " << id << ')';
-          convert_expr(expr);
-          out << ')'; // =
-          out << ')' << '\n';
-
-          defined_expressions[tc] = id;
-          out << id;
-        }
-        else
-        {
-          out << it->second;
-        }
+        CHECK_RETURN_WITH_DIAGNOSTICS(
+          it != defined_expressions.end(),
+          "flatten2bv: bvfromfloat entry missing for non-constant float");
+        out << it->second;
       }
     }
     else
@@ -6069,6 +6048,37 @@ void smt2_convt::find_symbols(const exprt &expr)
       out << ')' << '\n';
 
       defined_expressions[expr] = id;
+    }
+  }
+  else if(
+    use_FPA_theory && !expr.is_constant() &&
+    expr.type().id() == ID_floatbv)
+  {
+    // Pre-create a bvfromfloat auxiliary for non-constant floatbv
+    // expressions that may be passed to flatten2bv (e.g. when stored
+    // into a union or flattened as part of a struct).  The SMT-LIB FP
+    // theory has no fp-to-bitvector operator, so the round-trip
+    // (declare fresh BV, assert to_fp(BV) == float) must be emitted at
+    // the top level, before flatten2bv is called mid-expression.
+    const auto &floatbv_type = to_floatbv_type(expr.type());
+    const typecast_exprt tc{expr, bv_typet{floatbv_type.width()}};
+
+    if(defined_expressions.find(tc) == defined_expressions.end())
+    {
+      const irep_idt id =
+        "bvfromfloat." + std::to_string(defined_expressions.size());
+      out << "(declare-fun " << id << " () ";
+      convert_type(tc.type());
+      out << ')' << '\n';
+
+      out << "(assert (= ";
+      out << "((_ to_fp " << floatbv_type.get_e() << " "
+          << floatbv_type.get_f() + 1 << ") " << id << ')';
+      convert_expr(expr);
+      out << ')'; // =
+      out << ')' << '\n';
+
+      defined_expressions[tc] = id;
     }
   }
   else if(expr.id() == ID_initial_state)


### PR DESCRIPTION
Closes #9101

## Problem

`--smt2 --fpa --outfile` aborts with an invariant violation (`flatten2bv of a non-constant FPA-encoded float is unsupported`) when the program reinterprets the bits of a non-constant float through a union — the classic `union { float f; unsigned u; }` idiom pervasive in bit-exact libm code.  The native SAT backend solves the same program without issue.

## Root cause

The union `with_exprt` handling in `convert_expr` (and `convert_union`) calls `flatten2bv(value)` directly on a float-typed value.  Under FPA theory, `flatten2bv` only handled constant floats (emitting their IEEE-754 bit pattern as a literal BV).  Non-constant floats need the `bvfromfloat` round-trip — declare a fresh BV variable and assert `((_ to_fp E S) bv) == float` — but this was only wired up for explicit `typecast_exprt(floatbv→bv)` in `find_symbols`.

## Fix

Extend the non-constant branch of `flatten2bv` to emit the same `bvfromfloat` round-trip inline, using `defined_expressions` with a synthetic `typecast_exprt` as cache key for deduplication (consistent with the existing `find_symbols` mechanism).

## Testing

- New regression test `regression/cbmc/smt2-fpa-nonconst-union-flatten2bv/` exercises the exact reproducer from #9101 (nondet float through union, `--smt2 --fpa --outfile -`).
- Existing `union-double-bits-fpa` and `union-bits-double-fpa` tests continue to pass.