### PR TITLE
fix(docs): typo in short tutorial link

### DIFF
--- a/doc/doxygen-root/user_guide.md
+++ b/doc/doxygen-root/user_guide.md
@@ -3,7 +3,7 @@
 For a quick start with CBMC on simple problems, read
 
 * The \ref installation_guide
-* A [short tutorial](cprover-manual/md_cbmc_tutorial.html)
+* A [short tutorial](cprover-manual/md_cbmc-tutorial.html)
 * A [short manual](cprover-manual/index.html)
 
 For a quick start with CBMC on large software projects, read


### PR DESCRIPTION
The short tutorial link in user_guide.md had a typo leading to a 404 on the web documentation

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
