### PR TITLE
Abort on self-aliased operands in BigInt compound assignments

### DIFF
--- a/src/big-int/bigint-func.cc
+++ b/src/big-int/bigint-func.cc
@@ -20,7 +20,7 @@ pow (BigInt const &x, unsigned y)
       y >>= 1;
       if (y == 0)
 	return r;
-      a *= a;
+      a = a * a;
     }
 }
 
@@ -44,7 +44,7 @@ pow (BigInt const &x, BigInt const &y, BigInt const &m)
       b /= 2;
       if (b.is_zero())
 	return r;
-      a *= a;
+      a = a * a;
     }
 }
 

--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -11,6 +11,7 @@
 
 #include <cctype>
 #include <climits>
+#include <cstdlib>
 #include <cstring>
 
 // How to report errors.
@@ -779,6 +780,16 @@ BigInt::compare (BigInt const &b) const
 void
 BigInt::add (onedig_t const *dig, unsigned len, bool pos)
 {
+  // dig aliases this->digit when called via x += x or x -= x. The
+  // resize below may free that buffer, turning dig into a dangling
+  // pointer. Self-aliased operands are not supported; spell doubling
+  // as x + x or use a copy of the operand.
+  if(dig == digit)
+  {
+    error("BigInt::add: operand must not alias *this.");
+    abort();
+  }
+
   // Make sure the result fits into this, even with carry.
   resize ((length > len ? length : len) + 1);
 

--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -843,6 +843,15 @@ BigInt::add (onedig_t const *dig, unsigned len, bool pos)
 void
 BigInt::mul (onedig_t const *dig, unsigned len, bool pos)
 {
+    // Self-aliased operands are not supported: parts of the code below
+    // read the operand after this->digit has been reallocated or
+    // modified. Spell squaring as x * x or use a copy of the operand.
+    if(dig == digit)
+    {
+      error("BigInt::mul: operand must not alias *this.");
+      abort();
+    }
+
   if (len < 2)
     {
       // Handle small dig/len operand efficiently.
@@ -1140,6 +1149,13 @@ BigInt::div (BigInt const &x, BigInt const &y, BigInt &q, BigInt &r)
 BigInt &
 BigInt::operator/= (BigInt const &y)
 {
+  // Self-aliased operands are not supported anywhere in this library.
+  if(this == &y)
+  {
+      error("BigInt::operator/=: operand must not alias *this.");
+      abort();
+  }
+
   // Eliminate some trivial cases.
   int cmp = ucompare (y);
   if (cmp < 0)
@@ -1208,6 +1224,13 @@ BigInt::operator/= (BigInt const &y)
 BigInt &
 BigInt::operator%= (BigInt const &y)
 {
+  // Self-aliased operands are not supported anywhere in this library.
+  if(this == &y)
+  {
+    error("BigInt::operator%=: operand must not alias *this.");
+    abort();
+  }
+
   // Eliminate some trivial cases.
   int cmp = ucompare (y);
   if (cmp < 0)

--- a/unit/big-int/big-int.cpp
+++ b/unit/big-int/big-int.cpp
@@ -100,6 +100,24 @@ TEST_CASE("arbitrary precision integers", "[core][big-int][bigint]")
     const BigInt y_copy(y);
     y -= y_copy;
     REQUIRE(y.is_zero());
+
+    // Squaring through a copy of the operand; z *= z would abort.
+    BigInt z("18446744073709551616"); // 2^64
+    const BigInt z_copy(z);
+    z *= z_copy;
+    REQUIRE(to_string(z) == "340282366920938463463374607431768211456");
+
+    // Division and remainder with equal operands take the
+    // value-equality fast path; w /= w and v %= v would abort.
+    BigInt w("340282366920938463463374607431768211456"); // 2^128
+    const BigInt w_copy(w);
+    w /= w_copy;
+    REQUIRE(to_string(w) == "1");
+
+    BigInt v("340282366920938463463374607431768211456");
+    const BigInt v_copy(v);
+    v %= v_copy;
+    REQUIRE(v.is_zero());
   }
 
   // =====================================================================

--- a/unit/big-int/big-int.cpp
+++ b/unit/big-int/big-int.cpp
@@ -76,6 +76,33 @@ TEST_CASE("arbitrary precision integers", "[core][big-int][bigint]")
   }
 
   // =====================================================================
+  // Compound assignment with an operand equal to the left-hand side.
+  // =====================================================================
+  // Self-aliased operands (x += x) are not supported and abort at
+  // runtime: operator+= and operator-= pass the operand's digit buffer
+  // into add(), which resizes (and possibly frees) this->digit before
+  // reading that buffer. The tests below use a distinct copy of the
+  // operand, which is the supported spelling; they still exercise the
+  // buffer growth in add() with equal-length operands.
+  SECTION("compound assignment with equal operands")
+  {
+    // Scanning from a string produces a buffer without spare capacity:
+    // 2^192 - 1 occupies six 32-bit digits, the doubled value needs
+    // seven, forcing the reallocation inside add().
+    BigInt x("6277101735386680763835789423207666416102355444464034512895");
+    const BigInt x_copy(x);
+    x += x_copy;
+    REQUIRE(
+      to_string(x) ==
+      "12554203470773361527671578846415332832204710888928069025790");
+
+    BigInt y("6277101735386680763835789423207666416102355444464034512895");
+    const BigInt y_copy(y);
+    y -= y_copy;
+    REQUIRE(y.is_zero());
+  }
+
+  // =====================================================================
   // Test cases from the clisp test suite in number.tst.
   // =====================================================================
 


### PR DESCRIPTION
`operator+=` and `operator-=` pass the right-hand side's digit buffer into the private `add()` method, which resizes `*this` before reading from that buffer. When the right-hand side is `*this` itself (`x += x`, `x -= x`) and the result requires a larger buffer, resize replaces and frees the digit array, and `add()` then reads the operand's digits from freed memory. Address sanitizer flags the read; the computed value may be silently wrong. The bug went unnoticed because no in-tree code self-adds a BigInt, and buffers constructed via the numeric constructors carry enough spare capacity to make small self-additions stay in place.

Per our policy that operand aliasing must never be supported, self-aliased operands now abort loudly instead of silently computing garbage:

1. **Addition/subtraction:** `add()` aborts when the operand's digit buffer aliases `this->digit` (which is exactly the `x += x` / `x -= x` case, since distinct BigInt objects never share buffers). Doubling can be spelled `x + x` or via a copy of the operand.

2. **Multiplication/division:** `mul()` was safe for `x *= x` only by inspection of its current implementation, and self-multiplication is not hypothetical — `pow()` squared its base via `a *= a` on every iteration. `pow()` now squares via a temporary, and `mul()` aborts on self-aliased operands like `add()`. `operator/=` and `operator%=` handled self-aliasing correctly through the value-equality fast path, but abort as well to keep the library-wide contract uniform: a BigInt operand must never alias `*this`. Operands merely equal in value are unaffected.

Unit tests cover doubling, self-subtraction, squaring, division and remainder through a distinct copy of the operand — the supported spelling — using string-scanned values whose buffers have no spare capacity, so the buffer growth in `add()` is genuinely exercised. The abort paths are not unit-testable with Catch2 (no death tests).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
