### PR TITLE
C front-end: permit taking the address of built-in functions

### DIFF
--- a/regression/ansi-c/gcc_builtins_address_of/main.c
+++ b/regression/ansi-c/gcc_builtins_address_of/main.c
@@ -1,0 +1,22 @@
+#ifdef __GNUC__
+
+int main()
+{
+  void (*f)(int) = __builtin_exit;
+  int (*g)(float) = __builtin_isnanf;
+  int (*h)(int) = __builtin_ffs;
+  void *(*m)(__SIZE_TYPE__) = __builtin_malloc;
+  void *(*c)(void *, const void *, __SIZE_TYPE__) = __builtin_memcpy;
+  (void)g(3.14f);
+  (void)h(42);
+  f(1);
+  return 0;
+}
+
+#else
+
+int main()
+{
+}
+
+#endif

--- a/regression/ansi-c/gcc_builtins_address_of/test.desc
+++ b/regression/ansi-c/gcc_builtins_address_of/test.desc
@@ -1,0 +1,8 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/cbmc-library/__builtin_exit/main.c
+++ b/regression/cbmc-library/__builtin_exit/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  __builtin_exit(0);
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_exit/test.desc
+++ b/regression/cbmc-library/__builtin_exit/test.desc
@@ -1,0 +1,8 @@
+CORE gcc-only
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/gcc_builtins_address_of/main.c
+++ b/regression/cbmc/gcc_builtins_address_of/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main()
+{
+  void (*f)(int) = __builtin_exit;
+  int (*g)(float) = __builtin_isnanf;
+  assert(!g(3.14f));
+  f(1);
+  assert(0);
+  return 0;
+}

--- a/regression/cbmc/gcc_builtins_address_of/test.desc
+++ b/regression/cbmc/gcc_builtins_address_of/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -884,9 +884,15 @@ void c_typecheck_baset::typecheck_expr_symbol(exprt &expr)
   const symbolt *symbol_ptr;
   if(lookup(identifier, symbol_ptr))
   {
-    error().source_location = expr.source_location();
-    error() << "failed to find symbol '" << identifier << "'" << eom;
-    throw 0;
+    // If this is a built-in, try to add it to the symbol table on the fly,
+    // just like we do for function calls (see
+    // typecheck_side_effect_function_call).
+    if(builtin_factory(identifier) || lookup(identifier, symbol_ptr))
+    {
+      error().source_location = expr.source_location();
+      error() << "failed to find symbol '" << identifier << "'" << eom;
+      throw 0;
+    }
   }
 
   const symbolt &symbol=*symbol_ptr;

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -108,6 +108,14 @@ void exit(int status)
 #endif
 }
 
+/* FUNCTION: __builtin_exit */
+
+void __builtin_exit(int status)
+{
+  (void)status;
+  __CPROVER_assume(0);
+}
+
 /* FUNCTION: _Exit */
 
 #undef _Exit


### PR DESCRIPTION
Referencing a built-in function outside a direct call, such as when taking its address, failed with "failed to find symbol" (CONVERSION ERROR) because only typecheck_side_effect_function_call would consult builtin_factory to add declarations of built-ins on demand.

Also try builtin_factory when a symbol expression fails to resolve, so that code like 'void (*f)(int) = __builtin_exit;' type-checks. Direct calls to built-ins that CBMC rewrites into expressions are unaffected, as that rewriting happens for all calls irrespective of a symbol table entry. Calls via function pointers to built-ins without a library model continue to be flagged by the no-body checks.

Fixes: #8811

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
