### PR TITLE
Share object maps in value_sett::make_union when destination is empty

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -319,6 +319,20 @@ bool value_sett::make_union_would_change(
 
 bool value_sett::make_union(object_mapt &dest, const object_mapt &src) const
 {
+  if(src.read().empty())
+    return false;
+
+  // If the destination is empty we can just share the (reference-counted)
+  // representation of `src` instead of inserting elements one by one. Queries
+  // over a single symbol repeatedly arrive here with an empty destination, so
+  // this turns an operation that is linear in the size of the value set (with
+  // all the allocation work that entails) into a constant-time one.
+  if(dest.read().empty())
+  {
+    dest = src;
+    return true;
+  }
+
   bool result=false;
 
   for(object_map_dt::const_iterator it=src.read().begin();


### PR DESCRIPTION
The object_mapt representation is reference counted precisely so that multiple owners can share one map, yet make_union built the union element by element even when the destination was empty. Value-set queries for a single symbol (via get_value_set_rec) arrive here with an empty destination, so each such query copied the symbol's entire object map, including one std::optional<exprt> offset per element. Sharing the source map instead makes this constant time and removes the dominant allocation churn from value-set queries in symbolic execution.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
