### PR TITLE
goto-symex: skip string side-effect const-prop for value-returning applications

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -207,6 +207,16 @@ bool goto_symext::constant_propagate_assignment_with_side_effects(
 
     if(f_l1.function().id() == ID_symbol)
     {
+      // Value-returning string intrinsics (SMT String-sorted result, e.g. a
+      // front-end emitting the generic (str.++ a b)-style forms) carry no
+      // output (length, content) arguments -- the side-effects this machinery
+      // propagates do not exist for them, and the handlers below PRECONDITION
+      // on the output-argument convention (e.g. num_operands >= 4). A
+      // TYPE-based decision: the refined convention's applications have a
+      // bit-vector return-code type, never String.
+      if(f_l1.type().id() == ID_string)
+        return false;
+
       const irep_idt &func_id = to_symbol_expr(f_l1.function()).identifier();
 
       if(func_id == ID_cprover_string_concat_func)


### PR DESCRIPTION
constant_propagate_assignment_with_side_effects and its handlers assume the refined-string calling convention, where a string-producing intrinsic's first two arguments are the OUTPUT length and content (constant_propagate_string_substring PRECONDITIONs num_operands >= 4, and the other handlers similarly write through to_ssa_expr on those operands). A front-end emitting the value-returning convention instead -- the application's own value IS the result, of the SMT String sort, with no output arguments (e.g. the generic (str.++ a b)-shaped forms the smt2 encoder lowers directly) -- crashes those PRECONDITIONs.

Skip the machinery for String-typed applications: the side effects it propagates do not exist for them. This is a type-based decision; the refined convention's applications have a bit-vector return-code type, never String, so refined-string front-ends (JBMC) are unaffected.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
