### PR TITLE
DFCC: complete bodiless declarations when loading the contracts library

### DIFF
--- a/regression/contracts-dfcc/chain.sh
+++ b/regression/contracts-dfcc/chain.sh
@@ -21,6 +21,16 @@ else
   args_cbmc="${args#*" _ "}"
 fi
 
+# An optional pre-processing pass with goto-instrument can be requested by
+# separating its arguments from the main instrumentation arguments using
+# " __ ", as in: --drop-unused-functions __ --dfcc main
+args_pre=""
+if [[ "$args_inst" == *" __ "* ]]
+then
+  args_pre="${args_inst%%" __ "*}"
+  args_inst="${args_inst#*" __ "}"
+fi
+
 dfcc_suffix=""
 if [[ "${use_dfcc}" == "false" ]]; then
   set -- $args_inst
@@ -41,6 +51,12 @@ if [[ "${is_windows}" == "true" ]]; then
   $goto_cc "${name}.c" "/Fe${name}${dfcc_suffix}.gb"
 else
   $goto_cc -o "${name}${dfcc_suffix}.gb" "${name}.c"
+fi
+
+if [[ -n "$args_pre" ]]; then
+  $goto_instrument ${args_pre} "${name}${dfcc_suffix}.gb" \
+    "${name}${dfcc_suffix}-pre.gb"
+  mv "${name}${dfcc_suffix}-pre.gb" "${name}${dfcc_suffix}.gb"
 fi
 
 rm -f "${name}${dfcc_suffix}-mod.gb"

--- a/regression/contracts-dfcc/free_body_dropped/main.c
+++ b/regression/contracts-dfcc/free_body_dropped/main.c
@@ -1,0 +1,14 @@
+void free(void *ptr)
+{
+}
+
+void foo(void *p)
+{
+  free(p);
+}
+
+int main()
+{
+  int x = 42;
+  return 0;
+}

--- a/regression/contracts-dfcc/free_body_dropped/test.desc
+++ b/regression/contracts-dfcc/free_body_dropped/test.desc
@@ -1,0 +1,15 @@
+CORE dfcc-only
+main.c
+--drop-unused-functions __ --dfcc main
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test checks that goto-instrument --dfcc does not fail when the model
+contains a function symbol that carries the `compiled` marker value while its
+body is not present in the goto functions map. This state arises when
+--drop-unused-functions removes the body of a function (here: a user-provided
+model of free) that is unreachable from the entry point.
+See: https://github.com/diffblue/cbmc/issues/8814

--- a/regression/contracts-dfcc/free_in_unrelated_function/main.c
+++ b/regression/contracts-dfcc/free_in_unrelated_function/main.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+
+void foo(void *p)
+{
+  free(p);
+}
+
+int main()
+{
+  int x = 42;
+  return 0;
+}

--- a/regression/contracts-dfcc/free_in_unrelated_function/test.desc
+++ b/regression/contracts-dfcc/free_in_unrelated_function/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that goto-instrument --dfcc does not fail when code
+unrelated to the harness contains a call to free.
+See: https://github.com/diffblue/cbmc/issues/8814

--- a/regression/contracts-dfcc/free_user_defined/main.c
+++ b/regression/contracts-dfcc/free_user_defined/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int free_called = 0;
+
+void free(void *ptr)
+{
+  free_called = 1;
+}
+
+int main()
+{
+  int x;
+  free(&x);
+  assert(free_called == 1);
+  return 0;
+}

--- a/regression/contracts-dfcc/free_user_defined/test.desc
+++ b/regression/contracts-dfcc/free_user_defined/test.desc
@@ -1,0 +1,15 @@
+CORE dfcc-only
+main.c
+--dfcc main
+^EXIT=0$
+^SIGNAL=0$
+ASSIGN free_called := 1$
+IF free::__write_set_to_check = NULL THEN GOTO
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test checks that a user-provided model of free that is present in the
+model with a body is preserved by goto-instrument --dfcc: the body must not be
+replaced by the built-in library model, and it must be instrumented with a
+ghost write set parameter like any other function.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -12,6 +12,7 @@ Author: Remi Delmas, delmarsd@amazon.com
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
+#include <util/format_type.h>
 #include <util/message.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_predicates.h>
@@ -265,20 +266,35 @@ std::set<irep_idt> dfcc_libraryt::get_missing_funs()
   // go over all library functions
   for(const auto &pair : dfcc_fun_to_name)
   {
-    symbol_tablet::symbolst::const_iterator found =
-      goto_model.symbol_table.symbols.find(pair.second);
-
-    if(
-      found == goto_model.symbol_table.symbols.end() ||
-      found->second.value.is_nil())
-    {
+    // check for an actual body in the goto functions map instead of relying
+    // on the symbol's value: a symbol may carry the `compiled` marker value
+    // even when its body was dropped, e.g. by `--drop-unused-functions`
+    if(!dfcc_utilst::function_symbol_with_body_exists(goto_model, pair.second))
       missing.insert(pair.second);
-    }
   }
   return missing;
 }
 
 bool dfcc_libraryt::loaded = false;
+
+/// Returns true iff the two code types are equal when ignoring parameter
+/// identifiers and base names.
+static bool code_types_match(const typet &lhs, const typet &rhs)
+{
+  if(lhs == rhs)
+    return true;
+  code_typet lhs_code = to_code_type(lhs);
+  code_typet rhs_code = to_code_type(rhs);
+  for(code_typet *code_type : {&lhs_code, &rhs_code})
+  {
+    for(auto &parameter : code_type->parameters())
+    {
+      parameter.set_identifier(irep_idt{});
+      parameter.set_base_name(irep_idt{});
+    }
+  }
+  return lhs_code == rhs_code;
+}
 
 void dfcc_libraryt::load(std::set<irep_idt> &to_instrument)
 {
@@ -318,12 +334,38 @@ void dfcc_libraryt::load(std::set<irep_idt> &to_instrument)
   // compute missing library functions before modifying the symbol table
   std::set<irep_idt> missing = get_missing_funs();
 
-  // copy all loaded symbols to the main symbol table
+  // Copy all loaded symbols to the main symbol table. Functions that already
+  // exist in the model but have no body in the goto functions map are
+  // completed using the library implementation: the model may declare, say,
+  // `free` (via stdlib.h) without its body ever being linked in when all
+  // calls to it are unreachable from the entry point, or a body may have
+  // been removed by `--drop-unused-functions`, which leaves the symbol value
+  // set to the `compiled` marker. The DFCC library requires the
+  // implementations of the functions loaded above in either case. Symbols
+  // whose value holds a not-yet-converted body are left alone.
   for(const auto &symbol_pair : tmp_symbol_table.symbols)
   {
-    const auto &sym = symbol_pair.first;
-    if(!goto_model.symbol_table.has_symbol(sym))
-      goto_model.symbol_table.insert(symbol_pair.second);
+    auto insert_result = goto_model.symbol_table.insert(symbol_pair.second);
+    symbolt &existing = insert_result.first;
+    if(
+      !insert_result.second && symbol_pair.second.type.id() == ID_code &&
+      symbol_pair.second.value.is_not_nil() && existing.type.id() == ID_code &&
+      (existing.value.is_nil() || existing.is_compiled()) &&
+      !dfcc_utilst::function_symbol_with_body_exists(
+        goto_model, symbol_pair.first))
+    {
+      if(!code_types_match(existing.type, symbol_pair.second.type))
+      {
+        log.warning() << "dfcc_libraryt::load: replacing declaration of '"
+                      << symbol_pair.first << "' of type '"
+                      << format(existing.type)
+                      << "' with the CPROVER library implementation of type '"
+                      << format(symbol_pair.second.type) << "'"
+                      << messaget::eom;
+      }
+      existing.type = symbol_pair.second.type;
+      existing.value = symbol_pair.second.value;
+    }
   }
 
   // compile all missing library functions to GOTO


### PR DESCRIPTION
The DFCC library unconditionally requires implementations of malloc, free, and __CPROVER_deallocate, because they are called from __CPROVER_contracts_write_set_deallocate_freeable and friends, which get inlined during library loading.

The C library linker (link_to_library) only adds function bodies for functions reachable from the entry point. When user code declares free (via stdlib.h) and only calls it from functions unreachable from the harness, the symbol table contains a bodiless declaration of free. dfcc_libraryt::load then skipped copying the library implementation because a symbol of that name already existed, and inlining __CPROVER_contracts_write_set_deallocate_freeable subsequently failed with "no body for function 'free'".

Complete such bodiless function declarations with the library implementation when copying loaded library symbols into the model.

Fixes: #8814

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
