### PR TITLE
util/irep: O(1) SHARING fast-path for irept::compare

### DIFF
--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -300,6 +300,16 @@ bool irept::ordering(const irept &other) const
 /// comments are ignored
 int irept::compare(const irept &i) const
 {
+  // Fast path: structurally-shared instances compare equal in O(1).
+  // Without this, dictionaries / std::map<exprt> walk the entire
+  // sub-tree even when both keys point to the same node — this is
+  // a hot path under heavy SMT struct flattening (smt2_convt's
+  // defined_expressions / datatype_map lookups).
+#ifdef SHARING
+  if(data == i.data)
+    return 0;
+#endif
+
   int r;
 
   r=id().compare(i.id());


### PR DESCRIPTION
Under SHARING, return 0 immediately from irept::compare when both instances point to the same node (data == i.data). Structurally-shared expressions are common on hot std::map<exprt> paths (e.g. smt2_convt's defined_expressions / datatype_map lookups under heavy struct flattening), where the full sub-tree walk is redundant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
