### PR TITLE
Summarise sequential top-level calls by replacement in DFCC checks

### DIFF
--- a/regression/contracts-dfcc/check_multiple_top_level_calls/main.c
+++ b/regression/contracts-dfcc/check_multiple_top_level_calls/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+int foo(int x)
+  // clang-format off
+__CPROVER_requires(0 <= x && x < 1000)
+__CPROVER_ensures(__CPROVER_return_value == x + 1)
+// clang-format on
+{
+  return x + 1;
+}
+
+int main()
+{
+  // First top-level call: checked against the contract.
+  int a = foo(1);
+  assert(a == 2);
+  // Sequential top-level re-invocation: summarised by contract replacement.
+  int b = foo(a);
+  assert(b == 3);
+  return 0;
+}

--- a/regression/contracts-dfcc/check_multiple_top_level_calls/test.desc
+++ b/regression/contracts-dfcc/check_multiple_top_level_calls/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks that a second, sequential top-level call to a function whose contract
+is being enforced is summarised by contract replacement instead of being
+rejected with a "single top-level call" assertion failure.

--- a/regression/contracts-dfcc/check_multiple_top_level_calls_fail/main.c
+++ b/regression/contracts-dfcc/check_multiple_top_level_calls_fail/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+int foo(int x)
+  // clang-format off
+__CPROVER_requires(0 <= x && x < 1000)
+__CPROVER_ensures(__CPROVER_return_value == x + 1)
+// clang-format on
+{
+  return x + 1;
+}
+
+int main()
+{
+  // First top-level call: checked against the contract.
+  int a = foo(1);
+  assert(a == 2);
+  // Sequential top-level re-invocation via replacement: violates the
+  // precondition, which must be asserted in the caller's context.
+  int b = foo(-1);
+  return 0;
+}

--- a/regression/contracts-dfcc/check_multiple_top_level_calls_fail/test.desc
+++ b/regression/contracts-dfcc/check_multiple_top_level_calls_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.precondition.\d+\] line \d+ Check requires clause of contract contract::foo for function foo: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks that the precondition of a contract is asserted for sequential
+top-level re-invocations that are summarised by contract replacement.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.cpp
@@ -115,19 +115,21 @@ void dfcc_swap_and_wrapt::get_swapped_functions(std::set<irep_idt> &dest) const
 ///
 /// Adds the following instructions in the wrapper function body:
 /// ```c
-/// IF __contract_check_in_progress GOTO replace;
-/// ASSERT !__contract_checked_once "only a single top-level called allowed";
+/// IF __contract_check_in_progress GOTO recursion;
+/// IF __contract_checked_once GOTO replace;
 /// __contract_check_in_progress = true;
 /// <contract_handler.add_contract_checking_instructions(...)>;
 /// __contract_checked_once = true;
 /// __contract_check_in_progress = false;
 /// GOTO end;
-/// replace:
-/// // if allow_recursive_calls
-/// <contract_handler.add_contract_replacement_instructions(...)>;
+/// recursion:
 /// // if !allow_recursive_calls
 /// ASSERT false, "no recursive calls";
 /// ASSUME false;
+/// replace:
+/// // sequential top-level re-invocations (and, if allow_recursive_calls,
+/// // recursive calls) are summarised by contract replacement
+/// <contract_handler.add_contract_replacement_instructions(...)>;
 /// end:
 /// END_FUNCTION;
 /// ```
@@ -175,19 +177,21 @@ void dfcc_swap_and_wrapt::check_contract(
   auto check_started_goto = body.add(goto_programt::make_incomplete_goto(
     check_started, wrapper_symbol.location));
 
-  // At most a single top level call to the checked function in any execution
+  // At most a single top level call to the checked function is checked
+  // against the contract in any execution.
 
   // Recursive calls within a contract check correspond to
-  // `check_started && !check_completed` and are allowed.
+  // `check_started && !check_completed` and are allowed if
+  // `allow_recursive_calls` is set.
 
-  // Any other call occuring with `check_completed` true is forbidden.
-  source_locationt sl(wrapper_symbol.location);
-  sl.set_function(wrapper_symbol.name);
-  sl.set_property_class("single_top_level_call");
-  sl.set_comment(
-    "Only a single top-level call to function " + id2string(function_id) +
-    " when checking contract " + id2string(contract_id));
-  body.add(goto_programt::make_assertion(not_exprt(check_completed), sl));
+  // Any other call occurring with `check_completed` true is a sequential
+  // top-level re-invocation. Such calls are sound to summarise by contract
+  // replacement (their preconditions are asserted in the caller's context,
+  // their write set is havocked, and their postconditions are assumed), so
+  // jump to a replacement section instead of failing an assertion.
+  auto check_completed_goto = body.add(goto_programt::make_incomplete_goto(
+    check_completed, wrapper_symbol.location));
+
   body.add(goto_programt::make_assignment(
     check_started, true_exprt(), wrapper_symbol.location));
 
@@ -215,23 +219,12 @@ void dfcc_swap_and_wrapt::check_contract(
   auto goto_end_function =
     body.add(goto_programt::make_incomplete_goto(wrapper_symbol.location));
 
-  // Jump to the replacement section if check already in progress
-  auto contract_replacement_label =
+  // Jump here if a check is already in progress (recursive call)
+  auto recursion_label =
     body.add(goto_programt::make_skip(wrapper_symbol.location));
-  check_started_goto->complete_goto(contract_replacement_label);
+  check_started_goto->complete_goto(recursion_label);
 
-  if(allow_recursive_calls)
-  {
-    contract_handler.add_contract_instructions(
-      dfcc_contract_modet::REPLACE,
-      wrapper_id,
-      wrapped_id,
-      contract_id,
-      write_set_symbol,
-      body,
-      function_pointer_contracts);
-  }
-  else
+  if(!allow_recursive_calls)
   {
     source_locationt sl(wrapper_symbol.location);
     sl.set_function(wrapper_symbol.name);
@@ -243,6 +236,21 @@ void dfcc_swap_and_wrapt::check_contract(
     body.add(
       goto_programt::make_assumption(false_exprt(), wrapper_symbol.location));
   }
+
+  // Jump here for sequential top-level re-invocations after a completed
+  // check; allowed recursive calls fall through to the same replacement.
+  auto sequential_label =
+    body.add(goto_programt::make_skip(wrapper_symbol.location));
+  check_completed_goto->complete_goto(sequential_label);
+
+  contract_handler.add_contract_instructions(
+    dfcc_contract_modet::REPLACE,
+    wrapper_id,
+    wrapped_id,
+    contract_id,
+    write_set_symbol,
+    body,
+    function_pointer_contracts);
 
   auto end_function_label =
     body.add(goto_programt::make_end_function(wrapper_symbol.location));


### PR DESCRIPTION
When enforcing a contract, the DFCC wrapper so far rejected any second top-level call to the checked function with a "Only a single top-level call" assertion failure. This is stricter than necessary: once (or while) one call is being checked against the contract, any further call can soundly be summarised by contract replacement, exactly like calls to --replace-call-with-contract functions: the preconditions are asserted in the calling context, the assigns clause is havocked, and the postconditions are assumed.

Replace the assertion by a branch to a replacement section, which is now emitted unconditionally (previously it was only emitted for recursive checks with --dfcc-allow-recursive-calls; the behaviour for recursive calls is unchanged).

This restriction was a long-standing usability papercut: harnesses had to be written so that exactly one call to the function under verification was reachable. It has become a correctness problem for Rust verification via Kani, where contracts of dependencies are asserted by default (model-checking/kani#3802): the contract clauses of other functions in the harness's call graph may themselves call the function under verification - e.g. NonNull::new's postcondition calls NonNull::as_ptr, so a proof_for_contract(as_ptr) harness that constructs its input via NonNull::new fails the single-top-level-call assertion through no fault of the harness.

Two regression tests: a second sequential call is verified via replacement (with its ensures usable by the caller), and a second call violating the contract's requires is reported as a precondition failure.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
