### PR TITLE
docs: require Java 8 as the active JDK

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -167,18 +167,15 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    ```
    dnf install java-1.8.0-openjdk-devel maven jq
    ```
-   JBMC requires Java 8 to be the active default JDK; installing it alongside
-   a newer JDK is not sufficient. Verify both the runtime and compiler before
-   building:
+   JBMC requires a Java 8 toolchain in the build shell, but Java 8 does not
+   need to be the system-wide default JDK. If another JDK is selected by
+   default, set `JAVA_HOME` to the Java 8 installation and prepend its `bin`
+   directory to `PATH` for the build. Verify both the runtime and compiler:
    ```
    java -version
    javac -version
    ```
-   Both commands should report version 1.8. If another JDK is selected, use
-   `update-alternatives --config java` and
-   `update-alternatives --config javac` on Debian-like systems, or
-   `alternatives --config java` and `alternatives --config javac` on
-   Red Hat/Fedora systems, and select Java 8.
+   Both commands should report version 1.8.
 
 2. As a user, get the CBMC source via
    ```
@@ -262,10 +259,10 @@ Maven 3 manually.
    ```
    pkg install openjdk8 wget maven
    ```
-   Make sure the Java 8 installation is active before building. Set
-   `JAVA_HOME` to the OpenJDK 8 directory and prepend its `bin` directory to
-   `PATH` if another JDK is selected, then verify with `java -version` and
-   `javac -version`.
+   Java 8 needs only be selected for the build shell, not as the system-wide
+   default. Set `JAVA_HOME` to the OpenJDK 8 directory and prepend its `bin`
+   directory to `PATH` if another JDK is selected, then verify with
+   `java -version` and `javac -version`.
 2. As a user, get the CBMC source via
    ```
    git clone https://github.com/diffblue/cbmc cbmc-git

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -167,6 +167,18 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    ```
    dnf install java-1.8.0-openjdk-devel maven jq
    ```
+   JBMC requires Java 8 to be the active default JDK; installing it alongside
+   a newer JDK is not sufficient. Verify both the runtime and compiler before
+   building:
+   ```
+   java -version
+   javac -version
+   ```
+   Both commands should report version 1.8. If another JDK is selected, use
+   `update-alternatives --config java` and
+   `update-alternatives --config javac` on Debian-like systems, or
+   `alternatives --config java` and `alternatives --config javac` on
+   Red Hat/Fedora systems, and select Java 8.
 
 2. As a user, get the CBMC source via
    ```
@@ -250,6 +262,10 @@ Maven 3 manually.
    ```
    pkg install openjdk8 wget maven
    ```
+   Make sure the Java 8 installation is active before building. Set
+   `JAVA_HOME` to the OpenJDK 8 directory and prepend its `bin` directory to
+   `PATH` if another JDK is selected, then verify with `java -version` and
+   `javac -version`.
 2. As a user, get the CBMC source via
    ```
    git clone https://github.com/diffblue/cbmc cbmc-git


### PR DESCRIPTION
## Description

Fixes #9111.

Clarify that JBMC requires Java 8 to be the active default JDK, not merely installed alongside a newer JDK. The Linux instructions now show runtime/compiler verification and the appropriate alternatives commands for Debian-like and Red Hat/Fedora systems. The FreeBSD instructions now explain how to activate OpenJDK 8 through `JAVA_HOME` and `PATH`.

## Validation

- `git diff --check`

This documentation-only change does not require a compiled CBMC/JBMC test run.