### PR TITLE
introduce `<<` on `cprover_exception_baset`

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -40,7 +40,7 @@ std::string invalid_function_contract_pair_exceptiont::what() const
   std::string res;
 
   res += "Invalid function-contract mapping";
-  res += "\nReason: " + reason;
+  res += "\nReason: " + reason();
 
   if(!correct_format.empty())
   {

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -98,7 +98,7 @@ std::string invalid_restriction_exceptiont::what() const
   std::string res;
 
   res += "Invalid restriction";
-  res += "\nReason: " + reason;
+  res += "\nReason: " + reason();
 
   if(!correct_format.empty())
   {

--- a/src/solvers/smt2/smt2_tokenizer.h
+++ b/src/solvers/smt2/smt2_tokenizer.h
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_SMT2_SMT2_TOKENIZER_H
 #define CPROVER_SOLVERS_SMT2_SMT2_TOKENIZER_H
 
+#include <util/exception_utils.h>
+
 #include <optional>
 #include <sstream>
 #include <string>
@@ -27,34 +29,18 @@ public:
   }
 
   /// Exception thrown by the tokenizer (and the parser built on top of
-  /// it) to report a syntactic error at a known source line.  Holds an
-  /// `std::ostringstream` so that callers can assemble the diagnostic
-  /// piecewise via `operator<<`.
-  class smt2_errort
+  /// it) to report a syntactic error at a known source line.
+  class smt2_errort : public cprover_exception_baset
   {
   public:
-    smt2_errort(smt2_errort &&) = default;
-
-    smt2_errort(const smt2_errort &other)
-    {
-      // ostringstream does not have a copy constructor
-      message << other.message.str();
-      line_no = other.line_no;
-    }
-
     smt2_errort(const std::string &_message, unsigned _line_no)
       : line_no(_line_no)
     {
-      message << _message;
+      _reason << _message;
     }
 
     explicit smt2_errort(unsigned _line_no) : line_no(_line_no)
     {
-    }
-
-    std::string what() const
-    {
-      return message.str();
     }
 
     unsigned get_line_no() const
@@ -62,13 +48,7 @@ public:
       return line_no;
     }
 
-    std::ostringstream &message_ostream()
-    {
-      return message;
-    }
-
   protected:
-    std::ostringstream message;
     unsigned line_no;
   };
 
@@ -198,15 +178,6 @@ private:
   /// consult or update `peeked` -- callers handle that.
   tokent read_token();
 };
-
-/// add to the diagnostic information in the given smt2_tokenizer exception
-template <typename T>
-smt2_tokenizert::smt2_errort
-operator<<(smt2_tokenizert::smt2_errort &&e, const T &message)
-{
-  e.message_ostream() << message;
-  return std::move(e);
-}
 
 bool is_smt2_simple_symbol_character(char);
 

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -11,7 +11,7 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 
 std::string cprover_exception_baset::what() const
 {
-  return reason;
+  return reason();
 }
 
 std::string invalid_command_line_argument_exceptiont::what() const
@@ -19,7 +19,7 @@ std::string invalid_command_line_argument_exceptiont::what() const
   std::string res;
   res += "Invalid User Input";
   res += "\nOption: " + option;
-  res += "\nReason: " + reason;
+  res += "\nReason: " + reason();
   // Print an optional correct usage message assuming correct input parameters have been passed
   if(!correct_input.empty())
   {
@@ -58,7 +58,7 @@ incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
 
 std::string incorrect_goto_program_exceptiont::what() const
 {
-  std::string ret(reason);
+  std::string ret(reason());
 
   if(!source_location.is_nil())
     ret += " (at: " + source_location.as_string() + ")";
@@ -95,5 +95,5 @@ invalid_source_file_exceptiont::invalid_source_file_exceptiont(
 
 std::string invalid_source_file_exceptiont::what() const
 {
-  return source_location.as_string() + ": " + reason;
+  return source_location.as_string() + ": " + reason();
 }

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -9,10 +9,13 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 #ifndef CPROVER_UTIL_EXCEPTION_UTILS_H
 #define CPROVER_UTIL_EXCEPTION_UTILS_H
 
-#include <string>
-
 #include "invariant.h"
 #include "source_location.h"
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 /// Base class for exceptions thrown in the cprover project.
 /// Intended to be used as a convenient way to have a
@@ -30,19 +33,57 @@ public:
   virtual std::string what() const;
   virtual ~cprover_exception_baset() = default;
 
+  cprover_exception_baset() = default;
+
+  cprover_exception_baset(cprover_exception_baset &&) = default;
+
+  // std::ostringstream does not have a copy constructor
+  cprover_exception_baset(const cprover_exception_baset &src)
+  {
+    _reason << src.reason();
+  }
+
+  std::string reason() const
+  {
+    return _reason.str();
+  }
+
 protected:
   /// This constructor is marked protected to ensure this class isn't used
   /// directly. Deriving classes should be used to more precisely describe the
   /// problem that occurred.
   explicit cprover_exception_baset(std::string reason)
-    : reason(std::move(reason))
   {
+    // ostringstream does not have an appropriate constructor
+    _reason << reason;
   }
 
   /// The reason this exception was generated. This is the string returned by
-  /// `what()` unless that method is overridden
-  std::string reason;
+  /// `what()` unless that method is overridden.  This is an ostringstream
+  /// to enable efficient appending with <<.
+  std::ostringstream _reason;
+
+  // to provide access to the _reason field
+  template <typename E, typename T>
+  friend std::enable_if_t<
+    std::is_base_of<cprover_exception_baset, std::decay_t<E>>::value,
+    E &&>
+  operator<<(E &&, const T &);
 };
+
+/// add to the diagnostic information in the given
+/// cprover_exception_baset exception; the type of the
+/// exception is preserved, enabling
+/// `throw some_exceptiont{...} << "text"`
+template <typename E, typename T>
+std::enable_if_t<
+  std::is_base_of<cprover_exception_baset, std::decay_t<E>>::value,
+  E &&>
+operator<<(E &&e, const T &message)
+{
+  e._reason << message;
+  return std::forward<E>(e);
+}
 
 /// Thrown when users pass incorrect command line arguments,
 /// for example passing no files to analysis or setting
@@ -176,9 +217,10 @@ public:
     source_locationt source_location);
   std::string what() const override;
 
-  const std::string &get_reason() const
+  // This method will go away, in favor of cprover_exception_baset::reason
+  std::string get_reason() const
   {
-    return reason;
+    return reason();
   }
 
   const source_locationt &get_source_location() const

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -150,6 +150,7 @@ SRC += analyses/ai/ai.cpp \
        util/dense_integer_map.cpp \
        util/dstring.cpp \
        util/edit_distance.cpp \
+       util/exception_utils.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr_initializer.cpp \
        util/expr.cpp \

--- a/unit/util/exception_utils.cpp
+++ b/unit/util/exception_utils.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************\
+
+Module: Unit tests for cprover_exception_baset
+
+Author: Daniel Kroening
+
+\*******************************************************************/
+
+#include <util/exception_utils.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "cprover_exception_baset default construction",
+  "[core][util][exception_utils]")
+{
+  cprover_exception_baset e;
+  CHECK(e.reason().empty());
+}
+
+TEST_CASE(
+  "cprover_exception_baset with message via operator<<",
+  "[core][util][exception_utils]")
+{
+  auto e = cprover_exception_baset{} << "something went wrong";
+  CHECK(e.what() == "something went wrong");
+}
+
+TEST_CASE(
+  "cprover_exception_baset streaming multiple values",
+  "[core][util][exception_utils]")
+{
+  auto e = cprover_exception_baset{} << "error " << 42 << " occurred";
+  CHECK(e.what() == "error 42 occurred");
+}
+
+TEST_CASE(
+  "operator<< preserves the exception type",
+  "[core][util][exception_utils]")
+{
+  // must not slice to cprover_exception_baset
+  REQUIRE_THROWS_AS(
+    throw system_exceptiont{"file"} << " not found", system_exceptiont);
+}
+
+TEST_CASE(
+  "cprover_exception_baset copy constructor",
+  "[core][util][exception_utils]")
+{
+  auto original = cprover_exception_baset{} << "copy test";
+
+  cprover_exception_baset copy(original);
+  CHECK(copy.what() == "copy test");
+
+  // Modifying the copy doesn't affect the original
+  copy << " extra";
+  CHECK(copy.what() == "copy test extra");
+  CHECK(original.what() == "copy test");
+}


### PR DESCRIPTION
This introduces the operator `<<` on `error_exceptiont`, which offers the option to extend the reason message.  Any exception derived from `cprover_exception_baset` can then be thrown as follows:
    
      throw some_exceptiont{} << "text" << ....;

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
