### PR TITLE
Deploy docker images to GHCR instead of Docker Hub

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -82,14 +82,14 @@ jobs:
 
             ## Docker
 
-            We are also releasing new versions as images in [Dockerhub](https://hub.docker.com/r/diffblue/cbmc).
+            We are also releasing new versions as images in the [GitHub Container Registry](https://github.com/diffblue/cbmc/pkgs/container/cbmc).
 
             To run the CProver suite of tools under a Docker container, make sure that
             [Docker](https://www.docker.com/) is already installed in your system and
             set up correctly, and then issue:
 
             ```sh
-            $ docker run -it diffblue/cbmc:${{ env.CBMC_VERSION }}
+            $ docker run -it ghcr.io/diffblue/cbmc:${{ env.CBMC_VERSION }}
             #
             ```
 

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -314,8 +314,14 @@ jobs:
         with:
           path: .ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
-  push-docker-image-dockerhub:
+  push-docker-image-ghcr:
     runs-on: ubuntu-24.04
+    # Release images are published to the GitHub Container Registry, which is free
+    # for public packages and needs no Docker Hub credentials. Publishing requires
+    # packages:write on the built-in GITHUB_TOKEN.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout CBMC source
         uses: actions/checkout@v7
@@ -326,13 +332,15 @@ jobs:
           # Isolate the version number from a reference to a tag, for example,
           # '5.20.3' from a string like 'refs/tags/cbmc-5.20.3-exp'
           VERSION=$(echo ${{ github.ref }} | cut -d "/" -f 3 | cut -d "-" -f 2)
-          echo "IMAGE_TAG=diffblue/cbmc:$VERSION" >> $GITHUB_ENV
+          echo "IMAGE_TAG=ghcr.io/diffblue/cbmc:$VERSION" >> $GITHUB_ENV
       - name: Build docker image
         run: docker build -t "$IMAGE_TAG" .
-      - name: Push docker image to DockerHub
+      - name: Push docker image to GitHub Container Registry
         run: |
-          echo ${{ secrets.DOCKERHUB_ACCESS_DB_CI_CPROVER }} | docker login --username=dbcicprover --password-stdin
+          # Login uses the built-in GITHUB_TOKEN via github.actor, so no secrets
+          # are needed.
+          echo "${{ github.token }}" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
           docker image push "$IMAGE_TAG"
           # For security reasons remove stored login credentials from
           # configuration file they are stored at by docker login.
-          docker logout
+          docker logout ghcr.io

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -13,7 +13,7 @@ This document outlines the current release process in a summary form.
 2. After the PR has been merged, pull develop locally and spin off a tag with
    `git tag -a cbmc-<version>`. After some wait, this is going to trigger building
    Linux && Windows jobs and submit PR to [`homebrew`](https://formulae.brew.sh/formula/cbmc)
-   and image to [`docker`](https://hub.docker.com/r/diffblue/cbmc/tags).
+   and image to the [GitHub Container Registry](https://github.com/diffblue/cbmc/pkgs/container/cbmc).
    * The release creation is being driven by the `.github/workflows/regular-release.yaml` file,
      which creates a new release with some template text filled in.
    * After the release has been created, another github action starts building the


### PR DESCRIPTION
  We are sunsetting the CBMC images on Docker Hub, so release images are now
  published to the GitHub Container Registry (GHCR) instead. Publishing uses the
  built-in GITHUB_TOKEN, so no Docker Hub credentials are needed.

  Changes

  - .github/workflows/release-packages.yaml: the docker job now pushes
  ghcr.io/diffblue/cbmc:<version>, authenticating to ghcr.io via
  GITHUB_TOKEN/github.actor and declaring packages: write. The
  DOCKERHUB_ACCESS_DB_CI_CPROVER secret is no longer used.
  - .github/workflows/regular-release.yaml: release notes now point at docker 
  run -it ghcr.io/diffblue/cbmc:<version>.
  - RELEASE_PROCESS.md: updated to reference the GHCR package page.

  ⚠️  Action required if you pull CBMC images from Docker Hub

  After this PR is merged, switch to GHCR:

  `docker pull ghcr.io/diffblue/cbmc:<version>`   # was: diffblue/cbmc:<version>

  Pulling from Docker Hub will still work until 31 October 2026.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
