### PR TITLE
Fix long double width on FreeBSD/PowerPC

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1144,6 +1144,23 @@ bool configt::set(const cmdlinet &cmdline)
     ansi_c.char_is_unsigned = false;
     ansi_c.long_double_width = 8 * 8;
   }
+  else if(
+    os == "freebsd" &&
+    (arch == "powerpc" || arch == "ppc64" || arch == "ppc64le"))
+  {
+    // FreeBSD/PowerPC does not use the 128-bit long double assumed by
+    // set_arch_spec_power(): it is 64-bit, except on powerpc64le since
+    // FreeBSD 16.0, where it is IEEE binary128.  The width is a property
+    // of the release, which the target triple does not carry, so follow
+    // the toolchain when verifying natively and assume FreeBSD >= 16.0
+    // when cross-verifying.
+    if(arch == this_arch && os == this_os)
+      ansi_c.long_double_width = sizeof(long double) * CHAR_BIT;
+    else if(arch == "ppc64le")
+      ansi_c.long_double_width = 16 * 8;
+    else
+      ansi_c.long_double_width = 8 * 8;
+  }
 
   // Let's check some of the type widths in case we run
   // the same architecture and OS that we are verifying for.


### PR DESCRIPTION
set_arch_spec_power() sets long_double_width to 16*8 for every PowerPC subarchitecture. That matches Linux, where long double is 128-bit IBM double-double, but not FreeBSD, where long double on PowerPC is the same as double -- with the exception of powerpc64le since FreeBSD 16.0, which uses IEEE binary128.

Because the width does not match the host, verifying natively on FreeBSD/powerpc64le aborts as soon as any tool configures itself:

  --- begin invariant violation report ---
  Invariant check failed
  File: src/util/config.cpp:1132 function: set
  Condition: ansi_c.long_double_width == sizeof(long double) * CHAR_BIT
  Reason: long double width shall be equal to the system long double width
  --- end invariant violation report ---
  Abort trap (core dumped)

This is not hypothetical for a build either: the regression tests run the freshly built goto-gcc, so the build itself fails.

Neither constant is right for FreeBSD, as the width depends on the release:

  FreeBSD 15.1, powerpc64le:  sizeof(long double) * CHAR_BIT == 64
                              (__LDBL_MANT_DIG__ 53)
  FreeBSD 16.0, powerpc64le:  sizeof(long double) * CHAR_BIT == 128
                              (__LDBL_MANT_DIG__ 113, __LONG_DOUBLE_IEEE128__)

Take the width from the toolchain instead of hard-coding it, which is exactly the quantity the invariant compares against and stays correct across that transition. The override lives in configt::set() rather than in set_arch_spec_power(), which only receives the subarchitecture and has no way to know the target operating system; the neighbouring macos/arm64 case already sets long_double_width the same way.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
