### PR TITLE
Fix profiling memory limit under a pre-existing hard rlimit

### DIFF
--- a/scripts/profiling/runner.py
+++ b/scripts/profiling/runner.py
@@ -16,6 +16,23 @@ DWARF_STACK_SIZE = 16384
 _perf_event_cache = None
 
 
+def _limit_address_space(memory_mb):
+    """Limit the virtual address space of the current process; used as
+    preexec_fn in the perf-record subprocess.
+
+    Only the soft limit is set. The hard limit is left untouched: raising it
+    requires privilege, so attempting to set it to RLIM_INFINITY raises
+    ValueError whenever the calling shell already imposed a finite hard limit
+    (e.g. via `ulimit -v`). The soft limit is clamped to the existing hard
+    limit for the same reason. Exceptions in preexec_fn abort the child, so
+    err on the permissive side."""
+    soft = memory_mb * 1024 * 1024
+    hard = resource.getrlimit(resource.RLIMIT_AS)[1]
+    if hard != resource.RLIM_INFINITY:
+        soft = min(soft, hard)
+    resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
+
+
 def _detect_perf_event():
     """Detect whether hardware cycles counter is available, fall back to
     cpu-clock software event (for CI containers/VMs without PMU access).
@@ -100,8 +117,7 @@ def run_benchmark(cbmc, bench, output_dir, timeout, memory_mb, skip_solver):
     try:
         result = subprocess.run(
             perf_cmd, capture_output=True, text=True, timeout=timeout,
-            preexec_fn=lambda: resource.setrlimit(
-                resource.RLIMIT_AS, (memory_mb * 1024 * 1024, -1)))
+            preexec_fn=lambda: _limit_address_space(memory_mb))
         cbmc_stdout = result.stdout + result.stderr
         elapsed = time.monotonic() - start
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
The perf-record subprocess set its RLIMIT_AS with a hard limit of -1 (unlimited) in preexec_fn. Raising the hard limit requires privilege, so whenever the calling shell had already imposed a finite hard limit (e.g. an outer `ulimit -v`), setrlimit raised ValueError inside preexec_fn and the benchmark could not run at all. Set only the soft limit, clamped to the existing hard limit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
