### PR TITLE
Fix flattened overflow_result_exprt field order in SMT2

### DIFF
--- a/regression/cbmc/overflow-result-flattening1/main.c
+++ b/regression/cbmc/overflow-result-flattening1/main.c
@@ -1,0 +1,46 @@
+// The __builtin_*_overflow family lowers to overflow_result_exprt, a struct
+// { value, overflow-* }.  When that struct is flattened into a bit-vector
+// (every SMT2 back-end except Z3 and CVC5), the "value" component occupies the
+// least-significant bits.  If the flattening and the member accessors disagree
+// about the field order, "value" reads back as (result << 1) | overflow_flag
+// and the overflow flag reads back as the top bit of the truncated result.
+//
+// None of the assertions below can fail.  The results are held in globals so
+// that no pointer checks are generated for the &-operands.
+
+unsigned int uprod, usum;
+signed int sprod, ssum, sdiff;
+
+int main(void)
+{
+  unsigned int ua, ub;
+  __CPROVER_assume(ua < 4);
+  __CPROVER_assume(ub < 4);
+
+  int uprod_overflow = __builtin_mul_overflow(ua, ub, &uprod);
+  __CPROVER_assert(!uprod_overflow, "small unsigned product does not overflow");
+  __CPROVER_assert(uprod < 16, "small unsigned product is small");
+
+  int usum_overflow = __builtin_add_overflow(ua, ub, &usum);
+  __CPROVER_assert(!usum_overflow, "small unsigned sum does not overflow");
+  __CPROVER_assert(usum < 8, "small unsigned sum is small");
+
+  signed int sa, sb;
+  __CPROVER_assume(sa > -4 && sa < 4);
+  __CPROVER_assume(sb > -4 && sb < 4);
+
+  int sprod_overflow = __builtin_mul_overflow(sa, sb, &sprod);
+  __CPROVER_assert(!sprod_overflow, "small signed product does not overflow");
+  __CPROVER_assert(sprod > -16 && sprod < 16, "small signed product is small");
+
+  int ssum_overflow = __builtin_add_overflow(sa, sb, &ssum);
+  __CPROVER_assert(!ssum_overflow, "small signed sum does not overflow");
+  __CPROVER_assert(ssum > -8 && ssum < 8, "small signed sum is small");
+
+  int sdiff_overflow = __builtin_sub_overflow(sa, sb, &sdiff);
+  __CPROVER_assert(
+    !sdiff_overflow, "small signed difference does not overflow");
+  __CPROVER_assert(sdiff > -8 && sdiff < 8, "small signed difference is small");
+
+  return 0;
+}

--- a/regression/cbmc/overflow-result-flattening1/test.desc
+++ b/regression/cbmc/overflow-result-flattening1/test.desc
@@ -1,0 +1,19 @@
+CORE no-new-smt
+main.c
+
+^\*\* 0 of 10 failed
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+FAILURE
+--
+The overflow_result_exprt struct { value, overflow-* } is flattened into a
+bit-vector by every SMT2 back-end except Z3 and CVC5. The flattening must
+place the "value" component in the least-significant bits, to agree with
+flatten2bv, convert_struct and convert_member. When the multiply and the
+signed plus/minus emitters got the concatenation order backwards, "value"
+read back as (result << 1) | overflow_flag, and seven of the ten assertions
+failed spuriously under --cprover-smt2 / --bitwuzla / --boolector.
+The new SMT back-end does not support the overflow expressions yet.

--- a/regression/cbmc/overflow-result-flattening2/main.c
+++ b/regression/cbmc/overflow-result-flattening2/main.c
@@ -1,0 +1,27 @@
+// The mirror image of overflow-result-flattening1: a genuine overflow must
+// still be reported.  If the flattened overflow_result_exprt struct is read
+// back with the fields swapped, the overflow flag becomes the top bit of the
+// truncated result, and the result becomes (result << 1) | overflow_flag.
+//
+// The operands are constrained to a range rather than to a single value so
+// that the multiplication survives constant propagation and actually reaches
+// the SMT2 back-end.
+
+unsigned int prod;
+
+int main(void)
+{
+  unsigned int a, b;
+  __CPROVER_assume(a >= 0x10000u && a <= 0x10001u);
+  __CPROVER_assume(b >= 0x10000u && b <= 0x10001u);
+
+  // a * b lies in [2^32, (2^16+1)^2], so it always overflows an unsigned int,
+  // and for a == b == 0x10000 the truncated product is exactly 0.  Bit 31 of
+  // the truncated product is 0 for every allowed pair, so a back-end that
+  // reads the overflow flag from there misses the overflow entirely.
+  int overflow = __builtin_mul_overflow(a, b, &prod);
+  __CPROVER_assert(!overflow, "expected to FAIL: the product always overflows");
+  __CPROVER_assert(prod != 0, "expected to FAIL: truncated product can be 0");
+
+  return 0;
+}

--- a/regression/cbmc/overflow-result-flattening2/test.desc
+++ b/regression/cbmc/overflow-result-flattening2/test.desc
@@ -1,0 +1,18 @@
+CORE no-new-smt
+main.c
+
+^\[main.assertion.1\] line 23 expected to FAIL: the product always overflows: FAILURE$
+^\[main.assertion.2\] line 24 expected to FAIL: truncated product can be 0: FAILURE$
+^\*\* 2 of 2 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Unsoundness in the other direction: with the fields of the flattened
+overflow_result_exprt struct swapped, the overflow flag is read from the top
+bit of the truncated result. Bit 31 is 0 for every product allowed here, so
+--cprover-smt2 / --bitwuzla / --boolector used to report VERIFICATION SUCCESSFUL
+and silently miss both failures. The new SMT back-end does not support the
+overflow expressions yet.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2312,32 +2312,39 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << " ((_ sign_extend 1) ";
       convert_expr(op1);
       out << ")))) "; // sign_extend, bvadd/sub
+
+      const std::string overflow_condition =
+        "(not (= ((_ extract " + std::to_string(width) + " " +
+        std::to_string(width) + ") ?sum) ((_ extract " +
+        std::to_string(width - 1) + " " + std::to_string(width - 1) +
+        ") ?sum)))";
+
       if(keep_result)
       {
+        const std::string result =
+          "((_ extract " + std::to_string(width - 1) + " 0) ?sum)";
+
         if(use_datatypes)
         {
           const std::string &smt_typename = datatype_map.at(expr.type());
 
           // use the constructor for the Z3 datatype
-          out << "(mk-" << smt_typename;
+          out << "(mk-" << smt_typename << ' ' << result << ' '
+              << overflow_condition << ')';
         }
         else
-          out << "(concat";
+        {
+          // The struct is flattened into a bit-vector. The first component
+          // (the result) occupies the least-significant bits, so the overflow
+          // flag is the first operand of the concatenation -- cf. flatten2bv,
+          // convert_struct and convert_member.
+          out << "(concat (ite " << overflow_condition << " #b1 #b0) " << result
+              << ')';
+        }
+      }
+      else
+        out << overflow_condition;
 
-        out << " ((_ extract " << width - 1 << " 0) ?sum) ";
-        if(!use_datatypes)
-          out << "(ite ";
-      }
-      out << "(not (= "
-                   "((_ extract " << width << " " << width << ") ?sum) "
-                   "((_ extract " << (width-1) << " " << (width-1) << ") ?sum)";
-      out << "))"; // =, not
-      if(keep_result)
-      {
-        if(!use_datatypes)
-          out << " #b1 #b0)";
-        out << ")"; // concat
-      }
       out << ")"; // let
     }
     else if(op_type.id()==ID_unsignedbv ||
@@ -2352,7 +2359,12 @@ void smt2_convt::convert_expr(const exprt &expr)
       convert_expr(op1);
       out << "))))"; // zero_extend, bvsub/bvadd
       if(keep_result && !use_datatypes)
+      {
+        // ?sum is already the correct flattening of the struct: the result
+        // occupies the least-significant `width` bits and the carry-out (the
+        // overflow flag) is the most-significant bit.
         out << " ?sum";
+      }
       else
       {
         if(keep_result && use_datatypes)
@@ -2405,33 +2417,39 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << ") ((_ sign_extend " << width << ") ";
       convert_expr(op1);
       out << ")) )) ";
+
+      const std::string bound = "(_ bv" + integer2string(power(2, width - 1)) +
+                                " " + std::to_string(width * 2) + ")";
+      const std::string overflow_condition =
+        "(or (bvsge prod " + bound + ") (bvslt prod (bvneg " + bound + ")))";
+
       if(keep_result)
       {
+        const std::string result =
+          "((_ extract " + std::to_string(width - 1) + " 0) prod)";
+
         if(use_datatypes)
         {
           const std::string &smt_typename = datatype_map.at(expr.type());
 
           // use the constructor for the Z3 datatype
-          out << "(mk-" << smt_typename;
+          out << "(mk-" << smt_typename << ' ' << result << ' '
+              << overflow_condition << ')';
         }
         else
-          out << "(concat";
+        {
+          // The struct is flattened into a bit-vector. The first component
+          // (the result) occupies the least-significant bits, so the overflow
+          // flag is the first operand of the concatenation -- cf. flatten2bv,
+          // convert_struct and convert_member.
+          out << "(concat (ite " << overflow_condition << " #b1 #b0) " << result
+              << ')';
+        }
+      }
+      else
+        out << overflow_condition;
 
-        out << " ((_ extract " << width - 1 << " 0) prod) ";
-        if(!use_datatypes)
-          out << "(ite ";
-      }
-      out << "(or (bvsge prod (_ bv" << power(2, width-1) << " "
-          << width*2 << "))";
-      out << " (bvslt prod (bvneg (_ bv" << power(2, width - 1) << " "
-          << width * 2 << "))))";
-      if(keep_result)
-      {
-        if(!use_datatypes)
-          out << " #b1 #b0)";
-        out << ")"; // concat
-      }
-      out << ")";
+      out << ")"; // let
     }
     else if(op_type.id()==ID_unsignedbv)
     {
@@ -2440,30 +2458,38 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << ") ((_ zero_extend " << width << ") ";
       convert_expr(op1);
       out << ")))) ";
+
+      const std::string overflow_condition =
+        "(bvuge prod (_ bv" + integer2string(power(2, width)) + " " +
+        std::to_string(width * 2) + "))";
+
       if(keep_result)
       {
+        const std::string result =
+          "((_ extract " + std::to_string(width - 1) + " 0) prod)";
+
         if(use_datatypes)
         {
           const std::string &smt_typename = datatype_map.at(expr.type());
 
           // use the constructor for the Z3 datatype
-          out << "(mk-" << smt_typename;
+          out << "(mk-" << smt_typename << ' ' << result << ' '
+              << overflow_condition << ')';
         }
         else
-          out << "(concat";
+        {
+          // The struct is flattened into a bit-vector. The first component
+          // (the result) occupies the least-significant bits, so the overflow
+          // flag is the first operand of the concatenation -- cf. flatten2bv,
+          // convert_struct and convert_member.
+          out << "(concat (ite " << overflow_condition << " #b1 #b0) " << result
+              << ')';
+        }
+      }
+      else
+        out << overflow_condition;
 
-        out << " ((_ extract " << width - 1 << " 0) prod) ";
-        if(!use_datatypes)
-          out << "(ite ";
-      }
-      out << "(bvuge prod (_ bv" << power(2, width) << " " << width * 2 << "))";
-      if(keep_result)
-      {
-        if(!use_datatypes)
-          out << " #b1 #b0)";
-        out << ")"; // concat
-      }
-      out << ")";
+      out << ")"; // let
     }
     else
       INVARIANT_WITH_DIAGNOSTICS(

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -117,6 +117,154 @@ TEST_CASE("smt2_convt reduction operators", "[core][solvers][smt2]")
   }
 }
 
+/// Helper: extract the "(assert ...)" line under a solver configuration that
+/// enables SMT-LIB datatypes (Z3/CVC5), so structs are *not* flattened.
+static std::string get_assert_with_datatypes(const exprt &expr)
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+  std::ostringstream out;
+  smt2_convt conv(ns, "test", "", "QF_BV", smt2_convt::solvert::Z3, out);
+  conv.set_to(expr, true);
+  std::string result = out.str();
+  auto pos = result.rfind("(assert ");
+  REQUIRE(pos != std::string::npos);
+  auto end = result.find_last_not_of('\n');
+  return result.substr(pos, end - pos + 1);
+}
+
+TEST_CASE(
+  "smt2_convt flattened overflow_result_exprt field order",
+  "[core][solvers][smt2]")
+{
+  // overflow_result_exprt has struct type { value, overflow-<kind> }. Under a
+  // solver without datatype support the struct is flattened into a bit-vector.
+  // convert_struct, flatten2bv and convert_member all agree that the *first*
+  // component -- "value" -- occupies the least-significant bits, so the
+  // overflow flag has to be the *first* (most-significant) operand of the
+  // concatenation. Getting this backwards makes ".value" read back as
+  // (result << 1) | overflow_flag and ".overflow-*" read back as the top bit
+  // of the truncated result, which is unsound in both directions.
+  const unsignedbv_typet u8{8};
+  const signedbv_typet s8{8};
+  const symbol_exprt ua{"ua", u8}, ub{"ub", u8};
+  const symbol_exprt sa{"sa", s8}, sb{"sb", s8};
+
+  // Wrap in a notequal_exprt so set_to emits a plain assertion rather than a
+  // definition, and so the emitted text covers the member accessor too.
+  auto value_of = [](const exprt &overflow_result)
+  {
+    const auto &struct_type = to_struct_type(overflow_result.type());
+    const auto &value = struct_type.components().front();
+    return notequal_exprt{
+      member_exprt{overflow_result, value.get_name(), value.type()},
+      from_integer(0, value.type())};
+  };
+
+  SECTION("unsigned mult")
+  {
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{ua, ID_mult, ub})) ==
+      "(assert (not (= ((_ extract 7 0) (let ((prod (bvmul "
+      "((_ zero_extend 8) ua) ((_ zero_extend 8) ub)))) "
+      "(concat (ite (bvuge prod (_ bv256 16)) #b1 #b0) "
+      "((_ extract 7 0) prod)))) (_ bv0 8))))");
+  }
+
+  SECTION("signed mult")
+  {
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{sa, ID_mult, sb})) ==
+      "(assert (not (= ((_ extract 7 0) (let ( (prod (bvmul "
+      "((_ sign_extend 8) sa) ((_ sign_extend 8) sb)) )) "
+      "(concat (ite (or (bvsge prod (_ bv128 16)) "
+      "(bvslt prod (bvneg (_ bv128 16)))) #b1 #b0) "
+      "((_ extract 7 0) prod)))) (_ bv0 8))))");
+  }
+
+  SECTION("signed plus")
+  {
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{sa, ID_plus, sb})) ==
+      "(assert (not (= ((_ extract 7 0) (let ((?sum (bvadd "
+      "((_ sign_extend 1) sa) ((_ sign_extend 1) sb)))) "
+      "(concat (ite (not (= ((_ extract 8 8) ?sum) "
+      "((_ extract 7 7) ?sum))) #b1 #b0) "
+      "((_ extract 7 0) ?sum)))) (_ bv0 8))))");
+  }
+
+  SECTION("signed minus")
+  {
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{sa, ID_minus, sb})) ==
+      "(assert (not (= ((_ extract 7 0) (let ((?sum (bvsub "
+      "((_ sign_extend 1) sa) ((_ sign_extend 1) sb)))) "
+      "(concat (ite (not (= ((_ extract 8 8) ?sum) "
+      "((_ extract 7 7) ?sum))) #b1 #b0) "
+      "((_ extract 7 0) ?sum)))) (_ bv0 8))))");
+  }
+
+  SECTION("unsigned plus already has the right layout")
+  {
+    // The extended sum is emitted as-is: the result is in the low `width` bits
+    // and the carry-out is the most-significant bit, which is exactly the
+    // flattening this back-end expects.
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{ua, ID_plus, ub})) ==
+      "(assert (not (= ((_ extract 7 0) (let ((?sum (bvadd "
+      "((_ zero_extend 1) ua) ((_ zero_extend 1) ub))))"
+      " ?sum)) (_ bv0 8))))");
+  }
+
+  SECTION("unsigned minus already has the right layout")
+  {
+    REQUIRE(
+      get_assert(value_of(overflow_result_exprt{ua, ID_minus, ub})) ==
+      "(assert (not (= ((_ extract 7 0) (let ((?sum (bvsub "
+      "((_ zero_extend 1) ua) ((_ zero_extend 1) ub))))"
+      " ?sum)) (_ bv0 8))))");
+  }
+
+  SECTION("boolean-only overflow expressions are unaffected")
+  {
+    // The plain *_overflow_exprt variants carry no result, so no struct is
+    // built and no field order is involved. Pinned to show the refactoring of
+    // the keep_result branches left these outputs alone.
+    REQUIRE(
+      get_assert(mult_overflow_exprt{ua, ub}) ==
+      "(assert (let ((prod (bvmul ((_ zero_extend 8) ua) "
+      "((_ zero_extend 8) ub)))) (bvuge prod (_ bv256 16))))");
+    REQUIRE(
+      get_assert(mult_overflow_exprt{sa, sb}) ==
+      "(assert (let ( (prod (bvmul ((_ sign_extend 8) sa) "
+      "((_ sign_extend 8) sb)) )) (or (bvsge prod (_ bv128 16)) "
+      "(bvslt prod (bvneg (_ bv128 16))))))");
+    REQUIRE(
+      get_assert(plus_overflow_exprt{sa, sb}) ==
+      "(assert (let ((?sum (bvadd ((_ sign_extend 1) sa) "
+      "((_ sign_extend 1) sb)))) (not (= ((_ extract 8 8) ?sum) "
+      "((_ extract 7 7) ?sum)))))");
+    REQUIRE(
+      get_assert(minus_overflow_exprt{ua, ub}) ==
+      "(assert (let ((?sum (bvsub ((_ zero_extend 1) ua) "
+      "((_ zero_extend 1) ub))))(= ((_ extract 8 8) ?sum)#b1)))");
+  }
+
+  SECTION("datatypes encoding is unaffected")
+  {
+    // With datatypes the struct is built with a constructor and read with a
+    // selector, so no bit order is involved. Pinned here to make sure the
+    // refactoring of the flattened path did not disturb it.
+    REQUIRE(
+      get_assert_with_datatypes(
+        value_of(overflow_result_exprt{ua, ID_mult, ub})) ==
+      "(assert (not (= (struct.0.value (let ((prod (bvmul "
+      "((_ zero_extend 8) ua) ((_ zero_extend 8) ub)))) "
+      "(mk-struct.0 ((_ extract 7 0) prod) "
+      "(bvuge prod (_ bv256 16))))) (_ bv0 8))))");
+  }
+}
+
 TEST_CASE(
   "smt2_convt no unary concat for zero-width operand",
   "[core][solvers][smt2]")


### PR DESCRIPTION
Fixes #9144.

## Problem

`overflow_result_exprt` has the struct type `{ value, overflow-<kind> }`.
When SMT-LIB datatypes are unavailable, `smt2_convt` flattens that struct
into a bit-vector with `value` in the low bits and the overflow flag above
it.

Signed add/sub and signed/unsigned multiply emitted the fields in the
opposite order. Member access then returned the wrong result and overflow
flag, causing both false counterexamples and missed overflows.

## Change

The affected paths now emit:

```smt2
(concat overflow_flag result)
```

instead of:

```smt2
(concat result overflow_flag)
```

The patch updates:

- signed addition and subtraction
- signed multiplication
- unsigned multiplication

Unsigned addition and subtraction were already correct: their extended
sum has the result in the low bits and the carry-out above it.

The refactoring builds the overflow predicate once and then uses it in the
datatype, flattened-result, or boolean-only output. Datatype output and
boolean-only overflow checks are unchanged.

## Tests

### Unit test

`unit/solvers/smt2/smt2_conv.cpp` checks the emitted SMT2 for:

- the four corrected cases
- unsigned add/sub, which were already correct
- boolean-only overflow expressions
- the datatype encoding used by Z3/CVC5

Reverting the fix makes only the four corrected sections fail. The focused
Catch run reports 4 of 22 assertions failed.

### Regression tests

`overflow-result-flattening1` checks ten assertions across unsigned
multiply/add and signed multiply/add/sub. Before the fix, seven failed
spuriously under CPROVER SMT2 and Bitwuzla.

`overflow-result-flattening2` checks the opposite direction:
`0x10000u * 0x10000u` must overflow and may truncate to zero. Before the
fix, affected back-ends missed both failures.

Both tests are `CORE no-new-smt`, so they exercise the default SAT,
CPROVER SMT2, Bitwuzla, and Z3 paths while excluding the unsupported
incremental SMT2 back-end.

## Verification

With the fix, all four tested back-ends agree:

| Test | SAT | CPROVER SMT2 | Bitwuzla | Z3 |
| --- | ---: | ---: | ---: | ---: |
| no false failures | 0/10 | 0/10 | 0/10 | 0/10 |
| expected failures found | 2/2 | 2/2 | 2/2 | 2/2 |

Additional checks:

- focused SMT2 unit suite: 213 assertions in 40 test cases pass
- full default-SAT regression suite: pass, 67 skipped
- full CPROVER-SMT2 regression suite: pass, 112 skipped
- full Z3 regression suite: one unrelated flaky `Function4` failure; it
  passes in isolation and with unmodified CBMC 6.8.0/6.9.0
- downstream Kani `crypto-bigint` harness: Bitwuzla and Z3 agree across all
  40 properties after the fix

To run the focused checks:

```console
$ cmake --build build --target cbmc unit smt2_solver
$ ./build/bin/unit '[core][solvers][smt2]'
$ cd regression/cbmc
$ make test
$ make test-cprover-smt2
```
