### PR TITLE
Make trace generation opt-in for all user interfaces

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -165,11 +165,13 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
      cmdline.isset("outfile"))
     options.set_option("stop-on-fail", true);
 
+  // Trace generation is opt-in, consistently across the plain, JSON and XML
+  // interfaces: it is enabled by an explicit trace option, or by modes whose
+  // purpose is to produce a trace (--stop-on-fail, --graphml-witness,
+  // --validate-trace).
   if(
     cmdline.isset("trace") || cmdline.isset("compact-trace") ||
-    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail") ||
-    (ui_message_handler.get_ui() != ui_message_handlert::uit::PLAIN &&
-     !cmdline.isset("cover")))
+    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail"))
   {
     options.set_option("trace", true);
   }

--- a/regression/cbmc/Float24/test.desc
+++ b/regression/cbmc/Float24/test.desc
@@ -1,6 +1,6 @@
 CORE no-new-smt
 main.i
---win32 --xml-ui
+--win32 --xml-ui --trace
 ^EXIT=10$
 ^SIGNAL=0$
 VERIFICATION FAILED

--- a/regression/cbmc/function-return-no-body1/test.desc
+++ b/regression/cbmc/function-return-no-body1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---xml-ui
+--xml-ui --trace
 activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/json-ui-trace-opt-in/main.c
+++ b/regression/cbmc/json-ui-trace-opt-in/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int x;
+  __CPROVER_assert(x != 42, "should fail with a counterexample");
+  return 0;
+}

--- a/regression/cbmc/json-ui-trace-opt-in/test.desc
+++ b/regression/cbmc/json-ui-trace-opt-in/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--json-ui
+^EXIT=10$
+^SIGNAL=0$
+"status": "FAILURE"
+--
+"trace": \[
+--
+Traces are opt-in for all user interfaces: without --trace, the JSON
+interface must not generate counterexample traces for failed properties,
+only their status.

--- a/regression/cbmc/json-ui-trace-opt-in/trace.desc
+++ b/regression/cbmc/json-ui-trace-opt-in/trace.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--json-ui --trace
+^EXIT=10$
+^SIGNAL=0$
+"status": "FAILURE"
+"trace": \[
+--
+--
+With --trace, the JSON interface generates counterexample traces for failed
+properties.

--- a/regression/cbmc/xml-trace/test.desc
+++ b/regression/cbmc/xml-trace/test.desc
@@ -1,6 +1,6 @@
 CORE broken-cprover-smt-backend no-new-smt
 main.c
---xml-ui --function test --little-endian
+--xml-ui --trace --function test --little-endian
 activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/xml-trace2/test.desc
+++ b/regression/cbmc/xml-trace2/test.desc
@@ -1,6 +1,6 @@
 CORE no-new-smt
 main.c
---xml-ui
+--xml-ui --trace
 <full_lhs_value( binary="[01]+")?>\{ 14, 0 \}</full_lhs_value>
 ^EXIT=10$
 ^SIGNAL=0$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -304,11 +304,15 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
      cmdline.isset("outfile"))
     options.set_option("stop-on-fail", true);
 
+  // Trace generation is opt-in, consistently across the plain, JSON and XML
+  // interfaces: it is enabled by an explicit trace option, or by modes whose
+  // purpose is to produce a trace (--stop-on-fail, --graphml-witness, see
+  // below). Previously the JSON and XML interfaces generated traces for all
+  // failed properties by default, which is very costly on programs with many
+  // (expected) failures, e.g. cover-style reachability checks.
   if(
     cmdline.isset("trace") || cmdline.isset("compact-trace") ||
-    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail") ||
-    (ui_message_handler.get_ui() != ui_message_handlert::uit::PLAIN &&
-     !cmdline.isset("cover")))
+    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail"))
   {
     options.set_option("trace", true);
   }


### PR DESCRIPTION
The JSON and XML interfaces enabled counterexample-trace generation unconditionally, while the plain interface requires --trace. Consumers of the structured interfaces that only need property verdicts pay a very large cost for traces they discard: for a Kani-generated standard library harness with 611 properties, of which 63 are expected-failure reachability (cover-style) checks, CBMC with --json-ui spends 296 seconds wall-clock where the same invocation with the plain interface takes 34 seconds. 82% of total CPU time goes to BigInt::as_string via integer2binary, serialising ~2 MB of JSON trace - dominated by the "binary" fields of constant values - for each expected failure.

Make trace generation opt-in uniformly across the plain, JSON and XML interfaces, for both cbmc and jbmc: traces are generated when requested explicitly (--trace, --compact-trace, --stack-trace) or when a mode whose purpose is trace output is active (--stop-on-fail, --graphml-witness, --validate-trace). This is a behavioural change for JSON/XML consumers that relied on implicit traces; they need to pass --trace (as the plain interface always required). The --cover mode already disabled the implicit trace default, so the previous behaviour was not even uniform within the structured interfaces.

Regression tests that relied on implicit traces under --xml-ui now pass --trace explicitly (xml-trace, xml-trace2, Float24, function-return-no-body1); a new test checks both that --json-ui alone produces no trace elements and that --json-ui --trace does.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
