### PR TITLE
Avoid materializing value sets when simplifying POINTER_OBJECT equalties

### DIFF
--- a/src/goto-symex/simplify_expr_with_value_set.cpp
+++ b/src/goto-symex/simplify_expr_with_value_set.cpp
@@ -19,6 +19,10 @@ Author: Michael Tautschnig
 
 #include "goto_symex_can_forward_propagate.h"
 
+#include <cstdint>
+#include <set>
+#include <vector>
+
 /// Try to evaluate a simple pointer comparison.
 /// \param operation: ID_equal or ID_not_equal
 /// \param symbol_expr: The symbol expression in the condition
@@ -155,6 +159,62 @@ simplify_exprt::resultt<> simplify_expr_with_value_sett::simplify_inequality(
     return unchanged(expr);
 }
 
+/// Compute the object number (in \ref value_sett::object_numbering) of the
+/// root object of the object numbered \p object_number, or return an empty
+/// std::optional when the object is "unknown," "invalid," or a failed symbol.
+/// Results are cached: the numbering is global, append-only, and maps numbers
+/// to immutable expressions, so a result computed once remains valid for the
+/// lifetime of the program. This matters as value sets are repeatedly
+/// re-inspected element by element in
+/// \ref simplify_expr_with_value_sett::simplify_inequality_pointer_object,
+/// which makes the per-element cost of testing for failed symbols and of
+/// numbering root objects a dominant cost of symbolic execution when value
+/// sets grow large.
+static std::optional<object_numberingt::number_type>
+root_object_number(object_numberingt::number_type object_number)
+{
+  enum class statet : std::uint8_t
+  {
+    NOT_COMPUTED,
+    EXCLUDED,
+    VALID
+  };
+  struct cache_entryt
+  {
+    statet state = statet::NOT_COMPUTED;
+    object_numberingt::number_type root_object_number = 0;
+  };
+  static std::vector<cache_entryt> cache;
+
+  if(cache.size() <= object_number)
+    cache.resize(object_number + 1);
+
+  cache_entryt &entry = cache[object_number];
+  if(entry.state == statet::NOT_COMPUTED)
+  {
+    const exprt &object = value_sett::object_numbering[object_number];
+    const exprt &root_object = object_descriptor_exprt::root_object(object);
+
+    if(
+      object.id() == ID_unknown || object.id() == ID_invalid ||
+      is_failed_symbol(root_object))
+    {
+      entry.state = statet::EXCLUDED;
+    }
+    else
+    {
+      entry.state = statet::VALID;
+      entry.root_object_number =
+        value_sett::object_numbering.number(root_object);
+    }
+  }
+
+  if(entry.state == statet::EXCLUDED)
+    return {};
+  else
+    return entry.root_object_number;
+}
+
 simplify_exprt::resultt<>
 simplify_expr_with_value_sett::simplify_inequality_pointer_object(
   const binary_relation_exprt &expr)
@@ -162,44 +222,58 @@ simplify_expr_with_value_sett::simplify_inequality_pointer_object(
   PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
   PRECONDITION(expr.is_boolean());
 
+  // Collect the objects that `pointer` may point to, as a set of object
+  // numbers in value_sett::object_numbering. Working with object numbers
+  // rather than materialized expressions avoids both the cost of building an
+  // object_descriptor_exprt per value-set element and the cost of comparing
+  // deep expression trees when populating the set: the numbering is
+  // hash-consed, so each distinct expression is numbered once and set
+  // operations are operations over integers. An empty set means "no
+  // information".
   auto collect_objects = [this](const exprt &pointer)
   {
-    std::set<exprt> objects;
+    std::set<object_numberingt::number_type> objects;
     if(auto address_of = expr_try_dynamic_cast<address_of_exprt>(pointer))
     {
-      objects.insert(
-        object_descriptor_exprt::root_object(address_of->object()));
+      objects.insert(value_sett::object_numbering.number(
+        object_descriptor_exprt::root_object(address_of->object())));
     }
     else if(auto ssa_expr = expr_try_dynamic_cast<ssa_exprt>(pointer))
     {
       ssa_exprt l1_expr{*ssa_expr};
       l1_expr.remove_level_2();
-      const std::vector<exprt> value_set_elements =
-        value_set.get_value_set(l1_expr, ns);
+      const value_sett::object_mapt value_set_elements =
+        value_set.get_value_set(l1_expr, ns, false);
 
-      for(const auto &value_set_element : value_set_elements)
+      for(const auto &object_number_and_offset : value_set_elements.read())
       {
-        if(
-          value_set_element.id() == ID_unknown ||
-          value_set_element.id() == ID_invalid ||
-          is_failed_symbol(
-            to_object_descriptor_expr(value_set_element).root_object()))
+        auto object_number = root_object_number(object_number_and_offset.first);
+
+        if(!object_number.has_value())
         {
           objects.clear();
           break;
         }
 
-        objects.insert(
-          to_object_descriptor_expr(value_set_element).root_object());
+        objects.insert(*object_number);
       }
     }
     return objects;
   };
 
-  auto lhs_objects =
+  const auto lhs_objects =
     collect_objects(to_pointer_object_expr(expr.lhs()).pointer());
-  auto rhs_objects =
+
+  // an empty set of objects on either side means we cannot simplify, so don't
+  // bother collecting the objects of the other side
+  if(lhs_objects.empty())
+    return simplify_exprt::simplify_inequality_pointer_object(expr);
+
+  const auto rhs_objects =
     collect_objects(to_pointer_object_expr(expr.rhs()).pointer());
+
+  if(rhs_objects.empty())
+    return simplify_exprt::simplify_inequality_pointer_object(expr);
 
   if(lhs_objects.size() == 1 && lhs_objects == rhs_objects)
   {
@@ -209,14 +283,23 @@ simplify_expr_with_value_sett::simplify_inequality_pointer_object(
                                  : changed(static_cast<exprt>(false_exprt{}));
   }
 
-  std::list<exprt> intersection;
-  std::set_intersection(
-    lhs_objects.begin(),
-    lhs_objects.end(),
-    rhs_objects.begin(),
-    rhs_objects.end(),
-    std::back_inserter(intersection));
-  if(!lhs_objects.empty() && !rhs_objects.empty() && intersection.empty())
+  auto lhs_it = lhs_objects.begin();
+  auto rhs_it = rhs_objects.begin();
+  bool intersection_empty = true;
+  while(lhs_it != lhs_objects.end() && rhs_it != rhs_objects.end())
+  {
+    if(*lhs_it < *rhs_it)
+      ++lhs_it;
+    else if(*rhs_it < *lhs_it)
+      ++rhs_it;
+    else
+    {
+      intersection_empty = false;
+      break;
+    }
+  }
+
+  if(intersection_empty)
   {
     // all pointed-to objects on the left-hand side are different from any of
     // the pointed-to objects on the right-hand side

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -237,6 +237,19 @@ public:
   ///   are object_descriptor_exprt or have id ID_invalid or ID_unknown.
   std::vector<exprt> get_value_set(exprt expr, const namespacet &ns) const;
 
+  /// Gets values pointed to by `expr`, including following dereference
+  /// operators (i.e. this is not a simple lookup in `valuest`). Unlike the
+  /// single-argument overload above, the result is returned as a map over
+  /// object numbers (in \ref object_numbering), avoiding materializing an
+  /// `object_descriptor_exprt` per element.
+  /// \param expr: query expression
+  /// \param ns: global namespace
+  /// \param is_simplified: if false, simplify `expr` before reading.
+  /// \return the set of object numbers pointed to, together with per-object
+  ///   offsets
+  object_mapt
+  get_value_set(exprt expr, const namespacet &ns, bool is_simplified) const;
+
   void clear()
   {
     values.clear();
@@ -419,15 +432,6 @@ public:
   void erase_symbol(const symbol_exprt &symbol_expr, const namespacet &ns);
 
 protected:
-  /// Reads the set of objects pointed to by `expr`, including making
-  /// recursive lookups for dereference operations etc.
-  /// \param expr: query expression
-  /// \param ns: global namespace
-  /// \param is_simplified: if false, simplify `expr` before reading.
-  /// \return the set of object numbers pointed to
-  object_mapt
-  get_value_set(exprt expr, const namespacet &ns, bool is_simplified) const;
-
   /// See the other overload of `get_reference_set`. This one returns object
   /// numbers and offsets instead of expressions.
   void get_reference_set(


### PR DESCRIPTION
Symbolic execution is O(N^2) in the number of heap deallocations: each free generates same-object checks against __CPROVER_deallocated and __CPROVER_dead_object, whose value sets accumulate one element per previously freed object, and
simplify_expr_with_value_sett::simplify_inequality_pointer_object materialized each such value set into a std::set<exprt> on every query. This was 30.1% of symex instructions (callgrind) on a Kani-generated benchmark performing 128 allocate/free iterations, growing with the square of the iteration count: each query built an object_descriptor_exprt per element and inserted it into a set ordered by deep-tree irept::compare, with all the attendant irep sharing and allocation churn.

Instead, collect the root objects of value-set elements as a set of object numbers in value_sett::object_numbering. The numbering is hash-consed, so numbers are sound proxies for expression equality, and all set operations become operations over integers. The per-element classification (root object computation and failed-symbol test) is cached per object number, which is sound because the numbering is global, append-only, and maps numbers to immutable expressions. Also skip collecting the right-hand side objects entirely when the left-hand side came back empty, and test set disjointness without materializing the intersection.

This makes the object_mapt-returning value_sett::get_value_set overload public; it was previously only accessible to subclasses while the public overload materialized an expression per element.

On the benchmark family above (N allocate/free iterations, goto binaries generated by Kani, verified with --slice-formula etc.), Runtime Symex improves, together with the separately-proposed change sharing object maps in value_sett::make_union, from 7.2s to 5.3s (N=128), 19.5s to 10.9s (N=256), 62.1s to 23.3s (N=512) and 222.5s to 53.1s (N=1021), i.e. growth flattens from ~3.2x to ~2.1x per doubling of N. --show-vcc output is unchanged at N=8 and N=128, i.e. exactly the same simplifications are made. The function is down to 3.4% inclusive of symex time at N=512, which is also why a size cap on the simplification and memoization of whole value-set queries (both considered as alternatives) were not pursued: they would give up simplifications, or add cache invalidation complexity, for at most a few percent.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
