### PR TITLE
Fix ill-typed SMT2 for flattened aggregate expressions

### DIFF
--- a/regression/cbmc/smt2_zero_width_struct_concat/main.c
+++ b/regression/cbmc/smt2_zero_width_struct_concat/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+struct S
+{
+  unsigned char : 0;
+  unsigned char : 0;
+  unsigned char value;
+};
+
+union U
+{
+  struct S structure;
+  unsigned char value;
+};
+
+int main(int argc, char **argv)
+{
+  (void)argv;
+  unsigned char value = (unsigned char)argc;
+
+  union U object = {.structure = {.value = value}};
+  assert(object.value == value);
+}

--- a/regression/cbmc/smt2_zero_width_struct_concat/test.desc
+++ b/regression/cbmc/smt2_zero_width_struct_concat/test.desc
@@ -1,0 +1,17 @@
+CORE smt-backend no-new-smt
+main.c
+--smt2
+^\[main\.assertion\.1\] line \d+ assertion object\.value == value: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+expected at least 2 arguments to 'concat'
+^VERIFICATION ERROR$
+--
+The two unnamed zero-width bit-fields are retained as zero-width struct
+components.  Without the fix, the SMT2 struct encoders count the original
+components when constructing concat and emit a unary (concat value).  Storing
+the struct in a union forces it into a bit-vector: non-datatype backends pass
+through convert_struct, while datatype backends use flatten2bv.  The fixed
+encoders emit value directly.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -33,6 +33,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/range.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
+#include <util/replace_symbol.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/string2int.h>
@@ -2600,12 +2601,38 @@ void smt2_convt::convert_expr(const exprt &expr)
     const let_exprt &let_expr=to_let_expr(expr);
     const auto &variables = let_expr.variables();
     const auto &values = let_expr.values();
+    const exprt where = inline_flattened_array_let_bindings(let_expr);
+
+    bool has_remaining_bindings = false;
+    for(auto &binding : make_range(variables).zip(values))
+    {
+      if(
+        binding.first.type().id() != ID_array ||
+        use_array_theory(binding.second))
+      {
+        has_remaining_bindings = true;
+        break;
+      }
+    }
+
+    if(!has_remaining_bindings)
+    {
+      convert_expr(where);
+      return;
+    }
 
     out << "(let (";
     bool first = true;
 
     for(auto &binding : make_range(variables).zip(values))
     {
+      if(
+        binding.first.type().id() == ID_array &&
+        !use_array_theory(binding.second))
+      {
+        continue;
+      }
+
       if(first)
         first = false;
       else
@@ -2620,7 +2647,7 @@ void smt2_convt::convert_expr(const exprt &expr)
 
     out << ") "; // bindings
 
-    convert_expr(let_expr.where());
+    convert_expr(where);
     out << ')'; // let
   }
   else if(expr.id()==ID_constraint_select_one)
@@ -3701,6 +3728,23 @@ void smt2_convt::convert_floatbv_round_to_integral(
     UNEXPECTEDCASE("TODO floatbv_round_to_integral without FPA");
 }
 
+/// Return the indices of the components that have a non-zero bit-vector width.
+static std::vector<std::size_t> non_zero_width_component_indices(
+  const struct_typet::componentst &components,
+  const namespacet &ns)
+{
+  std::vector<std::size_t> result;
+  result.reserve(components.size());
+
+  for(std::size_t i = 0; i < components.size(); ++i)
+  {
+    if(!is_zero_width(components[i].type(), ns))
+      result.push_back(i);
+  }
+
+  return result;
+}
+
 void smt2_convt::convert_struct(const struct_exprt &expr)
 {
   const struct_typet &struct_type =
@@ -3751,27 +3795,22 @@ void smt2_convt::convert_struct(const struct_exprt &expr)
         convert_expr(op);
     };
 
-    // SMT-LIB 2 concat is binary only
-    std::size_t n_concat = 0;
-    for(std::size_t i = components.size(); i > 1; i--)
+    const auto component_indices =
+      non_zero_width_component_indices(components, ns);
+
+    // SMT-LIB 2 concat is binary only.
+    for(std::size_t i = component_indices.size(); i > 1; --i)
     {
-      if(is_zero_width(components[i - 1].type(), ns))
-        continue;
-      else if(i > 2 || !is_zero_width(components[0].type(), ns))
-      {
-        ++n_concat;
-        out << "(concat ";
-      }
-
-      convert_operand(expr.operands()[i - 1]);
-
-      out << " ";
+      out << "(concat ";
+      convert_operand(expr.operands()[component_indices[i - 1]]);
+      out << ' ';
     }
 
-    if(!is_zero_width(components[0].type(), ns))
-      convert_operand(expr.op0());
+    if(!component_indices.empty())
+      convert_operand(expr.operands()[component_indices.front()]);
 
-    out << std::string(n_concat, ')');
+    if(component_indices.size() > 1)
+      out << std::string(component_indices.size() - 1, ')');
   }
 }
 
@@ -5227,29 +5266,22 @@ void smt2_convt::flatten2bv(const exprt &expr)
       const struct_typet::componentst &components=
         struct_type.components();
 
-      // SMT-LIB 2 concat is binary only
-      std::size_t n_concat = 0;
-      for(std::size_t i=components.size(); i>1; i--)
+      const auto component_indices =
+        non_zero_width_component_indices(components, ns);
+
+      // SMT-LIB 2 concat is binary only.
+      for(std::size_t i = component_indices.size(); i > 1; --i)
       {
-        if(is_zero_width(components[i - 1].type(), ns))
-          continue;
-        else if(i > 2 || !is_zero_width(components[0].type(), ns))
-        {
-          ++n_concat;
-          out << "(concat ";
-        }
-
-        flatten2bv(member_exprt{expr, components[i - 1]});
-
-        out << " ";
+        out << "(concat ";
+        flatten2bv(member_exprt{expr, components[component_indices[i - 1]]});
+        out << ' ';
       }
 
-      if(!is_zero_width(components[0].type(), ns))
-      {
-        flatten2bv(member_exprt{expr, components[0]});
-      }
+      if(!component_indices.empty())
+        flatten2bv(member_exprt{expr, components[component_indices.front()]});
 
-      out << std::string(n_concat, ')'); // concat
+      if(component_indices.size() > 1)
+        out << std::string(component_indices.size() - 1, ')');
     }
     else
       convert_expr(expr);
@@ -6267,6 +6299,26 @@ void smt2_convt::find_symbols(const exprt &expr)
   }
 }
 
+exprt smt2_convt::inline_flattened_array_let_bindings(
+  const let_exprt &let_expr)
+{
+  replace_symbolt substitutions;
+
+  for(auto &binding : make_range(let_expr.variables()).zip(let_expr.values()))
+  {
+    if(
+      binding.first.type().id() == ID_array &&
+      !use_array_theory(binding.second))
+    {
+      substitutions.set(binding.first, binding.second);
+    }
+  }
+
+  exprt where = let_expr.where();
+  substitutions(where);
+  return where;
+}
+
 bool smt2_convt::use_array_theory(const exprt &expr)
 {
   const typet &type = expr.type();
@@ -6304,6 +6356,11 @@ bool smt2_convt::use_array_theory(const exprt &expr)
     const if_exprt &if_expr = to_if_expr(expr);
     return use_array_theory(if_expr.true_case()) ||
            use_array_theory(if_expr.false_case());
+  }
+  else if(expr.id() == ID_let)
+  {
+    return use_array_theory(
+      inline_flattened_array_let_bindings(to_let_expr(expr)));
   }
   else
     return use_datatypes || expr.id() != ID_member;

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -125,6 +125,8 @@ protected:
 
   // tweaks for arrays
   bool use_array_theory(const exprt &);
+  /// Inline array-valued let bindings whose values use bit-vector encoding.
+  exprt inline_flattened_array_let_bindings(const let_exprt &);
   void flatten_array(const exprt &);
 
   // specific expressions go here

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -35,12 +35,14 @@ TEST_CASE(
 }
 
 /// Helper: extract the "(assert ...)" line from SMT2 output of set_to
-static std::string get_assert(const exprt &red_expr)
+static std::string get_assert(
+  const exprt &red_expr,
+  smt2_convt::solvert solver = smt2_convt::solvert::GENERIC)
 {
   symbol_tablet symbol_table;
   namespacet ns(symbol_table);
   std::ostringstream out;
-  smt2_convt conv(ns, "test", "", "QF_BV", smt2_convt::solvert::GENERIC, out);
+  smt2_convt conv(ns, "test", "", "QF_BV", solver, out);
   conv.set_to(red_expr, true);
   std::string result = out.str();
   auto pos = result.find("(assert ");
@@ -117,19 +119,140 @@ TEST_CASE("smt2_convt reduction operators", "[core][solvers][smt2]")
   }
 }
 
+TEST_CASE("smt2_convt does not emit unary concat", "[core][solvers][smt2]")
+{
+  const unsignedbv_typet u8{8};
+
+  SECTION("concatenation expression with one non-zero-width operand")
+  {
+    const unsignedbv_typet u0{0};
+    const symbol_exprt x{"x", u8};
+    const symbol_exprt z{"z", u0};
+
+    const concatenation_exprt concat{{z, x}, u8};
+    REQUIRE(get_assert(equal_exprt{concat, x}) == "(assert (= x x))");
+  }
+
+  SECTION("struct with one non-zero-width component")
+  {
+    const struct_typet struct_type{
+      {{"empty1", empty_typet{}}, {"empty2", empty_typet{}}, {"value", u8}}};
+    const symbol_exprt value{"value", u8};
+    const struct_exprt construction{
+      {nil_exprt{}, nil_exprt{}, value}, struct_type};
+    const symbol_exprt structure{"structure", struct_type};
+
+    REQUIRE(
+      get_assert(equal_exprt{construction, structure}) ==
+      "(assert (= value structure))");
+  }
+
+  SECTION("struct concatenation preserves component order")
+  {
+    const struct_typet struct_type{
+      {{"low", u8}, {"empty", empty_typet{}}, {"high", u8}}};
+    const symbol_exprt low{"low", u8};
+    const symbol_exprt high{"high", u8};
+    const struct_exprt construction{{low, nil_exprt{}, high}, struct_type};
+    const symbol_exprt structure{"structure", struct_type};
+
+    REQUIRE(
+      get_assert(equal_exprt{construction, structure}) ==
+      "(assert (= (concat high low) structure))");
+  }
+
+  SECTION("datatype struct flattened to a bit-vector")
+  {
+    const struct_typet struct_type{
+      {{"empty1", empty_typet{}}, {"empty2", empty_typet{}}, {"value", u8}}};
+    const symbol_exprt structure{"structure", struct_type};
+    const symbol_exprt value{"value", u8};
+    const typecast_exprt flattened{structure, u8};
+
+    REQUIRE(
+      get_assert(equal_exprt{flattened, value}, smt2_convt::solvert::Z3) ==
+      "(assert (= (struct.0.value structure) value))");
+  }
+
+  SECTION("datatype flattening preserves component order")
+  {
+    const unsignedbv_typet u16{16};
+    const struct_typet struct_type{
+      {{"low", u8}, {"empty", empty_typet{}}, {"high", u8}}};
+    const symbol_exprt structure{"structure", struct_type};
+    const symbol_exprt value{"value", u16};
+    const typecast_exprt flattened{structure, u16};
+
+    REQUIRE(
+      get_assert(equal_exprt{flattened, value}, smt2_convt::solvert::Z3) ==
+      "(assert (= (concat (struct.0.high structure) "
+      "(struct.0.low structure)) value))");
+  }
+}
+
 TEST_CASE(
-  "smt2_convt no unary concat for zero-width operand",
+  "smt2_convt array-valued let uses the emitted array encoding",
   "[core][solvers][smt2]")
 {
-  unsignedbv_typet u8{8};
-  unsignedbv_typet u0{0};
-  symbol_exprt x{"x", u8};
-  symbol_exprt z{"z", u0};
+  const unsignedbv_typet u8{8};
+  array_typet array_type{u8, from_integer(2, u8)};
+  array_type.index_type_nonconst() = u8;
+  const struct_typet struct_type{{{"array", array_type}}};
+  const symbol_exprt structure{"structure", struct_type};
+  const member_exprt member{structure, "array", array_type};
+  const exprt zero = from_integer(0, u8);
 
-  // concat of a zero-width and a non-zero-width operand should emit
-  // the non-zero-width operand directly, not (concat x)
-  concatenation_exprt concat{{z, x}, u8};
-  REQUIRE(get_assert(equal_exprt{concat, x}) == "(assert (= x x))");
+  SECTION("the result encoding follows the let body")
+  {
+    const symbol_exprt scalar{"scalar", u8};
+    const let_exprt let{scalar, zero, member};
+    const index_exprt index{let, zero};
+    const std::string assertion = get_assert(notequal_exprt{index, zero});
+
+    INFO(assertion);
+    REQUIRE(assertion.find("(select") == std::string::npos);
+    REQUIRE(assertion.find("(bvlshr") != std::string::npos);
+  }
+
+  SECTION("flattened array bindings are inlined")
+  {
+    const symbol_exprt bound{"bound", array_type};
+    const index_exprt index{bound, zero};
+    const let_exprt let{bound, member, index};
+    const std::string assertion = get_assert(notequal_exprt{let, zero});
+
+    INFO(assertion);
+    REQUIRE(assertion.find("(select") == std::string::npos);
+    REQUIRE(assertion.find("(bvlshr") != std::string::npos);
+  }
+
+  SECTION("other bindings are retained")
+  {
+    const symbol_exprt scalar{"scalar", u8};
+    const symbol_exprt bound{"bound", array_type};
+    const index_exprt index{bound, zero};
+    const let_exprt let{{scalar, bound}, {zero, member}, index};
+    const std::string assertion = get_assert(notequal_exprt{let, zero});
+
+    INFO(assertion);
+    REQUIRE(assertion.find("(let ((scalar") != std::string::npos);
+    REQUIRE(assertion.find("(select") == std::string::npos);
+    REQUIRE(assertion.find("(bvlshr") != std::string::npos);
+  }
+
+  SECTION("array-theory bindings are retained")
+  {
+    const symbol_exprt array{"array", array_type};
+    const symbol_exprt bound{"bound", array_type};
+    const index_exprt index{bound, zero};
+    const let_exprt let{bound, array, index};
+    const std::string assertion = get_assert(notequal_exprt{let, zero});
+
+    INFO(assertion);
+    REQUIRE(assertion.find("(let ((bound array))") != std::string::npos);
+    REQUIRE(assertion.find("(select bound") != std::string::npos);
+    REQUIRE(assertion.find("(bvlshr") == std::string::npos);
+  }
 }
 
 TEST_CASE("smt2_convt range encoding", "[core][solvers][smt2]")


### PR DESCRIPTION
Fixes #9146.

## Problem

The SMT2 aggregate encoding could emit two invalid terms:

- `(concat value)` for a struct with several zero-width fields and only one
  non-zero-width field
- `(select <bit-vector> index)` for an array-valued `let` whose body or bound
  value is a flattened struct member

Strict SMT-LIB parsers reject these terms instead of checking the program.
The unary `concat` case is reachable from C using structs with unnamed
zero-width `unsigned char` bit-fields. No C producer is currently known for the
array-valued `let` case; it is covered as an internal converter invariant.

## Change

Struct conversion now collects the non-zero-width component indices first and
adds exactly one binary `concat` per additional component. The datatype
flattening path uses the same helper.

Array-valued `let` expressions now follow the encoding of their emitted body.
Bindings whose array values use the flattened bit-vector encoding are inlined;
other bindings remain in the SMT `let`.

## Tests

`unit/solvers/smt2/smt2_conv.cpp` now checks:

- a struct with two empty fields and one 8-bit field is emitted directly,
  without unary `concat`
- mixed empty and non-empty struct fields preserve their bit-vector order
- flattening the equivalent datatype struct to a bit-vector also avoids unary
  `concat`
- indexing an array-valued `let` uses bit-vector extraction when its body is a
  flattened struct member
- flattened array bindings are inlined
- unrelated scalar bindings remain in the emitted `let`
- bindings that genuinely use array theory remain in the emitted `let`

`regression/cbmc/smt2_zero_width_struct_concat` provides a C reproducer. It
stores the struct in a union, exercising both non-datatype struct conversion
and datatype-to-bit-vector flattening.

The focused failure cases emit unary `concat` or apply `select` to a bit-vector
on `develop`. The other sections guard component order and ensure array-theory
bindings are not unnecessarily inlined.

## Verification

```console
$ cmake --build build --target unit -j4
$ ./build/bin/unit 'smt2_convt does not emit unary concat'
All tests passed (10 assertions in 1 test case)

$ ./build/bin/unit 'smt2_convt array-valued let uses the emitted array encoding'
All tests passed (14 assertions in 1 test case)

$ ./build/bin/unit '[core][solvers][smt2]'
All tests passed (213 assertions in 40 test cases)
```

The malformed examples from the issue were also checked with Bitwuzla 0.9.1.
It rejects both original forms and accepts the corrected formulas. The bundled
CPROVER SMT2 parser rejects the array sort mismatch and accepts both corrected
forms.

The C regression passes with the default SMT2 configuration, CPROVER SMT2,
Bitwuzla, and Z3. With the old encoder, Bitwuzla reports the property as `ERROR`
and exits with `VERIFICATION ERROR`.
