### PR TITLE
strings: factor trim into a parameterised strip facility

### DIFF
--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -20,8 +20,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_GENERATOR_H
 #define CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_GENERATOR_H
 
-#include <limits>
-#include <solvers/strings/string_constraint.h>
 #include <util/constexpr.def>
 #include <util/deprecate.h>
 #include <util/namespace.h>
@@ -29,7 +27,12 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/replace_expr.h>
 #include <util/string_expr.h>
 
+#include <solvers/strings/string_constraint.h>
+
 #include "array_pool.h"
+
+#include <functional>
+#include <limits>
 
 class function_application_exprt;
 
@@ -262,6 +265,14 @@ public:
 
   std::pair<exprt, string_constraintst>
   add_axioms_for_trim(const function_application_exprt &f);
+
+  std::pair<exprt, string_constraintst> add_axioms_for_strip(
+    const array_string_exprt &str,
+    const array_string_exprt &res,
+    const std::function<exprt(const exprt &)> &is_strippable,
+    bool strip_front,
+    bool strip_back,
+    const typet &result_type);
 
   std::pair<exprt, string_constraintst> add_axioms_for_code_point(
     const array_string_exprt &res,

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -184,78 +184,100 @@ string_constraint_generatort::add_axioms_for_trim(
   const function_application_exprt &f)
 {
   PRECONDITION(f.arguments().size() == 3);
-  string_constraintst constraints;
   const array_string_exprt &str = get_string_expr(array_pool, f.arguments()[2]);
   const array_string_exprt &res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
-  const typet &index_type = str.length_type();
   const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
-  const symbol_exprt idx = fresh_symbol("index_trim", index_type);
   const exprt space_char = from_integer(' ', char_type);
+  // Java trim: strip characters <= ' ' from both ends.
+  return add_axioms_for_strip(
+    str,
+    res,
+    [&](const exprt &c) -> exprt
+    { return binary_relation_exprt(c, ID_le, space_char); },
+    true,
+    true,
+    f.type());
+}
 
-  // Axiom 1.
-  constraints.existential.push_back(greater_or_equal_to(
-    array_pool.get_or_create_length(str),
-    plus_exprt(idx, array_pool.get_or_create_length(res))));
+/// Generic parameterised strip (shared by Java trim and Python strip): remove
+/// a maximal run of `is_strippable` characters from the front (if
+/// `strip_front`) and/or back (if `strip_back`) of `str`, producing `res`.
+std::pair<exprt, string_constraintst>
+string_constraint_generatort::add_axioms_for_strip(
+  const array_string_exprt &str,
+  const array_string_exprt &res,
+  const std::function<exprt(const exprt &)> &is_strippable,
+  bool strip_front,
+  bool strip_back,
+  const typet &result_type)
+{
+  string_constraintst constraints;
+  const typet &index_type = str.length_type();
+  const symbol_exprt idx = fresh_symbol("index_strip", index_type);
+  const exprt str_len = array_pool.get_or_create_length(str);
+  const exprt res_len = array_pool.get_or_create_length(res);
 
-  binary_relation_exprt a2(idx, ID_ge, from_integer(0, index_type));
-  constraints.existential.push_back(a2);
+  constraints.existential.push_back(
+    greater_or_equal_to(str_len, plus_exprt(idx, res_len)));
+  constraints.existential.push_back(
+    binary_relation_exprt(idx, ID_ge, from_integer(0, index_type)));
+  constraints.existential.push_back(greater_or_equal_to(str_len, idx));
+  constraints.existential.push_back(
+    greater_or_equal_to(res_len, from_integer(0, index_type)));
+  constraints.existential.push_back(less_than_or_equal_to(res_len, str_len));
 
-  const exprt a3 =
-    greater_or_equal_to(array_pool.get_or_create_length(str), idx);
-  constraints.existential.push_back(a3);
+  if(!strip_front)
+    constraints.existential.push_back(
+      equal_exprt(idx, from_integer(0, index_type)));
+  if(!strip_back)
+    constraints.existential.push_back(
+      equal_exprt(res_len, minus_exprt(str_len, idx)));
 
-  const exprt a4 = greater_or_equal_to(
-    array_pool.get_or_create_length(res), from_integer(0, index_type));
-  constraints.existential.push_back(a4);
+  // res[n] == str[n + idx] for n < |res| (result is the kept middle slice).
+  {
+    const symbol_exprt n = fresh_symbol("QA_strip_copy", index_type);
+    constraints.universal.push_back(string_constraintt(
+      n,
+      zero_if_negative(res_len),
+      equal_exprt(res[n], str[plus_exprt(n, idx)]),
+      message_handler));
+  }
+  // Removed front characters [0, idx) are strippable.
+  if(strip_front)
+  {
+    const symbol_exprt n = fresh_symbol("QA_strip_front", index_type);
+    constraints.universal.push_back(string_constraintt(
+      n, zero_if_negative(idx), is_strippable(str[n]), message_handler));
+  }
+  // Removed trailing characters [idx+|res|, |str|) are strippable.
+  if(strip_back)
+  {
+    const symbol_exprt n = fresh_symbol("QA_strip_back", index_type);
+    const exprt bound = minus_exprt(minus_exprt(str_len, idx), res_len);
+    constraints.universal.push_back(string_constraintt(
+      n,
+      zero_if_negative(bound),
+      is_strippable(str[plus_exprt(idx, plus_exprt(res_len, n))]),
+      message_handler));
+  }
 
-  const exprt a5 = less_than_or_equal_to(
-    array_pool.get_or_create_length(res), array_pool.get_or_create_length(str));
-  constraints.existential.push_back(a5);
+  // Maximality: either the result is empty (idx == |str|), or the kept
+  // boundary characters are non-strippable (so all leading/trailing
+  // strippable characters were removed).
+  exprt non_strip = static_cast<exprt>(true_exprt{});
+  if(strip_front)
+    non_strip = and_exprt(non_strip, not_exprt(is_strippable(str[idx])));
+  if(strip_back)
+  {
+    const exprt last =
+      minus_exprt(plus_exprt(idx, res_len), from_integer(1, index_type));
+    non_strip = and_exprt(non_strip, not_exprt(is_strippable(str[last])));
+  }
+  constraints.existential.push_back(
+    or_exprt(equal_exprt(idx, str_len), non_strip));
 
-  symbol_exprt n = fresh_symbol("QA_index_trim", index_type);
-  binary_relation_exprt non_print(str[n], ID_le, space_char);
-  string_constraintt a6(n, zero_if_negative(idx), non_print, message_handler);
-  constraints.universal.push_back(a6);
-
-  // Axiom 7.
-  constraints.universal.push_back([&] {
-    const symbol_exprt n2 = fresh_symbol("QA_index_trim2", index_type);
-    const minus_exprt bound(
-      minus_exprt(array_pool.get_or_create_length(str), idx),
-      array_pool.get_or_create_length(res));
-    const binary_relation_exprt eqn2(
-      str[plus_exprt(
-        idx, plus_exprt(array_pool.get_or_create_length(res), n2))],
-      ID_le,
-      space_char);
-    return string_constraintt(
-      n2, zero_if_negative(bound), eqn2, message_handler);
-  }());
-
-  symbol_exprt n3 = fresh_symbol("QA_index_trim3", index_type);
-  equal_exprt eqn3(res[n3], str[plus_exprt(n3, idx)]);
-  string_constraintt a8(
-    n3,
-    zero_if_negative(array_pool.get_or_create_length(res)),
-    eqn3,
-    message_handler);
-  constraints.universal.push_back(a8);
-
-  // Axiom 9.
-  constraints.existential.push_back([&] {
-    const plus_exprt index_before(
-      idx,
-      minus_exprt(
-        array_pool.get_or_create_length(res), from_integer(1, index_type)));
-    const binary_relation_exprt no_space_before(
-      str[index_before], ID_gt, space_char);
-    return or_exprt(
-      equal_exprt(idx, array_pool.get_or_create_length(str)),
-      and_exprt(
-        binary_relation_exprt(str[idx], ID_gt, space_char), no_space_before));
-  }());
-  return {from_integer(0, f.type()), constraints};
+  return {from_integer(0, result_type), std::move(constraints)};
 }
 
 /// Convert two expressions to pair of chars


### PR DESCRIPTION
Refactor add_axioms_for_trim into a thin wrapper over a new generic add_axioms_for_strip(str, res, is_strippable, strip_front, strip_back, result_type): remove a maximal run of `is_strippable` characters from the selected end(s). Java trim instantiates it with its `c <= ' '` predicate on both ends; behaviour-preserving.

The parameterisation lets other strip-family operations share one axiom set instead of near-duplicating it: a different character predicate (e.g. Java 11's String.strip family uses the Character.isWhitespace set, which KEEPS control bytes below 0x20 that trim strips, so it cannot reuse trim) and one-sided stripping (stripLeading / stripTrailing) become instantiations rather than new axiom code.

Verified: [strings] unit green; regression/strings green; jbmc-strings green (Java trim behaviour unchanged).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
