### PR TITLE
Add --evaluation-order-check for unspecified evaluation order

### DIFF
--- a/regression/cbmc/Eval_Order2/test.desc
+++ b/regression/cbmc/Eval_Order2/test.desc
@@ -1,7 +1,14 @@
-FUTURE
+CORE
 main.c
-
+--evaluation-order-check
+^\[main\.evaluation-order\.1\] line 3 value of x is independent of evaluation order: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
+^warning: ignoring
+--
+The read of x in ++x + x is unsequenced relative to the side effect of ++x,
+which is undefined behaviour (C11 6.5p2); --evaluation-order-check reports
+that the value of the read depends on the evaluation order. This test was
+FUTURE before --evaluation-order-check existed.

--- a/regression/cbmc/Function_Eval_Order1/test.desc
+++ b/regression/cbmc/Function_Eval_Order1/test.desc
@@ -1,7 +1,15 @@
-FUTURE
+CORE
 main.c
-
+--evaluation-order-check
+^\[main\.assertion\.1\] line 24 assertion z == 5: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
+^warning: ignoring
+--
+The two calls to f00() are evaluated in an unspecified order (C99 6.5.2.2:10)
+and increment a static counter, so z is 5 under left-to-right and 7 under
+right-to-left evaluation. --evaluation-order-check explores both orders and
+refutes the assertion. This test was FUTURE before --evaluation-order-check
+existed.

--- a/regression/cbmc/evaluation_order_check/conflicting_writes.c
+++ b/regression/cbmc/evaluation_order_check/conflicting_writes.c
@@ -1,0 +1,17 @@
+int n;
+int f(void)
+{
+  n = 1;
+  return 0;
+}
+int g(void)
+{
+  n = 2;
+  return 0;
+}
+int main()
+{
+  int j = f() + g();
+  __CPROVER_assert(n == 2, "n == 2 regardless of evaluation order");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/conflicting_writes.desc
+++ b/regression/cbmc/evaluation_order_check/conflicting_writes.desc
@@ -1,0 +1,17 @@
+CORE
+conflicting_writes.c
+--evaluation-order-check
+^\[main\.assertion\.1\] line 15 n == 2 regardless of evaluation order: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+f() and g() both write n and are indeterminately sequenced, so the final
+value of n is either 1 or 2 depending on the evaluation order chosen by the
+compiler. --evaluation-order-check explores both orders of the two calls, so
+the assertion n == 2, which holds under left-to-right evaluation only, is
+refuted. Without the option the fixed lowering order would wrongly prove it
+(the very miss discussed in the review of the argument evaluation order
+modelling).

--- a/regression/cbmc/evaluation_order_check/division_after_call.c
+++ b/regression/cbmc/evaluation_order_check/division_after_call.c
@@ -1,0 +1,15 @@
+int p = 5;
+
+int f(int x)
+{
+  p = 0;
+  return x / 2;
+}
+
+int main()
+{
+  int i = 10;
+  int j = f(i) + i / p;
+  __CPROVER_assert(j == 7, "j == 7");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/division_before_call.c
+++ b/regression/cbmc/evaluation_order_check/division_before_call.c
@@ -1,0 +1,15 @@
+int b = 0;
+
+int f(void)
+{
+  b = 1;
+  return 0;
+}
+
+int main()
+{
+  int a = 10;
+  int j = a / b + f();
+  __CPROVER_assert(j == 10, "j == 10");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/division_before_call.desc
+++ b/regression/cbmc/evaluation_order_check/division_before_call.desc
@@ -1,0 +1,17 @@
+CORE
+division_before_call.c
+--div-by-zero-check --evaluation-order-check
+^\[main\.division-by-zero\.1\] line 12 division by zero in a / b: FAILURE$
+^\[main\.evaluation-order\.1\] line 12 value of a / b is independent of evaluation order: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+The call f() sets b from 0 to 1, so evaluating a / b before the call divides
+by zero, while goto conversion's fixed lowering places the call's side
+effects first and hence misses the division without
+--evaluation-order-check. With the check, the pre-call snapshot of a / b
+carries the division-by-zero check into the pre-call state and the
+evaluation-order-independence assertion fails.

--- a/regression/cbmc/evaluation_order_check/division_before_call_no_check.desc
+++ b/regression/cbmc/evaluation_order_check/division_before_call_no_check.desc
@@ -1,0 +1,14 @@
+CORE
+division_before_call.c
+--div-by-zero-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Without --evaluation-order-check, goto conversion lowers the expression in
+one fixed evaluation order (the call's side effects first), which misses the
+division by zero that occurs when a conforming compiler evaluates a / b
+before the call. This test documents that baseline behaviour; see
+division_before_call.desc for the checked variant.

--- a/regression/cbmc/evaluation_order_check/four_conflicting_writes.c
+++ b/regression/cbmc/evaluation_order_check/four_conflicting_writes.c
@@ -1,0 +1,29 @@
+int n;
+int a(void)
+{
+  n = n * 2;
+  return 0;
+}
+int b(void)
+{
+  n = n + 1;
+  return 0;
+}
+int c(void)
+{
+  n = n * 3;
+  return 0;
+}
+int d(void)
+{
+  n = n + 5;
+  return 0;
+}
+int main()
+{
+  n = 1;
+  int j = a() + b() + c() + d();
+  /* left-to-right gives ((1*2)+1)*3+5 = 14; other orders differ */
+  __CPROVER_assert(n == 14, "n == 14 regardless of order");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/four_conflicting_writes.desc
+++ b/regression/cbmc/evaluation_order_check/four_conflicting_writes.desc
@@ -1,0 +1,14 @@
+CORE
+four_conflicting_writes.c
+--evaluation-order-check
+^\[main\.assertion\.1\] line 27 n == 14 regardless of order: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+Four calls with non-commuting side effects on the same global: the value of n
+depends on which of the 24 possible evaluation orders the compiler chooses.
+The nondeterministic round-based scheduling explores all orders without a
+bound on the number of unsequenced side effects.

--- a/regression/cbmc/evaluation_order_check/four_independent_writes.c
+++ b/regression/cbmc/evaluation_order_check/four_independent_writes.c
@@ -1,0 +1,27 @@
+int p, q, r, s;
+int a(void)
+{
+  p = 1;
+  return 1;
+}
+int b(void)
+{
+  q = 2;
+  return 2;
+}
+int c(void)
+{
+  r = 3;
+  return 3;
+}
+int d(void)
+{
+  s = 4;
+  return 4;
+}
+int main()
+{
+  int j = a() + b() + c() + d();
+  __CPROVER_assert(j == 10 && p + q + r + s == 10, "order independent");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/four_independent_writes.desc
+++ b/regression/cbmc/evaluation_order_check/four_independent_writes.desc
@@ -1,0 +1,12 @@
+CORE
+four_independent_writes.c
+--evaluation-order-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Four calls whose side effects target distinct objects commute, so all 24
+evaluation orders yield the same state and the verification succeeds without
+false alarms.

--- a/regression/cbmc/evaluation_order_check/pure_calls.c
+++ b/regression/cbmc/evaluation_order_check/pure_calls.c
@@ -1,0 +1,15 @@
+int f(int x)
+{
+  return x + 1;
+}
+int g(int y)
+{
+  return y * 2;
+}
+int main()
+{
+  int a = 1, b = 2;
+  int j = f(a) + g(b);
+  __CPROVER_assert(j == 6, "j");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/pure_calls.desc
+++ b/regression/cbmc/evaluation_order_check/pure_calls.desc
@@ -1,0 +1,13 @@
+CORE
+pure_calls.c
+--evaluation-order-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^\[main\.evaluation-order
+--
+Calls without conflicting side effects are evaluation-order independent:
+the check explores both argument orders and finds no difference, and no
+evaluation-order property is generated for operands without memory reads.

--- a/regression/cbmc/evaluation_order_check/test.desc
+++ b/regression/cbmc/evaluation_order_check/test.desc
@@ -1,0 +1,17 @@
+CORE
+division_after_call.c
+--div-by-zero-check --evaluation-order-check
+^\[main\.division-by-zero\.\d+\] line 12 division by zero in i / p: FAILURE$
+^\[main\.evaluation-order\.1\] line 12 value of i / p is independent of evaluation order: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+The call f(i) sets p to 0, so evaluating i / p after the call divides by
+zero. The C standard leaves the evaluation order of the operands of +
+unspecified (the call is indeterminately sequenced), so both orders are
+possible; --evaluation-order-check reports that the value of i / p depends
+on the evaluation order, and the division-by-zero check applies to both the
+pre-call and the post-call evaluation.

--- a/regression/cbmc/evaluation_order_check/unsequenced_increment.c
+++ b/regression/cbmc/evaluation_order_check/unsequenced_increment.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int i = 1;
+  int j = i++ + i;
+  __CPROVER_assert(j == 3, "j == 3");
+  return 0;
+}

--- a/regression/cbmc/evaluation_order_check/unsequenced_increment.desc
+++ b/regression/cbmc/evaluation_order_check/unsequenced_increment.desc
@@ -1,0 +1,13 @@
+CORE
+unsequenced_increment.c
+--evaluation-order-check
+^\[main\.evaluation-order\.1\] line 4 value of i is independent of evaluation order: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+In i++ + i the read of i is unsequenced relative to the side effect of i++,
+which makes the behaviour undefined (C11 6.5p2). The evaluation-order check
+reports that the value of the read depends on the evaluation order.

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_convert_class.h"
 
+#include <util/arith_tools.h>
 #include <util/config.h>
 #include <util/expr_util.h>
 #include <util/fresh_symbol.h>
@@ -21,10 +22,37 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol.h>
 
 #include <analyses/natural_loops.h>
+#include <langapi/language_util.h>
 
 #include "destructor.h"
 
+#include <algorithm>
 #include <unordered_map>
+
+/// Returns true if \p expr reads memory (contains a symbol or dereference)
+/// and has a type for which equality comparison is meaningful, making it a
+/// candidate for evaluation-order-invariance snapshotting.
+static bool is_snapshot_candidate(const exprt &expr)
+{
+  if(expr.is_constant())
+    return false;
+  const typet &type = expr.type();
+  if(
+    type.id() != ID_signedbv && type.id() != ID_unsignedbv &&
+    type.id() != ID_bool && type.id() != ID_c_bool && type.id() != ID_pointer &&
+    type.id() != ID_floatbv && type.id() != ID_c_enum_tag)
+  {
+    return false;
+  }
+  bool has_read = false;
+  expr.visit_pre(
+    [&has_read](const exprt &node)
+    {
+      if(node.id() == ID_symbol || node.id() == ID_dereference)
+        has_read = true;
+    });
+  return has_read;
+}
 
 static symbol_exprt find_base_symbol(const exprt &expr)
 {
@@ -443,6 +471,19 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_expr(
   const irep_idt &mode,
   bool result_is_used)
 {
+  struct depth_guardt
+  {
+    unsigned &depth;
+    explicit depth_guardt(unsigned &_depth) : depth(_depth)
+    {
+      ++depth;
+    }
+    ~depth_guardt()
+    {
+      --depth;
+    }
+  } depth_guard{clean_expr_depth};
+
   // this cleans:
   //   && || ==> ?: comma (control-dependency)
   //   function calls
@@ -742,6 +783,30 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_expr(
     side_effects.add(
       clean_function_call_operands(call.function(), call.arguments(), mode));
   }
+  else if(config.ansi_c.evaluation_order_check && clean_expr_depth == 1)
+  {
+    // clean the operands individually so that evaluation-order dependence
+    // between them can be explored and refuted
+    std::vector<goto_programt> blocks;
+    exprt::operandst pure_reads;
+    std::list<irep_idt> temporaries;
+    Forall_operands(it, expr)
+    {
+      clean_expr_resultt operand_result = clean_expr(*it, mode);
+      temporaries.splice(temporaries.begin(), operand_result.temporaries);
+      if(!operand_result.side_effects.instructions.empty())
+        blocks.push_back(std::move(operand_result.side_effects));
+      else if(is_snapshot_candidate(*it))
+        pure_reads.push_back(*it);
+    }
+    if(!blocks.empty())
+    {
+      side_effects.add(emit_evaluation_order_checked_blocks(
+        std::move(blocks), pure_reads, expr.source_location(), mode));
+    }
+    side_effects.temporaries.splice(
+      side_effects.temporaries.begin(), temporaries);
+  }
   else
   {
     Forall_operands(it, expr)
@@ -872,10 +937,49 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_function_call_operands(
   exprt::operandst &arguments,
   const irep_idt &mode)
 {
+  struct depth_guardt
+  {
+    unsigned &depth;
+    explicit depth_guardt(unsigned &_depth) : depth(_depth)
+    {
+      ++depth;
+    }
+    ~depth_guardt()
+    {
+      --depth;
+    }
+  } depth_guard{clean_expr_depth};
+
   clean_expr_resultt side_effects;
 
   // The function operand is evaluated before the arguments either way.
   side_effects.add(clean_expr(function, mode));
+
+  if(config.ansi_c.evaluation_order_check && clean_expr_depth == 1)
+  {
+    // clean the arguments individually so that evaluation-order dependence
+    // between them can be explored and refuted
+    std::vector<goto_programt> blocks;
+    exprt::operandst pure_reads;
+    std::list<irep_idt> temporaries;
+    for(auto &argument : arguments)
+    {
+      clean_expr_resultt argument_result = clean_expr(argument, mode);
+      temporaries.splice(temporaries.begin(), argument_result.temporaries);
+      if(!argument_result.side_effects.instructions.empty())
+        blocks.push_back(std::move(argument_result.side_effects));
+      else if(is_snapshot_candidate(argument))
+        pure_reads.push_back(argument);
+    }
+    if(!blocks.empty())
+    {
+      side_effects.add(emit_evaluation_order_checked_blocks(
+        std::move(blocks), pure_reads, function.source_location(), mode));
+    }
+    side_effects.temporaries.splice(
+      side_effects.temporaries.begin(), temporaries);
+    return side_effects;
+  }
 
   // The C and C++ standards leave the order of evaluation of function call
   // arguments unspecified; model the fixed order that the configured
@@ -894,4 +998,148 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_function_call_operands(
   }
 
   return side_effects;
+}
+
+goto_convertt::clean_expr_resultt
+goto_convertt::emit_evaluation_order_checked_blocks(
+  std::vector<goto_programt> &&blocks,
+  const exprt::operandst &pure_reads,
+  const source_locationt &source_location,
+  const irep_idt &mode)
+{
+  clean_expr_resultt result;
+
+  // hoist declarations out of the blocks so that the blocks can be emitted
+  // several times, in different orders, under disjoint branches
+  goto_programt declarations;
+  for(auto &block : blocks)
+  {
+    auto it = block.instructions.begin();
+    while(it != block.instructions.end())
+    {
+      if(it->is_decl())
+      {
+        auto next = std::next(it);
+        declarations.instructions.splice(
+          declarations.instructions.end(), block.instructions, it);
+        it = next;
+      }
+      else
+        ++it;
+    }
+  }
+  result.side_effects.destructive_append(declarations);
+
+  // snapshot the values of side-effect-free sibling operands before any of
+  // the side effects execute; the boundary assertions below establish that
+  // these values are invariant under the side effects, and hence that all
+  // placements of these reads that the C standard permits yield the same
+  // value. Note that evaluating the operands in the pre-state also applies
+  // all enabled undefined-behaviour checks (division by zero etc.) to the
+  // pre-state, covering evaluation orders in which the read happens before
+  // the side effects.
+  std::vector<std::pair<symbol_exprt, exprt>> snapshots;
+  for(const exprt &read : pure_reads)
+  {
+    const symbolt &snapshot_symbol = new_tmp_symbol(
+      read.type(), "eval_order", result.side_effects, source_location, mode);
+    result.add_temporary(snapshot_symbol.name);
+    result.side_effects.add(goto_programt::make_assignment(
+      snapshot_symbol.symbol_expr(), read, source_location));
+    snapshots.emplace_back(snapshot_symbol.symbol_expr(), read);
+  }
+
+  const auto make_boundary_assertions = [&](goto_programt &dest)
+  {
+    for(const auto &[snapshot, read] : snapshots)
+    {
+      source_locationt annotated_location = source_location;
+      annotated_location.set_property_class("evaluation-order");
+      annotated_location.set_comment(
+        "value of " + from_expr(ns, mode, read) +
+        " is independent of evaluation order");
+      dest.add(goto_programt::make_assertion(
+        equal_exprt{snapshot, read}, annotated_location));
+    }
+  };
+
+  if(blocks.size() <= 1)
+  {
+    for(auto &block : blocks)
+    {
+      result.side_effects.destructive_append(block);
+      make_boundary_assertions(result.side_effects);
+    }
+    return result;
+  }
+
+  // Execute the (mutually independent) blocks in a nondeterministically
+  // chosen order: k rounds, each of which executes one not-yet-executed
+  // block selected by a nondeterministic choice. This covers all k!
+  // orders while emitting only k copies of each block.
+  std::vector<symbol_exprt> done_flags;
+  for(std::size_t i = 0; i < blocks.size(); ++i)
+  {
+    const symbolt &done_symbol = new_tmp_symbol(
+      bool_typet{}, "eval_order", result.side_effects, source_location, mode);
+    result.add_temporary(done_symbol.name);
+    result.side_effects.add(goto_programt::make_assignment(
+      done_symbol.symbol_expr(), false_exprt{}, source_location));
+    done_flags.push_back(done_symbol.symbol_expr());
+  }
+
+  for(std::size_t round = 0; round < blocks.size(); ++round)
+  {
+    const symbolt &choice_symbol = new_tmp_symbol(
+      unsignedbv_typet{8},
+      "eval_order",
+      result.side_effects,
+      source_location,
+      mode);
+    result.add_temporary(choice_symbol.name);
+    result.side_effects.add(goto_programt::make_assignment(
+      choice_symbol.symbol_expr(),
+      side_effect_expr_nondett{unsignedbv_typet{8}, source_location},
+      source_location));
+
+    exprt::operandst valid_choices;
+    for(std::size_t i = 0; i < blocks.size(); ++i)
+    {
+      valid_choices.push_back(and_exprt{
+        equal_exprt{
+          choice_symbol.symbol_expr(), from_integer(i, unsignedbv_typet{8})},
+        not_exprt{done_flags[i]}});
+    }
+    result.side_effects.add(goto_programt::make_assumption(
+      disjunction(valid_choices), source_location));
+
+    goto_programt round_end;
+    goto_programt::targett round_end_target =
+      round_end.add(goto_programt::make_skip(source_location));
+
+    for(std::size_t i = 0; i < blocks.size(); ++i)
+    {
+      goto_programt arm_end;
+      goto_programt::targett arm_end_target =
+        arm_end.add(goto_programt::make_skip(source_location));
+      const and_exprt guard{
+        equal_exprt{
+          choice_symbol.symbol_expr(), from_integer(i, unsignedbv_typet{8})},
+        not_exprt{done_flags[i]}};
+      result.side_effects.add(goto_programt::make_goto(
+        arm_end_target, not_exprt{guard}, source_location));
+      goto_programt copy;
+      copy.copy_from(blocks[i]);
+      result.side_effects.destructive_append(copy);
+      result.side_effects.add(goto_programt::make_assignment(
+        done_flags[i], true_exprt{}, source_location));
+      result.side_effects.add(goto_programt::make_goto(
+        round_end_target, true_exprt{}, source_location));
+      result.side_effects.destructive_append(arm_end);
+    }
+    result.side_effects.destructive_append(round_end);
+    make_boundary_assertions(result.side_effects);
+  }
+
+  return result;
 }

--- a/src/ansi-c/goto-conversion/goto_convert_class.h
+++ b/src/ansi-c/goto-conversion/goto_convert_class.h
@@ -61,6 +61,10 @@ protected:
   std::string tmp_symbol_prefix;
   lifetimet lifetime = lifetimet::STATIC_GLOBAL;
 
+  /// Nesting depth of expression-cleaning contexts; used to identify the
+  /// outermost context of a full expression for --evaluation-order-check.
+  unsigned clean_expr_depth = 0;
+
   struct clean_expr_resultt
   {
     /// Identifiers of temporaries introduced while cleaning an expression. The
@@ -86,6 +90,25 @@ protected:
       temporaries.push_front(id);
     }
   };
+
+  /// For --evaluation-order-check: emit the per-operand side-effect blocks of
+  /// one full expression such that any evaluation-order dependence between
+  /// sibling operands is either explored (by evaluating independent blocks in
+  /// several orders) or refuted (by assertions that the values of
+  /// side-effect-free sibling operands are invariant under the side effects).
+  /// \param blocks: side-effect implementations of those operands that carry
+  ///   side effects, in source order
+  /// \param pure_reads: side-effect-free sibling operands whose value could
+  ///   be affected by the side effects
+  /// \param source_location: location of the full expression
+  /// \param mode: language mode
+  /// \return statements to be emitted in place of the concatenation of \p
+  ///   blocks, and the temporaries introduced
+  [[nodiscard]] clean_expr_resultt emit_evaluation_order_checked_blocks(
+    std::vector<goto_programt> &&blocks,
+    const exprt::operandst &pure_reads,
+    const source_locationt &source_location,
+    const irep_idt &mode);
 
   void goto_convert_rec(
     const codet &code,

--- a/src/ansi-c/goto-conversion/module_dependencies.txt
+++ b/src/ansi-c/goto-conversion/module_dependencies.txt
@@ -1,5 +1,6 @@
 analyses
 ansi-c
 goto-programs
+langapi
 linking
 util

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1275,6 +1275,8 @@ bool configt::set(const cmdlinet &cmdline)
   if(cmdline.isset("malloc-fail-assert"))
     ansi_c.malloc_failure_mode = ansi_c.malloc_failure_mode_assert_then_assume;
 
+  ansi_c.evaluation_order_check = cmdline.isset("evaluation-order-check");
+
   if(cmdline.isset("malloc-may-fail"))
   {
     ansi_c.malloc_may_fail = true;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -73,11 +73,14 @@ class symbol_table_baset;
     " {y--round-to-plus-inf} \t rounding towards plus infinity\n"              \
     " {y--round-to-minus-inf} \t rounding towards minus infinity\n"            \
     " {y--round-to-zero} \t rounding towards zero\n"                           \
-    " {y--no-library} \t disable built-in abstract C library\n"
+    " {y--no-library} \t disable built-in abstract C library\n"                \
+    " {y--evaluation-order-check} \t "                                         \
+    "assert that expression values are independent of evaluation order\n"
 
 #define OPT_CONFIG_LIBRARY                                                     \
   "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
   "(no-malloc-may-fail)"                                                       \
+  "(evaluation-order-check)"                                                   \
   "(string-abstraction)"                                                       \
   "(dfcc-debug-lib)"                                                           \
   "(dfcc-simple-invalid-pointer-model)"
@@ -234,9 +237,14 @@ public:
     endiannesst endianness;
 
     // Order in which compilers evaluate the arguments of a function call.
-    // The C and C++ standards leave this order unspecified, but any given
-    // compiler/architecture combination uses a fixed order, which is
-    // observable when argument expressions have side effects. Empirically
+    // The C and C++ standards leave this order unspecified, and (unlike for
+    // implementation-defined behaviour) no compiler documents or guarantees
+    // a particular choice: per C11 3.4.4 the choice need not even be
+    // consistent between two call sites in one program. The values below
+    // describe the order the supported compilers have been OBSERVED to use,
+    // which is observable when argument expressions have side effects; use
+    // --evaluation-order-check to verify that a program's behaviour does not
+    // depend on such choices. Empirically
     // confirmed (test programs on native and cross-compiled targets, and
     // via Compiler Explorer): GCC evaluates right-to-left on the x86 family
     // (i386, x86_64, x32) and left-to-right on all other architectures
@@ -250,6 +258,13 @@ public:
       RIGHT_TO_LEFT
     };
     argument_evaluation_ordert argument_evaluation_order;
+
+    // Emit assertions during goto conversion that the value of each full
+    // expression is independent of the evaluation order that the C and C++
+    // standards leave unspecified. When these assertions hold, the fixed
+    // evaluation order used by goto conversion covers all behaviours that a
+    // conforming compiler may produce for the given expression.
+    bool evaluation_order_check = false;
 
     // whether the architecture set via one of the set_arch_spec_* functions
     // is a member of the x86 family (i386, x86_64, x32); used to compute


### PR DESCRIPTION
The C and C++ standards leave the evaluation order within expressions largely open: the operands of most operators and the arguments of a function call are evaluated in an unspecified order (C11 6.5p3, 6.5.2.2p10), and per C11 3.4.4 that choice need not be consistent between two instances in one program, so the order observed for a given compiler is not a guarantee. Function executions do not interleave with other evaluations (they are indeterminately sequenced), and unsequenced conflicting accesses to the same scalar object in open code are undefined behaviour outright (C11 6.5p2).

Goto conversion, like other verifiers that lower expressions to statement sequences, picks one evaluation order per expression. That is sound if and only if the expression's value and effect are independent of the orders the standard permits; when they are not, verification against the single modelled order can miss behaviours of a conforming compiler. For example, in

  int b = 0;
  int f(void) { b = 1; return 0; }
  ... a / b + f() ...

goto conversion hoists f's side effects before the division, so the division by zero that occurs when a compiler evaluates a / b first (gcc does, on several architectures) goes unnoticed.

The new option --evaluation-order-check makes this sound: whenever the lowering of a full expression involves side effects next to sibling sub-evaluations, goto conversion now
- snapshots the value of each side-effect-free sibling operand in the state before any of the side effects, and asserts after each side-effect block that the value is unchanged; the assertions fail exactly when a permitted evaluation order can observe a different value, and evaluating the operands in the pre-state also applies the enabled undefined-behaviour checks (division by zero, overflow, pointer checks) to that state;
- executes the side-effect blocks of sibling operands, which are mutually independent by construction, in a nondeterministically chosen order, using round-based scheduling (each round executes one not-yet-executed block selected by an unconstrained choice), which covers all k! orders of k blocks while emitting only k copies of each block, so no bound on the number of unsequenced side effects is needed.

When all emitted evaluation-order assertions hold, the expression's value and the resulting state are the same under every evaluation order the standard permits at the granularity of sibling operands, and the fixed lowering order is a complete model. Known limitations, by design of this first version: unsequenced conflicts between an assignment's left-hand side and its right-hand side (i = i++ + 1) are not detected (the lhs is lowered separately); interleavings *within* one operand's evaluation relative to its siblings are only explored at operand granularity; reads of aggregate-typed operands are not snapshotted.

The check is off by default: the fixed per-target evaluation order (introduced for function-call arguments in #9120) remains the best model of what deployed compilers were observed to do, and the pre-#9120 behaviour was equally a single fixed order. The comment documenting configt::ansi_ct::argument_evaluation_order is reworded to make explicit that the recorded orders are observations, not guarantees, and to point to the new option.

The regression tests double as documentation of the semantics discussed in the review of #9120, including both directions of the division-by-zero example and the two-writes example where the fixed order would wrongly prove an assertion. The previously FUTURE tests Eval_Order2 and Function_Eval_Order1, which documented the aspiration of modelling evaluation-order nondeterminism, are promoted to CORE using the new option.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
