### PR TITLE
Dominator sets: use sharing map to avoid quadratic memory

### DIFF
--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -467,9 +467,13 @@ static java_bytecode_convert_methodt::method_offsett get_common_dominator(
       dominator_analysis.cfg.entry_map.at(v->var.start_pc);
     const auto &this_var_doms=
       dominator_analysis.cfg[dominator_nodeidx].dominators;
-    for(const auto this_var_dom : this_var_doms)
-      if(this_var_dom<=first_pc)
-        candidate_dominators.push_back(this_var_dom);
+    this_var_doms.for_each(
+      [&candidate_dominators, first_pc](
+        const java_bytecode_convert_methodt::method_offsett &this_var_dom)
+      {
+        if(this_var_dom <= first_pc)
+          candidate_dominators.push_back(this_var_dom);
+      });
   }
   std::sort(candidate_dominators.begin(), candidate_dominators.end());
 

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -12,14 +12,17 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 #ifndef CPROVER_ANALYSES_CFG_DOMINATORS_H
 #define CPROVER_ANALYSES_CFG_DOMINATORS_H
 
-#include <set>
-#include <list>
-#include <map>
-#include <iosfwd>
+#include <util/sharing_map.h>
 
+#include <goto-programs/cfg.h>
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_program.h>
-#include <goto-programs/cfg.h>
+
+#include <algorithm>
+#include <iosfwd>
+#include <list>
+#include <map>
+#include <vector>
 
 /// Dominator graph. This computes a control-flow graph (see \ref cfgt) and
 /// decorates it with dominator sets per program point, following
@@ -36,7 +39,97 @@ template <class P, class T, bool post_dom>
 class cfg_dominators_templatet
 {
 public:
-  typedef std::set<T, typename P::target_less_than> target_sett;
+  /// Set of program points, backed by a copy-on-write sharing map so that
+  /// similar sets share most of their representation. Dominator sets of
+  /// adjacent program points typically differ in just a single element, so
+  /// the sharing keeps the total memory linear-ish in the program size, where
+  /// explicit per-node `std::set`s are worst-case quadratic (a straight-line
+  /// program of N instructions has dominator sets of total size N^2/2, which
+  /// for machine-generated functions with ~100k instructions exhausts tens of
+  /// gigabytes of memory).
+  class target_sett
+  {
+  public:
+    bool empty() const
+    {
+      return map.empty();
+    }
+
+    std::size_t size() const
+    {
+      return map.size();
+    }
+
+    std::size_t count(const T &t) const
+    {
+      return map.has_key(t) ? 1 : 0;
+    }
+
+    void insert(const T &t)
+    {
+      if(!map.has_key(t))
+        map.insert(t, unitt{});
+    }
+
+    /// Invoke \p f for each element of the set, in no particular order.
+    void for_each(std::function<void(const T &)> f) const
+    {
+      map.iterate([&f](const T &k, const unitt &) { f(k); });
+    }
+
+    /// Remove all elements that are not also contained in \p other, except
+    /// that \p keep is always retained. Return true if any element was
+    /// removed. The delta view used here only visits elements in subtrees
+    /// that are not shared between the two maps, so intersecting largely
+    /// overlapping sets is much cheaper than element-wise iteration.
+    bool intersect_with(const target_sett &other, const T &keep)
+    {
+      typename mapt::delta_viewt delta_view;
+      map.get_delta_view(other.map, delta_view, false);
+
+      std::vector<T> to_erase;
+      for(const auto &delta_item : delta_view)
+      {
+        if(!delta_item.is_in_both_maps() && !(delta_item.k == keep))
+          to_erase.push_back(delta_item.k);
+      }
+
+      for(const auto &item : to_erase)
+        map.erase(item);
+
+      return !to_erase.empty();
+    }
+
+  protected:
+    struct unitt
+    {
+    };
+
+    struct target_hasht
+    {
+      /// Program-point hash: program points are either integral (e.g. Java
+      /// bytecode offsets) or iterator-like (e.g. goto-program targets), so
+      /// hash the value itself or the address of the object it refers to,
+      /// respectively.
+      template <typename U = T>
+      typename std::enable_if<std::is_integral<U>::value, std::size_t>::type
+      operator()(const U &t) const
+      {
+        return std::hash<U>{}(t);
+      }
+
+      template <typename U = T>
+      typename std::enable_if<!std::is_integral<U>::value, std::size_t>::type
+      operator()(const U &t) const
+      {
+        return std::hash<const void *>{}(&*t);
+      }
+    };
+
+    typedef sharing_mapt<T, unitt, false, target_hasht> mapt;
+
+    mapt map;
+  };
 
   struct nodet
   {
@@ -210,38 +303,7 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
       if(other.empty())
         continue;
 
-      typename target_sett::const_iterator n_it=node.dominators.begin();
-      typename target_sett::const_iterator o_it=other.begin();
-
-      // in-place intersection. not safe to use set_intersect
-      while(n_it!=node.dominators.end() && o_it!=other.end())
-      {
-        if(*n_it==current)
-          ++n_it;
-        else if(typename P::target_less_than()(*n_it, *o_it))
-        {
-          changed=true;
-          node.dominators.erase(n_it++);
-        }
-        else if(typename P::target_less_than()(*o_it, *n_it))
-          ++o_it;
-        else
-        {
-          ++n_it;
-          ++o_it;
-        }
-      }
-
-      while(n_it!=node.dominators.end())
-      {
-        if(*n_it==current)
-          ++n_it;
-        else
-        {
-          changed=true;
-          node.dominators.erase(n_it++);
-        }
-      }
+      changed |= node.dominators.intersect_with(other, current);
     }
 
     if(changed) // fixed point for node reached?
@@ -284,8 +346,17 @@ void cfg_dominators_templatet<P, T, post_dom>::output(std::ostream &out) const
       out << " post-dominated by ";
     else
       out << " dominated by ";
+
+    std::vector<T> sorted_dominators;
+    cfg[node.second].dominators.for_each([&sorted_dominators](const T &d)
+                                         { sorted_dominators.push_back(d); });
+    std::sort(
+      sorted_dominators.begin(),
+      sorted_dominators.end(),
+      typename P::target_less_than{});
+
     bool first=true;
-    for(const auto &d : cfg[node.second].dominators)
+    for(const auto &d : sorted_dominators)
     {
       if(!first)
         out << ", ";

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -107,7 +107,7 @@ void dep_graph_domaint::control_dependencies(
       const cfg_post_dominatorst::cfgt::nodet &m_s=
         pd.cfg[edge.first];
 
-      if(m_s.dominators.find(to)!=m_s.dominators.end())
+      if(m_s.dominators.count(to) != 0)
         post_dom_one=true;
       else
         post_dom_all=false;

--- a/src/analyses/sese_regions.cpp
+++ b/src/analyses/sese_regions.cpp
@@ -146,10 +146,21 @@ void sese_region_analysist::compute_sese_regions(
     // but our current dominator analysis doesn't make it easy to determine an
     // immediate dominator.
 
+    // Iterate in a deterministic (location-number) order, since ties on the
+    // dominator-set size below are broken by iteration order.
+    std::vector<goto_programt::const_targett> sorted_postdoms;
+    instruction_postdoms.for_each(
+      [&sorted_postdoms](const goto_programt::const_targett &d)
+      { sorted_postdoms.push_back(d); });
+    std::sort(
+      sorted_postdoms.begin(),
+      sorted_postdoms.end(),
+      goto_programt::target_less_than{});
+
     // Ideally I would use `std::optional<std::size_t>` here, but it triggers a
     // GCC-5 bug.
     std::size_t closest_exit_index = dominators.cfg.size();
-    for(const auto &possible_exit : instruction_postdoms)
+    for(const auto &possible_exit : sorted_postdoms)
     {
       const auto possible_exit_index = dominators.get_node_index(possible_exit);
       const auto &possible_exit_node = dominators.cfg[possible_exit_index];

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -272,7 +272,7 @@ void variable_sensitivity_dependence_domaint::control_dependencies(
     {
       const cfg_post_dominatorst::cfgt::nodet &m_s = pd.cfg[edge.first];
 
-      if(m_s.dominators.find(to) != m_s.dominators.end())
+      if(m_s.dominators.count(to) != 0)
         post_dom_one = true;
       else
         post_dom_all = false;

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -155,23 +155,31 @@ void full_slicert::add_jumps(
       // lex_succ
       goto_programt::const_targett nearest=lex_succ;
       std::size_t post_dom_size=0;
-      for(cfg_dominatorst::target_sett::const_iterator d_it =
-            j_PC_node.dominators.begin();
-          d_it != j_PC_node.dominators.end();
-          ++d_it)
+      // Iterate over the dominators in a deterministic (location-number)
+      // order, since ties on `post_dom_size` below are broken by iteration
+      // order.
+      std::vector<goto_programt::const_targett> sorted_dominators;
+      j_PC_node.dominators.for_each(
+        [&sorted_dominators](const goto_programt::const_targett &dominator)
+        { sorted_dominators.push_back(dominator); });
+      std::sort(
+        sorted_dominators.begin(),
+        sorted_dominators.end(),
+        goto_programt::target_less_than{});
+      for(const auto &dominator : sorted_dominators)
       {
-        const auto &node = cfg.get_node(*d_it);
+        const auto &node = cfg.get_node(dominator);
         if(node.node_required)
         {
           const irep_idt &id2 = node.function_id;
           INVARIANT(id==id2,
                     "goto/jump expected to be within a single function");
 
-          const auto &postdom_node = pd.get_node(*d_it);
+          const auto &postdom_node = pd.get_node(dominator);
 
           if(postdom_node.dominators.size() > post_dom_size)
           {
-            nearest=*d_it;
+            nearest = dominator;
             post_dom_size = postdom_node.dominators.size();
           }
         }


### PR DESCRIPTION
cfg_dominators_templatet stored the full dominator set of every program point in a per-node std::set. Dominator sets of adjacent program points are nearly identical, so this representation needs memory quadratic in the function size: for a mostly straight-line function of N instructions the sets hold N^2/2 elements in total. Machine-generated functions make this prohibitive: goto-instrument --ensure-one-backedge-per-target (which Kani runs on every harness) peaked at 22.1 GB resident memory on a 3.6 MB goto binary from the Rust sha2 crate, whose macro-unrolled compression function has ~80k instructions.

Back the dominator sets by sharing_mapt, CBMC's copy-on-write hash trie: copying a predecessor's set is now O(1), inserting a single element into a copy is O(log N), and the fixed point's intersection uses get_delta_view, which only visits elements in subtrees not physically shared between the two sets and hence is cheap precisely when the sets are similar.

On the sha2 goto binary above, --ensure-one-backedge-per-target improves from 22.1 GB / 67 s to 1.9 GB / 12.6 s, with bit-identical output; the crate becomes verifiable on ordinary hardware. Consumers that iterated the sorted std::set now sort explicitly where order matters for tie-breaking (full_slicer, sese_regions) and for stable output (output()), since the sharing map iterates in hash order.

Alternative approaches to the same problem were proposed before and remain complementary:
- #5137 stores only the immediate dominator per node (Cooper et al.'s dominator tree). That is asymptotically stronger still (linear memory even for join-heavy CFGs where structural sharing degrades), but changes the interface of every dominator-set consumer, which must walk idom chains instead of querying sets; the PR has been inactive since 2019. The change here keeps the existing set-based API and its consumers intact, at the cost of remaining an iterative set-based fixed point.
- #5042 computes dominators on basic-block rather than instruction granularity. That reduces N by a constant factor but keeps the quadratic set representation; it would compose with this change, further reducing both memory and the delta-view work.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
