### PR TITLE
smt2: do not declare UFs whose signature involves RegLan

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -46,6 +46,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "smt2_tokenizer.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 
@@ -5739,6 +5740,22 @@ void smt2_convt::find_symbols(const exprt &expr)
 
     if(id_entry.second)
     {
+      // A function symbol whose signature involves RegLan cannot be declared
+      // as a UF: SMT-LIB's RegLan is not a first-class sort (cvc5: "expected
+      // first-class sort as domain sort"). Such applications (the
+      // cprover_regex_* / to_regex / in_regex intrinsic family) are lowered
+      // inline by convert_expr, so the declaration is not needed.
+      if(expr.type().id() == ID_mathematical_function)
+      {
+        const auto &mf = to_mathematical_function_type(expr.type());
+        auto is_regex = [](const typet &t) { return t.id() == ID_regex; };
+        if(
+          is_regex(mf.codomain()) ||
+          std::any_of(mf.domain().begin(), mf.domain().end(), is_regex))
+        {
+          return;
+        }
+      }
       std::string smt2_identifier=convert_identifier(identifier);
       smt2_identifiers.insert(smt2_identifier);
 

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -270,6 +270,27 @@ TEST_CASE(
     REQUIRE(get_assert(in) == "(assert (str.in_re s1 (str.to_re s2)))");
   }
 
+  SECTION("no UF declaration is emitted for RegLan-signature functions")
+  {
+    // RegLan is not a first-class SMT-LIB sort: cvc5 rejects a
+    // (declare-fun ... RegLan ...) with "expected first-class sort as domain
+    // sort". The regex intrinsics are lowered inline, so find_symbols must
+    // not declare them.
+    const auto re =
+      string_builtin_app(ID_cprover_string_to_regex_func, {s1}, regex_type);
+    const auto in = string_builtin_app(
+      ID_cprover_string_in_regex_func, {s2, re}, bool_typet{});
+    symbol_tablet symbol_table;
+    namespacet ns(symbol_table);
+    std::ostringstream out;
+    smt2_convt conv(ns, "test", "", "QF_BV", smt2_convt::solvert::GENERIC, out);
+    conv.set_to(in, true);
+    const std::string full = out.str();
+    REQUIRE(full.find("RegLan)") == std::string::npos);
+    REQUIRE(
+      full.find("(assert (str.in_re s2 (str.to_re s1)))") != std::string::npos);
+  }
+
   SECTION("regex star lowers to re.*")
   {
     const auto re =


### PR DESCRIPTION
find_symbols emits a (declare-fun ...) for every not-yet-seen function symbol, including the cprover_regex_* / to_regex / in_regex intrinsic family, whose signatures involve the RegLan sort. RegLan is not a first-class SMT-LIB sort: cvc5 rejects such a declaration with "expected first-class sort as domain sort", so any goto program carrying these intrinsics fails before solving. The applications are lowered inline by convert_expr, so the declaration is not needed at all -- skip it whenever the symbol's mathematical_function_typet involves ID_regex in its domain or codomain.

The existing unit tests never caught this because the get_assert helper strips everything before "(assert ": the ill-sorted declaration was being emitted, unchecked, all along. The new test section checks the FULL output: no "RegLan)" declaration text, and the inline (str.in_re s2 (str.to_re s1)) lowering intact. It fails without the fix and passes with it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
