### PR TITLE
Make sorting deterministic

### DIFF
--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -23,7 +23,7 @@ for f in "$@"; do
 done
 
 # Make sure all internal library functions have tests exercising them:
-grep '^/\* FUNCTION:' ../*/library/* | cut -f3 -d" " | sort -u > __functions
+grep '^/\* FUNCTION:' ../*/library/* | cut -f3 -d" " | LC_ALL=C sort -u > __functions
 
 # Some functions are not expected to have tests:
 perl -p -i -e 's/^__CPROVER_jsa_synthesise\n//' __functions
@@ -101,7 +101,7 @@ perl -p -i -e 's/^_mm_setr_epi(16|32)\n//' __functions # cbmc/SIMD1
 perl -p -i -e 's/^_mm_setr_pi16\n//' __functions # cbmc/SIMD1
 perl -p -i -e 's/^_mm_subs_ep[iu]16\n//' __functions # cbmc/SIMD1
 
-ls ../../regression/cbmc-library/ | egrep -v '(Makefile|CMakeLists.txt)' | sort -u > __tests
+ls -1 ../../regression/cbmc-library/ | egrep -v '(Makefile|CMakeLists.txt)' | LC_ALL=C sort -u > __tests
 diff -u __tests __functions
 ec="${?}"
 rm __functions __tests


### PR DESCRIPTION
Without this change, files `__functions` and `__tests` can appear in different order.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
