### PR TITLE
goto-symex/slice: never slice CPROVER string-refinement intrinsics

### DIFF
--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -12,8 +12,41 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "slice.h"
 #include "symex_slice_class.h"
 
+#include <util/expr_iterator.h>
 #include <util/find_symbols.h>
+#include <util/mathematical_expr.h>
 #include <util/std_expr.h>
+
+/// True iff the expression contains a function application whose
+/// callee is a CPROVER string-refinement intrinsic. These functions
+/// (`cprover_string_*`, `cprover_char_*`, `cprover_associate_*`) have
+/// non-data side effects on the string-refinement solver: the
+/// `cprover_associate_array_to_pointer_func` call, for instance, is
+/// the only mechanism by which the solver learns that a given char
+/// pointer aliases a particular char-array. Slicing them based on
+/// data dependencies alone is unsound — the assignment's LHS (a
+/// dummy "return code" symbol) is unused, but the *call* must still
+/// reach the solver.
+static bool contains_string_refinement_intrinsic(const exprt &expr)
+{
+  for(auto it = expr.depth_cbegin(); it != expr.depth_cend(); ++it)
+  {
+    if(it->id() != ID_function_application)
+      continue;
+    const auto &fn = to_function_application_expr(*it).function();
+    if(fn.id() != ID_symbol)
+      continue;
+    const std::string id = id2string(to_symbol_expr(fn).get_identifier());
+    // Match the three intrinsic families that the string-refinement
+    // solver consumes side-channel information from.
+    if(
+      id.rfind("cprover_string_", 0) == 0 ||
+      id.rfind("cprover_char_", 0) == 0 ||
+      id.rfind("cprover_associate_", 0) == 0)
+      return true;
+  }
+  return false;
+}
 
 void symex_slicet::get_symbols(const exprt &expr)
 {
@@ -109,6 +142,19 @@ void symex_slicet::slice_assignment(SSA_stept &SSA_step)
   auto entry = depends.find(id);
   if(entry == depends.end())
   {
+    // Even if this assignment's LHS is not transitively used by any
+    // assertion, the RHS may carry a side-effecting call to a
+    // string-refinement intrinsic (cprover_string_*,
+    // cprover_associate_*, ...). The string-refinement decision
+    // procedure scans these calls during dec_solve to populate its
+    // pointer↔array and length-of-array maps; dropping them yields
+    // unsound results for code that uses CBMC's string solver
+    // (e.g., Python's str(), f-strings, etc.).
+    if(contains_string_refinement_intrinsic(SSA_step.ssa_rhs))
+    {
+      get_symbols(SSA_step.ssa_rhs);
+      return;
+    }
     // we don't really need it
     SSA_step.ignore=true;
   }


### PR DESCRIPTION
cprover_string_* / cprover_char_* / cprover_associate_* applications carry non-data side effects into the string-refinement solver (e.g. associate_array_to_pointer is the only way the solver learns a char pointer aliases a char array). Slicing them on data dependencies alone is unsound; preserve any SSA step whose RHS contains such an intrinsic.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
