### PR TITLE
Regression tests for same-named functions across translation units

### DIFF
--- a/regression/cbmc/Static_Functions1/resolve_a.c
+++ b/regression/cbmc/Static_Functions1/resolve_a.c
@@ -1,0 +1,10 @@
+// file-local f, distinct from resolve_b.c's static f and the global f
+static int f(void)
+{
+  return 1;
+}
+
+int fa(void)
+{
+  return f();
+}

--- a/regression/cbmc/Static_Functions1/resolve_b.c
+++ b/regression/cbmc/Static_Functions1/resolve_b.c
@@ -1,0 +1,10 @@
+// file-local f, distinct from resolve_a.c's static f and the global f
+static int f(void)
+{
+  return 2;
+}
+
+int fb(void)
+{
+  return f();
+}

--- a/regression/cbmc/Static_Functions1/resolve_main.c
+++ b/regression/cbmc/Static_Functions1/resolve_main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+// Two further translation units (resolve_a.c, resolve_b.c) each define their
+// own file-local (static) function f, while this unit defines a global
+// (external linkage) f, all sharing the name f. Each call must resolve to the
+// definition mandated by the C standard: internal linkage stays within its
+// translation unit, external linkage is shared.
+int fa(void); // returns resolve_a.c's static f (== 1)
+int fb(void); // returns resolve_b.c's static f (== 2)
+
+int f(void) // the global f
+{
+  return 3;
+}
+
+int main(void)
+{
+  assert(fa() == 1);
+  assert(fb() == 2);
+  assert(f() == 3); // resolves to the global f defined above
+}

--- a/regression/cbmc/Static_Functions1/test-resolve.desc
+++ b/regression/cbmc/Static_Functions1/test-resolve.desc
@@ -1,0 +1,16 @@
+CORE
+resolve_main.c
+resolve_a.c resolve_b.c
+^\[main\.assertion\.1\] line 18 assertion fa\(\) == 1: SUCCESS$
+^\[main\.assertion\.2\] line 19 assertion fb\(\) == 2: SUCCESS$
+^\[main\.assertion\.3\] line 20 assertion f\(\) == 3: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Two translation units define a file-local (static) function named f, and a
+third defines a global f. Each call must resolve to the definition mandated
+by the C standard: the file-local calls stay within their unit, and the call
+from the unit defining the global f reaches that global.

--- a/regression/cbmc/Static_Functions1/test-unwind.desc
+++ b/regression/cbmc/Static_Functions1/test-unwind.desc
@@ -1,0 +1,20 @@
+CORE
+unwind_main.c
+unwind_a.c unwind_b.c --unwinding-assertions --unwindset 'count.0:4,count$link1.0:2'
+^\[count\.unwind\.0\] file unwind_b\.c line 6 unwinding assertion loop 0: FAILURE$
+^\[main\.assertion\.1\] line 13 assertion a_entry\(3\) == 3: SUCCESS$
+^\[main\.assertion\.2\] line 14 assertion b_entry\(3\) == 6: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+file unwind_a\.c line 5 unwinding assertion loop 0: FAILURE
+--
+Two translation units define a file-local (static) function count, each with a
+loop. Linking renames the second, giving distinct loop identifiers count.0
+(unwind_a.c) and count$link1.0 (unwind_b.c). --unwindset uses those identifiers
+to bound the loops independently: count.0:4 is sufficient for unwind_a.c (no
+unwinding-assertion failure there), while count$link1.0:2 is too few for
+unwind_b.c and its unwinding assertion fails. This confirms the linker-renamed
+identifier selects the intended loop.

--- a/regression/cbmc/Static_Functions1/unwind_a.c
+++ b/regression/cbmc/Static_Functions1/unwind_a.c
@@ -1,0 +1,13 @@
+// file-local count; its loop is identified as count.0 after linking
+static int count(int n)
+{
+  int s = 0;
+  for(int i = 0; i < n; i++)
+    s += 1;
+  return s;
+}
+
+int a_entry(int n)
+{
+  return count(n);
+}

--- a/regression/cbmc/Static_Functions1/unwind_b.c
+++ b/regression/cbmc/Static_Functions1/unwind_b.c
@@ -1,0 +1,14 @@
+// file-local count with the same name as the one in unwind_a.c; after linking
+// its loop is renamed and identified as count$link1.0
+static int count(int n)
+{
+  int s = 0;
+  for(int i = 0; i < n; i++)
+    s += 2;
+  return s;
+}
+
+int b_entry(int n)
+{
+  return count(n);
+}

--- a/regression/cbmc/Static_Functions1/unwind_main.c
+++ b/regression/cbmc/Static_Functions1/unwind_main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+// unwind_a.c and unwind_b.c both define a file-local (static) function named
+// count, each containing a loop. After linking, the second definition is
+// renamed, so the two loops carry distinct identifiers: count.0 (unwind_a.c)
+// and count$link1.0 (unwind_b.c). This shows those identifiers can be used
+// with --unwindset to bound each loop independently.
+int a_entry(int n);
+int b_entry(int n);
+
+int main(void)
+{
+  assert(a_entry(3) == 3);
+  assert(b_entry(3) == 6);
+}


### PR DESCRIPTION
Static (internal-linkage) functions may share a name across translation units, and may coexist with a global (external-linkage) function of the same name. Extend the existing Static_Functions1 directory with two further test descriptors confirming CBMC's behaviour here:

* test-resolve.desc checks that calls resolve to the definition mandated by the C standard when two translation units each define a file-local f and a third defines a global f: each file-local call stays within its unit, and the call from the unit defining the global reaches it.

* test-unwind.desc checks loop unwinding in this context. Linking renames the second same-named static function, so the two loops carry distinct identifiers count.0 and count$link1.0. The test uses --unwindset with those identifiers to bound the loops independently, demonstrating that the linker-renamed identifier selects the intended loop.

The pre-existing test.desc already covers a static function shadowing a global of the same name.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
