### PR TITLE
Honor --compact-trace in JSON trace output

### DIFF
--- a/regression/cbmc/trace_options_json_compact/compact.desc
+++ b/regression/cbmc/trace_options_json_compact/compact.desc
@@ -1,0 +1,14 @@
+CORE
+test.c
+--trace --compact-trace --json-ui
+^EXIT=10$
+^SIGNAL=0$
+"stepType": "failure"
+"stepType": "assignment"
+--
+"assignmentType": "actual-parameter"
+"hidden": true
+--
+With --compact-trace, the JSON trace must apply the same filtering as the
+plain-text compact trace: no hidden steps and no actual-parameter
+assignments, while retaining regular assignments and the violated property.

--- a/regression/cbmc/trace_options_json_compact/non-compact.desc
+++ b/regression/cbmc/trace_options_json_compact/non-compact.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--trace --json-ui
+^EXIT=10$
+^SIGNAL=0$
+"assignmentType": "actual-parameter"
+--
+--
+Without --compact-trace, the JSON trace contains actual-parameter
+assignments (baseline for the compact.desc sibling test).

--- a/regression/cbmc/trace_options_json_compact/test.c
+++ b/regression/cbmc/trace_options_json_compact/test.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+// A function whose parameter-passing and internal steps show up in a full
+// trace; with --compact-trace only non-parameter assignments, declarations,
+// function calls/returns and the violated assertion remain.
+int add(int a, int b)
+{
+  int result = a + b;
+  return result;
+}
+
+int main(int argc, char *argv[])
+{
+  int x = add(argc, 2);
+  assert(x == 0);
+}

--- a/src/goto-programs/json_goto_trace.h
+++ b/src/goto-programs/json_goto_trace.h
@@ -120,6 +120,52 @@ void convert(
 
   for(const auto &step : goto_trace.steps)
   {
+    // With --compact-trace, apply the same filtering as
+    // show_compact_goto_trace: skip hidden steps, actual-parameter
+    // assignments, and everything but assignments, declarations, function
+    // calls/returns and violated assertions. This in particular drops the
+    // values of internal instrumentation steps, which can shrink the trace
+    // by orders of magnitude on instrumentation-heavy programs.
+    if(trace_options.compact_trace)
+    {
+      if(step.hidden)
+        continue;
+
+      switch(step.type)
+      {
+      case goto_trace_stept::typet::ASSERT:
+      case goto_trace_stept::typet::DECL:
+      case goto_trace_stept::typet::FUNCTION_CALL:
+      case goto_trace_stept::typet::FUNCTION_RETURN:
+        break;
+
+      case goto_trace_stept::typet::ASSIGNMENT:
+        if(
+          step.assignment_type ==
+          goto_trace_stept::assignment_typet::ACTUAL_PARAMETER)
+        {
+          continue;
+        }
+        break;
+
+      case goto_trace_stept::typet::OUTPUT:
+      case goto_trace_stept::typet::INPUT:
+      case goto_trace_stept::typet::ATOMIC_BEGIN:
+      case goto_trace_stept::typet::ATOMIC_END:
+      case goto_trace_stept::typet::DEAD:
+      case goto_trace_stept::typet::LOCATION:
+      case goto_trace_stept::typet::GOTO:
+      case goto_trace_stept::typet::ASSUME:
+      case goto_trace_stept::typet::MEMORY_BARRIER:
+      case goto_trace_stept::typet::SPAWN:
+      case goto_trace_stept::typet::SHARED_READ:
+      case goto_trace_stept::typet::SHARED_WRITE:
+      case goto_trace_stept::typet::CONSTRAINT:
+      case goto_trace_stept::typet::NONE:
+        continue;
+      }
+    }
+
     const source_locationt &source_location = step.pc->source_location();
 
     jsont json_location;


### PR DESCRIPTION
The --compact-trace option was silently ignored with --json-ui: the JSON trace converter received the trace options but only consulted them for the extended-LHS format, so JSON consumers always got the full trace including hidden steps and actual-parameter assignments.

Apply the same filtering as show_compact_goto_trace when the option is set: skip hidden steps and actual-parameter assignments, and keep only assignments, declarations, function calls/returns and violated assertions. On instrumentation-heavy programs this shrinks the JSON trace by orders of magnitude because the values of internal instrumentation steps dominate the output; on a Kani-generated verification harness for Rust's write_bytes intrinsic, the trace output shrinks from 427 MB to 3 MB while retaining all counterexample-relevant assignments.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
