### PR TITLE
Remove the redundant homebrew-pr release job

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -192,24 +192,6 @@ jobs:
         with:
           path: .ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
-  homebrew-pr:
-    runs-on: macos-15-intel
-    steps:
-      - name: Get release tag name
-        # The GITHUB_REF we get has refs/tags/ in front of the tag name so we
-        # strip that here
-        run: echo "RELEASE_TAG=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
-      - name: Configure git user name and email
-        uses: Homebrew/actions/git-user-config@c62170a03ff2bcb9ab097fd7d6acbc905618e42a
-        with:
-          username: db-ci-cprover
-      - name: Create homebrew PR
-        run: |
-          brew update-reset
-          brew bump-formula-pr --tag "$RELEASE_TAG" --revision "$GITHUB_SHA" cbmc
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.DB_CI_CPROVER_ACCESS_TOKEN }}
-
   windows-msi-package:
     runs-on: windows-2025
     env:


### PR DESCRIPTION
Homebrew-core auto-bumps the cbmc formula via BrewTestBot, so the manual `brew bump-formula-pr` this job runs is now rejected (the formula is on the autobump list) - the job has only produced failures since 6.9.0 while the formula on homebrew-core stays current on its own. Versioned formulae in the diffblue/homebrew-cbmc tap are likewise maintained by that tap's own scheduled workflow. Remove the job.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
