### PR TITLE
C front-end: rewrite array size when refined from unknown to defined

### DIFF
--- a/regression/cbmc/Extern_Array_Size_Refinement/main.c
+++ b/regression/cbmc/Extern_Array_Size_Refinement/main.c
@@ -1,0 +1,23 @@
+// A function indexing an array that is declared (extern, unsized) before its
+// sized definition is typechecked before the array size becomes known.  The C
+// front-end must rewrite the stale size-less array types carried on the symbol
+// expressions in that function body to the concrete array type when the size is
+// refined, otherwise the same object is typed both as a sized and as a
+// size-less array and the solver hits an internal error.
+extern unsigned long lookup[];
+
+unsigned long lookup_fn(unsigned long base, unsigned long i)
+{
+  return base + lookup[i & 63UL];
+}
+
+unsigned long lookup[64];
+
+int main(void)
+{
+  unsigned long base = 1000;
+  unsigned long i = 5;
+  unsigned long v = lookup_fn(base, i);
+  __CPROVER_assert(v > 0, "value is positive");
+  return 0;
+}

--- a/regression/cbmc/Extern_Array_Size_Refinement/test.desc
+++ b/regression/cbmc/Extern_Array_Size_Refinement/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
 #include <util/mathematical_expr.h>
+#include <util/replace_symbol.h>
 #include <util/std_types.h>
 #include <util/symbol_table_base.h>
 
@@ -344,6 +345,25 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     // update the type to enable the use of sizeof(x) on the
     // right-hand side of a definition of x
     old_symbol.type=new_symbol.type;
+
+    // The array size was just refined from "unknown" to a concrete value.
+    // Any symbol expression referring to this symbol in code that was
+    // typechecked before this definition still carries the old, size-less
+    // array type.  Rewrite them so that the symbol's type and the types
+    // carried on its symbol expressions stay consistent; otherwise the same
+    // object ends up typed both as a sized and as a size-less array.
+    symbol_exprt updated_symbol_expr = old_symbol.symbol_expr();
+    unchecked_replace_symbolt array_type_updates;
+    array_type_updates.insert(updated_symbol_expr, updated_symbol_expr);
+    for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
+    {
+      if(
+        !it->second.is_type && !it->second.is_macro &&
+        it->second.value.is_not_nil())
+      {
+        array_type_updates(it.get_writeable_symbol().value);
+      }
+    }
   }
 
   // do initializer, this may change the type


### PR DESCRIPTION
cbmc crashes with an invariant violation in boolbv_mapt::get_literals ("number of literals in the literal map shall equal the bitvector width") on programs like:

```c
extern unsigned long pdx_pfn_lookup[];

unsigned long pdx_to_pfn(unsigned long pdx, unsigned long i)
{
  return pdx + pdx_pfn_lookup[...];   // typechecked before size is known
}

unsigned long pdx_pfn_lookup[64];      // size refined here
```

The array is first declared with an unknown size (array[nil]), indexed in a function body, and later defined with a concrete size. The C front-end typechecks the function body before the sized definition, so the symbol expressions in that body keep the stale size-less type array[nil] (copied at typecheck time in typecheck_expr_symbol). The symbol table is later refined to array[64], but code bodies are not rewritten, leaving the same object typed both as a size-less and as a sized array.

In the solver, the zero-init equality is converted with the concrete type array[64] (4096 bits) while the index expression is converted with array[nil] (treated as unbounded : width 0). Since boolbv_mapt is keyed by identifier only, the second lookup finds the 4096-literal entry and 4096 != 0 trips the invariant.
The existing adjust_tentative_array_definitions fix (Fixes #7608) only handles arrays that are still size-less at end of TU (rewritten to size 1); it does not cover the size-less : concrete refinement.

In typecheck_redefinition_non_type (src/ansi-c/c_typecheck_base.cpp), at the point the array size is refined from unknown to a concrete value, rewrite the symbol expressions referring to that symbol across the symbol table so they carry the concrete array type. This uses unchecked_replace_symbolt, the same mechanism as adjust_tentative_array_definitions, keeping the symbol's type and the types carried on its uses consistent.

Tests:
- Added regression test regression/cbmc/Extern_Array_Size_Refinement/ (extern unsized array indexed before its sized definition). It crashes (invariant violation) without the fix and passes with it.


- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

